### PR TITLE
Also build go binary before image build

### DIFF
--- a/boilerplate/openshift/golang_osd_cluster_operator/standard.mk
+++ b/boilerplate/openshift/golang_osd_cluster_operator/standard.mk
@@ -54,7 +54,7 @@ isclean:
 	@(test "$(ALLOW_DIRTY_CHECKOUT)" != "false" || test 0 -eq $$(git status --porcelain | wc -l)) || (echo "Local git checkout is not clean, commit changes and try again." >&2 && exit 1)
 
 .PHONY: build
-build: isclean envtest
+build: isclean envtest gobuild
 	docker build . -f $(OPERATOR_DOCKERFILE) -t $(OPERATOR_IMAGE_URI)
 	docker tag $(OPERATOR_IMAGE_URI) $(OPERATOR_IMAGE_URI_LATEST)
 


### PR DESCRIPTION
The `build` target builds the docker image for the operators. But it may not work because the binary required to build the image is missing. This adds `gobuild` as a prerequisite for the docker image build.