### PR TITLE
Harden test framework

### DIFF
--- a/test/case/01_bootstrap_update
+++ b/test/case/01_bootstrap_update
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash -x
 
 HERE=${0%/*}
 
@@ -18,3 +18,4 @@ cd $repo
 export REPO_NAME=${0##*/}
 
 make update_boilerplate
+exit $?

--- a/test/case/02_nonexistent_convention
+++ b/test/case/02_nonexistent_convention
@@ -1,0 +1,43 @@
+#!/bin/bash -x
+
+echo "Validate that a nonexistent convention causes update to fail."
+
+HERE=${0%/*}
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+source $REPO_ROOT/test/lib.sh
+
+repo=$(empty_repo)
+add_cleanup $repo
+
+bootstrap_repo $repo
+
+cd $repo
+# Subscribe to a "convention" that doesn't exist upstream
+echo "bogus/convention" >> boilerplate/update.cfg
+
+# TODO: test REPO_NAME detection by setting an appropriately-formatted
+# git remote
+export REPO_NAME=${0##*/}
+
+LOG=${0##*/}.log
+
+# A little cheat so we can get the RC from `make`
+make update_boilerplate >$LOG 2>&1
+rc=$?
+cat $LOG
+
+if [[ $rc -eq 0 ]]; then
+    echo "Expected update to fail!"
+    exit 1
+fi
+expected="Invalid convention directory: 'bogus/convention'"
+if ! grep -q "$expected" $LOG; then
+    echo "Expected update output to contain:"
+    echo "  $expected"
+    echo "...but it didn't. See above."
+    exit 1
+fi
+
+exit 0

--- a/test/driver
+++ b/test/driver
@@ -9,42 +9,49 @@ HERE=${0%/*}
 
 source $HERE/lib.sh
 
-_PASS_COUNT=0
-_FAIL_COUNT=0
+_PASS=()
+_FAIL=()
 
 main() {
     cd "$HERE/case"
     # TODO: Add support for running just certain cases
     cases=$(find . -type f -perm /111 | sort)
+    if [[ -z "$cases" ]]; then
+        echo "No test cases found! Something is wrong!"
+        exit 1
+    fi
 
     echo "Will run test cases:"
     echo "$cases"
 
-    for c in $cases; do
+    for test_case_executable in $cases; do
         echo
         hr
-        echo "Running test case $c"
+        echo "Running test case $test_case_executable"
         hr
-        source ./$c
+        # Invoke
+        $test_case_executable
         RC=$?
         hr
         if [[ $RC -eq 0 ]]; then
             echo PASS
-            _PASS_COUNT=$((_PASS_COUNT+1))
+            _PASS+=($test_case_executable)
         else
             echo "FAIL with RC=$RC"
-            _FAIL_COUNT=$((_FAIL_COUNT+1))
+            _FAIL+=($test_case_executable)
         fi
         echo
     done
 
     hr
-    cat <<EOF
-PASS: $_PASS_COUNT
-FAIL: $_FAIL_COUNT
-EOF
+    echo "PASS: ${#_PASS[@]}"
+    echo -n "  "
+    echo ${_PASS[@]} | sed 's/ /\n  /g'
+    echo "FAIL: ${#_FAIL[@]}"
+    echo -n "  "
+    echo ${_FAIL[@]} | sed 's/ /\n  /g'
     hr
-    if [[ $_FAIL_COUNT -ne 0 ]]; then
+    if [[ ${#_FAIL[@]} -ne 0 ]]; then
         exit 1
     fi
     exit 0


### PR DESCRIPTION
- Fail if no test cases found.
- Run, don't source, the test cases.
- Improve test driver summary output.
- Make test case 01_bootstrap_update explicit about errors (don't use `-e`).
- Add test case 02_nonexistent_convention, proving that subscribing to a nonexistent convention causes the update to fail.