### PR TITLE
$CONVENTION_NAME

### DIFF
--- a/boilerplate/_lib/common.sh
+++ b/boilerplate/_lib/common.sh
@@ -3,3 +3,29 @@ err() {
   exit 1
 }
 
+# Only used for error messages
+_lib=${BASH_SOURCE##*/}
+
+# When this lib is sourced (which is what it's designed for), $0 is the
+# script that did the sourcing.
+SOURCER=$(realpath $0)
+[[ -n "$SOURCER" ]] || err "$_lib couldn't discover where it was sourced from"
+
+HERE=${SOURCER%/*}
+[[ -n "$HERE" ]] || err "$_lib failed to discover the dirname of sourcer at $SOURCER"
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+[[ -n "$REPO_ROOT" ]] || err "$_lib couldn't discover the repo root"
+
+CONVENTION_ROOT=$REPO_ROOT/boilerplate
+[[ -d "$CONVENTION_ROOT" ]] || err "$CONVENTION_ROOT: not a directory"
+
+# Were we sourced from within a convention?
+if [[ "$HERE" == "$CONVENTION_ROOT/"* ]]; then
+  # Okay, figure out the name of the convention
+  CONVENTION_NAME=${HERE#$CONVENTION_ROOT/}
+  # If we got here, we really expected to be able to identify the
+  # convention name.
+  [[ -n "$CONVENTION_NAME" ]] || err "$_lib couldn't discover the name of the sourcing convention"
+fi
+

--- a/boilerplate/openshift/golang_osd_cluster_operator/update
+++ b/boilerplate/openshift/golang_osd_cluster_operator/update
@@ -2,8 +2,6 @@
 
 source $CONVENTION_ROOT/_lib/common.sh
 
-HERE=${0%/*}
-
 # No PRE
 [[ "$1" == "PRE" ]] && exit 0
 
@@ -19,7 +17,7 @@ THINGS YOU NEED TO DO
 =====================
 - Make sure the following line is in your base Makefile:
 
-include boilerplate/openshift/golang_osd_cluster_operator/includes.mk
+include boilerplate/$CONVENTION_NAME/includes.mk
 
 - Remove any other 'include' lines, unless they're for things truly
   unique to your repository. (Otherwise, consider proposing them to

--- a/test/case/01_bootstrap_update
+++ b/test/case/01_bootstrap_update
@@ -1,7 +1,5 @@
 #!/bin/bash -xe
 
-HERE=${0%/*}
-
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 source $REPO_ROOT/test/lib.sh

--- a/test/case/02_nonexistent_convention
+++ b/test/case/02_nonexistent_convention
@@ -2,8 +2,6 @@
 
 echo "Validate that a nonexistent convention causes update to fail."
 
-HERE=${0%/*}
-
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 source $REPO_ROOT/test/lib.sh

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 REPO_ROOT=$(git rev-parse --show-toplevel)
 # Make all tests use this local clone by default.
 export BOILERPLATE_GIT_REPO=$REPO_ROOT
@@ -75,7 +73,9 @@ compare() {
             echo "$repo/boilerplate/_data/last_boilerplate_commit does not exist" >> $LOG_FILE
         fi
     else
-        diff --recursive -q $1 $BOILERPLATE_GIT_REPO/boilerplate/$1 >> $LOG_FILE 2>&1
+        # Don't let this kill tests using -e. The failure is detected
+        # later based on the $LOG_FILE being nonempty.
+        diff --recursive -q $1 $BOILERPLATE_GIT_REPO/boilerplate/$1 >> $LOG_FILE 2>&1 || true
     fi
 }
 
@@ -87,7 +87,7 @@ compare() {
 # :param LOG_FILE: Log file name (optional). If none is provided, a name will be generated. 
 # If file isn't empty, it will be truncated.
 check_update() {
-    if [ $# -le 2 ] ; then
+    if [ $# -lt 2 ] ; then
         echo "Usage: check_update REPO (LOG_FILE)"
     fi
     


### PR DESCRIPTION
When boilerplate/_lib/common.sh is sourced by a convention `update`
script, it's useful for that script to know the name of its convention
without having to hardcode it. This commit adds logic to common.sh to
discover this and put it in a `$CONVENTION_NAME` variable. The
openshift/golang_osd_cluster_operator convention's `update` script is
modified to use the new variable.

As part of this discovery, `$HERE` (the directory containing the file
doing the sourcing) is also discovered and set. This commit removes it
from places where it is no longer needed (or never was).

Also remove a redundant shebang from a lib that should only ever be
sourced.