### PR TITLE
Seed a test driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,12 @@
+ALLOW_DIRTY_CHECKOUT?=false
+
+.PHONY: isclean
+isclean:
+	@(test "$(ALLOW_DIRTY_CHECKOUT)" != "false" || test 0 -eq $$(git status --porcelain | wc -l)) || (echo "Local git checkout is not clean, commit changes and try again." >&2 && exit 1)
+
+.PHONY: test
+test: isclean
+	test/driver
+
 .PHONY: pr-check
-pr-check:
-	true
+pr-check: test

--- a/README.md
+++ b/README.md
@@ -182,3 +182,15 @@ In your fork of this repository (not a consuming repository):
       `update` driver and the convention subdirectories themselves. Of
       note, `${CONVENTION_ROOT}/_lib/` contains some utilities that may
       be useful for `update`s.
+
+### Tests
+Test cases are executed by running `make test`. This must be done on a
+clean git repository; otherwise the tests will not be using your
+uncommitted changes.
+
+Add new test cases by creating executable files in the [test/case](test/case)
+subdirectory. These are discovered and executed in lexicographic order by
+`make test`. Your test case should exit zero to indicate success; nonzero to
+indicate failure. The [test/lib.sh](test/lib.sh) library defines convenient
+variables and functions you can use if your test case is written in `bash`.
+See existing test cases for examples.

--- a/boilerplate/update
+++ b/boilerplate/update
@@ -52,6 +52,10 @@ export CONVENTION_ROOT=$DIR
 if [ -z "$REPO_NAME" ]; then
   # This is a tad ambitious, but it should usually work.
   export REPO_NAME=$(git remote get-url origin | sed 's,.*/,,; s/\.git$//')
+  # If that still didn't work, warn (but proceed)
+  if [ -z "$REPO_NAME" ]; then
+    echo 'Failed to discover repository name! $REPO_NAME not set!'
+  fi
 fi
 
 export REPO_ROOT=$(git rev-parse --show-toplevel)

--- a/test/case/01_bootstrap_update
+++ b/test/case/01_bootstrap_update
@@ -1,0 +1,20 @@
+#!/bin/bash -xe
+
+HERE=${0%/*}
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+source $REPO_ROOT/test/lib.sh
+
+repo=$(empty_repo)
+add_cleanup $repo
+
+bootstrap_repo $repo
+
+cd $repo
+
+# TODO: test REPO_NAME detection by setting an appropriately-formatted
+# git remote
+export REPO_NAME=${0##*/}
+
+make update_boilerplate

--- a/test/driver
+++ b/test/driver
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Runs executable files under the `case` subdirectory, in alpha order.
+#
+# If $PRESERVE_TEMP_DIRS is set, temporary directories created by test
+# cases are preserved; otherwise they are deleted.
+
+HERE=${0%/*}
+
+source $HERE/lib.sh
+
+_PASS_COUNT=0
+_FAIL_COUNT=0
+
+main() {
+    cd "$HERE/case"
+    # TODO: Add support for running just certain cases
+    cases=$(find . -type f -perm /111 | sort)
+
+    echo "Will run test cases:"
+    echo "$cases"
+
+    for c in $cases; do
+        echo
+        hr
+        echo "Running test case $c"
+        hr
+        source ./$c
+        RC=$?
+        hr
+        if [[ $RC -eq 0 ]]; then
+            echo PASS
+            _PASS_COUNT=$((_PASS_COUNT+1))
+        else
+            echo "FAIL with RC=$RC"
+            _FAIL_COUNT=$((_FAIL_COUNT+1))
+        fi
+        echo
+    done
+
+    hr
+    cat <<EOF
+PASS: $_PASS_COUNT
+FAIL: $_FAIL_COUNT
+EOF
+    hr
+    if [[ $_FAIL_COUNT -ne 0 ]]; then
+        exit 1
+    fi
+    exit 0
+}
+
+main

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+# Make all tests use this local clone by default.
+export BOILERPLATE_GIT_REPO=$REPO_ROOT
+
+_BP_TEST_TEMP_DIRS=
+
+_cleanup() {
+    echo
+    echo "Cleaning up"
+    [ -z "$_BP_TEST_TEMP_DIRS" ] && return
+
+    if [ -z "$PRESERVE_TEMP_DIRS" ]; then
+        echo "Removing temporary directories"
+        rm -fr $_BP_TEST_TEMP_DIRS
+    else
+        echo "Preserving temporary directories: $_BP_TEST_TEMP_DIRS"
+    fi
+}
+trap _cleanup EXIT
+
+add_cleanup() {
+    # Stage this temp dir for cleanup
+    _BP_TEST_TEMP_DIRS="$_BP_TEST_TEMP_DIRS $1"
+}
+
+empty_repo() {
+    tmpd=$(mktemp -d)
+    git init $tmpd >&2
+    echo $tmpd
+}
+
+## bootstrap_repo PATH
+#
+# Gets a git repo ready for boilerplate:
+# - Copies in boilerplate/update from $REPO_ROOT
+# - Seeds the Makefile with the update_boilerplate target
+# - Creates an empty boilerplate/update.cfg
+# It does not run the update.
+#
+# :param PATH: An existing directory that has been `git init`ed, like
+#       what you get when you run `empty_repo`.
+bootstrap_repo() {
+    repodir=$1
+    (
+        cd $repodir
+        mkdir boilerplate
+        cp $REPO_ROOT/boilerplate/update boilerplate
+        cat <<EOF > Makefile
+.PHONY: update_boilerplate
+update_boilerplate:
+	@boilerplate/update
+EOF
+        > boilerplate/update.cfg
+    )
+}
+
+hr() {
+    echo "========================="
+}


### PR DESCRIPTION
This commit sets up some basic framework for testing the boilerplate
repository itself.

- Add a `make test` target, which runs `test/driver`.
- Add a `test/driver` script, which discovers test cases as executables
under the `test/case` subdirectory, and runs them.
- Add a `test/lib.sh` bash library containing convenient functions and
variables for use by test cases.
- Add a PoC of such a test case, which simply creates and initializes an
empty git repository in a temp dir, bootstraps it with the boilerplate
seeds, and runs the update.
- Add an `isclean` make target, included by the `test` target, that
forces you to have files committed. (If you don't, the tests won't be
testing with your unstaged changes.)
- Change the `pr-check` make target to run the `test` target.

Part of Jira: [OSD-4948](https://issues.redhat.com/browse/OSD-4948)