### PR TITLE
Ensure golangci-lint for the correct OS

### DIFF
--- a/boilerplate/_lib/ensure.sh
+++ b/boilerplate/_lib/ensure.sh
@@ -5,15 +5,24 @@ GOLANGCI_LINT_VERSION="1.30.0"
 DEPENDENCY=${1:-}
 
 case "${DEPENDENCY}" in
-    golangci-lint)
-        GOPATH=$(go env GOPATH)
-        if [ ! -f "${GOPATH}/bin/golangci-lint" ]; then
-            DOWNLOAD_URL="https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-linux-amd64.tar.gz"
-            curl -sfL "${DOWNLOAD_URL}" | tar -C "${GOPATH}/bin" -zx --strip-components=1 "golangci-lint-${GOLANGCI_LINT_VERSION}-linux-amd64/golangci-lint"
+golangci-lint)
+    GOPATH=$(go env GOPATH)
+    if which golangci-lint ; then
+        exit
+    else
+        mkdir -p "${GOPATH}/bin"
+        echo "${PATH}" | grep -q "${GOPATH}/bin"
+        IN_PATH=$?
+        if [ $IN_PATH != 0 ]; then
+            echo "${GOPATH}/bin not in $$PATH"
+            exit 1
         fi
+        DOWNLOAD_URL="https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-${GOOS}-amd64.tar.gz"
+        curl -sfL "${DOWNLOAD_URL}" | tar -C "${GOPATH}/bin" -zx --strip-components=1 "golangci-lint-${GOLANGCI_LINT_VERSION}-${GOOS}-amd64/golangci-lint"
+    fi
     ;;
-    *)
-        echo "Unknown dependency: ${DEPENDENCY}"
-        exit 1
+*)
+    echo "Unknown dependency: ${DEPENDENCY}"
+    exit 1
     ;;
 esac

--- a/boilerplate/_lib/ensure.sh
+++ b/boilerplate/_lib/ensure.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 GOLANGCI_LINT_VERSION="1.30.0"
 DEPENDENCY=${1:-}
+GOOS=${GOOS:-linux}
 
 case "${DEPENDENCY}" in
 golangci-lint)

--- a/boilerplate/_lib/ensure.sh
+++ b/boilerplate/_lib/ensure.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 GOLANGCI_LINT_VERSION="1.30.0"
 DEPENDENCY=${1:-}
-GOOS=${GOOS:-linux}
+GOOS=$(go env GOOS)
 
 case "${DEPENDENCY}" in
 golangci-lint)

--- a/boilerplate/openshift/golang_osd_cluster_operator/standard.mk
+++ b/boilerplate/openshift/golang_osd_cluster_operator/standard.mk
@@ -75,7 +75,7 @@ docker-push: push
 
 .PHONY: gocheck
 gocheck: ## Lint code
-	GOOS=${GOOS} boilerplate/_lib/ensure.sh golangci-lint
+	boilerplate/_lib/ensure.sh golangci-lint
 	GOLANGCI_LINT_CACHE=${GOLANGCI_LINT_CACHE} golangci-lint run -c boilerplate/openshift/golang_osd_cluster_operator/golangci.yml ./...
 
 .PHONY: gogenerate

--- a/boilerplate/openshift/golang_osd_cluster_operator/standard.mk
+++ b/boilerplate/openshift/golang_osd_cluster_operator/standard.mk
@@ -37,6 +37,10 @@ GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS=
 
 GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"
 
+# GOLANGCI_LINT_CACHE needs to be set to a directory which is writeable
+# Relevant issue - https://github.com/golangci/golangci-lint/issues/734
+GOLANGCI_LINT_CACHE ?= /tmp/golangci-cache
+
 TESTTARGETS := $(shell ${GOENV} go list -e ./... | egrep -v "/(vendor)/")
 # ex, -v
 TESTOPTS :=
@@ -71,10 +75,8 @@ docker-push: push
 
 .PHONY: gocheck
 gocheck: ## Lint code
-	boilerplate/_lib/ensure.sh golangci-lint
-	# GOLANGCI_LINT_CACHE needs to be set to a directory which is writeable
-	# Relevant issue - https://github.com/golangci/golangci-lint/issues/734
-	GOLANGCI_LINT_CACHE=/tmp/golangci-cache golangci-lint run -c boilerplate/openshift/golang_osd_cluster_operator/golangci.yml ./...
+	GOOS=${GOOS} boilerplate/_lib/ensure.sh golangci-lint
+	GOLANGCI_LINT_CACHE=${GOLANGCI_LINT_CACHE} golangci-lint run -c boilerplate/openshift/golang_osd_cluster_operator/golangci.yml ./...
 
 .PHONY: gogenerate
 gogenerate:


### PR DESCRIPTION
Attempts to fix #20 

Currently the `ensure.sh` attempts to download the `golangci-lint` tool even when the tool is present on the path. The `ensure.sh` will now download the script only when the tool is not present in `$PATH`. Also other minor improvements:

- Ensure that `$GOPATH/bin` is present in `$PATH`.
- Allow user to specify the path for `$GOLANGCI_LINT_CACHE`