### PR TITLE
Removing the extra layer in the repo tree

### DIFF
--- a/boilerplate/update
+++ b/boilerplate/update
@@ -103,7 +103,7 @@ while read directory junk; do
   fi
   rm -rf "${DIR}/${directory}"
   mkdir -p $(dirname "${DIR}/${directory}")
-  rsync -a -r "$dir_path" "${DIR}/${directory}"
+  rsync -a -r "$dir_path" $(dirname "${DIR}/${directory}")
   if [ -f "${DIR}/${directory}/update" ]; then
     echo "executing ${DIR}/${directory}/update POST"
     "${DIR}/${directory}/update" POST


### PR DESCRIPTION
Due to the last commit, convention copy is adding an extra repository which is breaking the project.
call to `basedir` is removing this extra repository.