### PR TITLE
Added yaml validation as a phony target

### DIFF
--- a/boilerplate/openshift/golang_osd_cluster_operator/standard.mk
+++ b/boilerplate/openshift/golang_osd_cluster_operator/standard.mk
@@ -28,6 +28,8 @@ OPERATOR_DOCKERFILE ?=build/Dockerfile
 BINFILE=build/_output/bin/$(OPERATOR_NAME)
 MAINPACKAGE=./cmd/manager
 
+CRDS_PATH ?= deploy/crds
+
 # Containers may default GOFLAGS=-mod=vendor which would break us since
 # we're using modules.
 unexport GOFLAGS
@@ -108,7 +110,7 @@ envtest: isclean
 	@eval $$($(MAKE) env --no-print-directory) || (echo 'Unable to evaulate output of `make env`.  This breaks osd-operators-registry.' >&2 && exit 1)
 
 .PHONY: test
-test: envtest gotest
+test: envtest gotest yaml-validate
 
 .PHONY: env
 .SILENT: env
@@ -117,3 +119,7 @@ env: isclean
 	echo OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE)
 	echo OPERATOR_VERSION=$(OPERATOR_VERSION)
 	echo OPERATOR_IMAGE_URI=$(OPERATOR_IMAGE_URI)
+
+.PHONY: yaml-validate
+yaml-validate:
+	python boilerplate/openshift/golang_osd_cluster_operator/validate_yaml.py ${CRDS_PATH}

--- a/boilerplate/openshift/golang_osd_cluster_operator/standard.mk
+++ b/boilerplate/openshift/golang_osd_cluster_operator/standard.mk
@@ -28,8 +28,6 @@ OPERATOR_DOCKERFILE ?=build/Dockerfile
 BINFILE=build/_output/bin/$(OPERATOR_NAME)
 MAINPACKAGE=./cmd/manager
 
-CRDS_PATH ?= deploy/crds
-
 # Containers may default GOFLAGS=-mod=vendor which would break us since
 # we're using modules.
 unexport GOFLAGS
@@ -122,4 +120,4 @@ env: isclean
 
 .PHONY: yaml-validate
 yaml-validate:
-	python boilerplate/openshift/golang_osd_cluster_operator/validate_yaml.py ${CRDS_PATH}
+	python3 boilerplate/openshift/golang_osd_cluster_operator/validate_yaml.py $(shell git ls-files | egrep -v '^(vendor|boilerplate)/' | egrep '.*\.ya?ml')

--- a/boilerplate/openshift/golang_osd_cluster_operator/validate_yaml.py
+++ b/boilerplate/openshift/golang_osd_cluster_operator/validate_yaml.py
@@ -1,0 +1,41 @@
+# Usage
+# python validate_yaml.py path/to/file/or/dir
+
+import sys
+import yaml
+from os import listdir
+from os.path import isdir, isfile, join, splitext
+
+usage = "Usage: {0:s} path/to/file/or/dir".format(sys.argv[0])
+
+if len(sys.argv) != 2:
+    print(usage)
+    sys.exit(1)
+
+path = sys.argv[1]
+
+if isfile(path):
+    files = [path]
+elif isdir(path):
+    files = [join(path, f) for f in listdir(path) if isfile(join(path, f))]
+else:
+    print("Path {0:s} does not exist".format(path))
+    sys.exit(0)
+
+error = False
+for file_path in files:
+    _, ext = splitext(file_path)
+    if ext not in [".yml", ".yaml"]:
+        continue
+
+    print("Validating YAML {}".format(file_path))
+    with open(file_path, "r") as f:
+        data = f.read()
+    try:
+        for y in yaml.safe_load_all(data):
+            pass
+    except Exception as e:
+        print(e)
+        error = True
+
+sys.exit(error)

--- a/boilerplate/openshift/golang_osd_cluster_operator/validate_yaml.py
+++ b/boilerplate/openshift/golang_osd_cluster_operator/validate_yaml.py
@@ -6,36 +6,39 @@ import yaml
 from os import listdir
 from os.path import isdir, isfile, join, splitext
 
-usage = "Usage: {0:s} path/to/file/or/dir".format(sys.argv[0])
+usage = "Usage: {0:s} path/to/file/or/dir...".format(sys.argv[0])
 
-if len(sys.argv) != 2:
+if len(sys.argv) < 2:
     print(usage)
     sys.exit(1)
 
-path = sys.argv[1]
-
-if isfile(path):
-    files = [path]
-elif isdir(path):
-    files = [join(path, f) for f in listdir(path) if isfile(join(path, f))]
-else:
-    print("Path {0:s} does not exist".format(path))
-    sys.exit(0)
+input_paths = sys.argv[1:]
 
 error = False
-for file_path in files:
-    _, ext = splitext(file_path)
-    if ext not in [".yml", ".yaml"]:
+
+for path in input_paths:
+    if isfile(path):
+        files = [path]
+    elif isdir(path):
+        files = [join(path, f) for f in listdir(path) if isfile(join(path, f))]
+    else:
+        print("Path {0:s} does not exist".format(path))
+        error=True
         continue
 
-    print("Validating YAML {}".format(file_path))
-    with open(file_path, "r") as f:
-        data = f.read()
-    try:
-        for y in yaml.safe_load_all(data):
-            pass
-    except Exception as e:
-        print(e)
-        error = True
+    for file_path in files:
+        _, ext = splitext(file_path)
+        if ext not in [".yml", ".yaml"]:
+            continue
+
+        print("Validating YAML {}".format(file_path))
+        with open(file_path, "r") as f:
+            data = f.read()
+        try:
+            for y in yaml.safe_load_all(data):
+                pass
+        except Exception as e:
+            print(e)
+            error = True
 
 sys.exit(error)


### PR DESCRIPTION
Added a make target to validate yaml files. This target is also a requisite for the `test` target. By default it checks for YAML files in the path `deploy/crds`. If the path doesn't exist then it does nothing. Otherwise it goes through the directory and validates every YAML file. The location of the YAML files can be overriden by setting the environment variable `CRDS_PATH` with the path to the directory or file.