### PR TITLE
Copy golang_osd_cluster_operator to ..._hive_...

### DIFF
--- a/boilerplate/openshift/golang_osd_hive_operator/.codecov.yml
+++ b/boilerplate/openshift/golang_osd_hive_operator/.codecov.yml
@@ -1,0 +1,26 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
+
+coverage:
+  precision: 2
+  round: down
+  range: "20...100"
+
+  status:
+    project: no
+    patch: no
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no 

--- a/boilerplate/openshift/golang_osd_hive_operator/README.md
+++ b/boilerplate/openshift/golang_osd_hive_operator/README.md
@@ -1,3 +1,24 @@
 # Conventions for hive-deployed OSD operators written in Go
 
-Nothing to see here yet.
+The following components are included:
+
+## `make` targets and functions.
+**Note:** Your repository's main `Makefile` needs to be edited to include these libraries.
+
+## Code coverage
+- A `codecov.sh` script, referenced by the `coverage` `make` target, to
+run code coverage analysis per [this SOP](https://github.com/openshift/ops-sop/blob/ff297220d1a6ac5d3199d242a1b55f0d4c433b87/services/codecov.md).
+
+- A `.codecov.yml` configuration file for
+  [codecov.io](https://docs.codecov.io/docs/codecov-yaml). Note that
+  this is copied into the repository root, because that's
+  [where codecov.io expects it](https://docs.codecov.io/docs/codecov-yaml#can-i-name-the-file-codecovyml).
+
+## Linting and other static analysis with `golangci-lint`
+
+- A `gocheck` `make` target, which
+- ensures the proper version of `golangci-lint` is installed, and
+- runs it against
+- a `golangci.yml` config.
+
+## More coming soon

--- a/boilerplate/openshift/golang_osd_hive_operator/codecov.sh
+++ b/boilerplate/openshift/golang_osd_hive_operator/codecov.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+CI_SERVER_URL=https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test
+COVER_PROFILE=${COVER_PROFILE:-coverage.out}
+JOB_TYPE=${JOB_TYPE:-"local"}
+
+make -C "${REPO_ROOT}" gotest TESTOPTS="-coverprofile=${COVER_PROFILE}.tmp -covermode=atomic -coverpkg=./..."
+
+# Remove generated files from coverage profile
+grep -v "zz_generated" "${COVER_PROFILE}.tmp" > "${COVER_PROFILE}"
+rm -f "${COVER_PROFILE}.tmp"
+
+# Configure the git refs and job link based on how the job was triggered via prow
+if [[ "${JOB_TYPE}" == "presubmit" ]]; then
+       echo "detected PR code coverage job for #${PULL_NUMBER}"
+       REF_FLAGS="-P ${PULL_NUMBER} -C ${PULL_PULL_SHA}"
+       JOB_LINK="${CI_SERVER_URL}/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+elif [[ "${JOB_TYPE}" == "postsubmit" ]]; then
+       echo "detected branch code coverage job for ${PULL_BASE_REF}"
+       REF_FLAGS="-B ${PULL_BASE_REF} -C ${PULL_BASE_SHA}"
+       JOB_LINK="${CI_SERVER_URL}/logs/${JOB_NAME}/${BUILD_ID}"
+elif [[ "${JOB_TYPE}" == "local" ]]; then
+       echo "coverage report available at ${COVER_PROFILE}"
+       exit 0
+else
+       echo "${JOB_TYPE} jobs not supported"
+       exit 1
+fi
+
+# Configure certain internal codecov variables with values from prow.
+export CI_BUILD_URL="${JOB_LINK}"
+export CI_BUILD_ID="${JOB_NAME}"
+export CI_JOB_ID="${BUILD_ID}"
+
+bash <(curl -s https://codecov.io/bash) -Z -K -f "${COVER_PROFILE}" -r "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}

--- a/boilerplate/openshift/golang_osd_hive_operator/golangci.yml
+++ b/boilerplate/openshift/golang_osd_hive_operator/golangci.yml
@@ -1,0 +1,6 @@
+# options for analysis running
+run:
+  # default concurrency is a available CPU number
+  concurrency: 10
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 2m

--- a/boilerplate/openshift/golang_osd_hive_operator/includes.mk
+++ b/boilerplate/openshift/golang_osd_hive_operator/includes.mk
@@ -1,0 +1,4 @@
+# This is a rollup of includes in this convention, for easier inclusion
+# by the repo's Makefile, which should just include this file.
+include boilerplate/openshift/golang_osd_cluster_operator/project.mk
+include boilerplate/openshift/golang_osd_cluster_operator/standard.mk

--- a/boilerplate/openshift/golang_osd_hive_operator/project.mk
+++ b/boilerplate/openshift/golang_osd_hive_operator/project.mk
@@ -1,0 +1,10 @@
+# Project specific values
+OPERATOR_NAME?=$(shell sed -n 's/.*OperatorName .*"\([^"]*\)".*/\1/p' config/config.go)
+OPERATOR_NAMESPACE?=$(shell sed -n 's/.*OperatorNamespace .*"\([^"]*\)".*/\1/p' config/config.go)
+
+IMAGE_REGISTRY?=quay.io
+IMAGE_REPOSITORY?=$(USER)
+IMAGE_NAME?=$(OPERATOR_NAME)
+
+VERSION_MAJOR?=0
+VERSION_MINOR?=1

--- a/boilerplate/openshift/golang_osd_hive_operator/standard.mk
+++ b/boilerplate/openshift/golang_osd_hive_operator/standard.mk
@@ -1,0 +1,125 @@
+# Validate variables in project.mk exist
+ifndef IMAGE_REGISTRY
+$(error IMAGE_REGISTRY is not set; check project.mk file)
+endif
+ifndef IMAGE_REPOSITORY
+$(error IMAGE_REPOSITORY is not set; check project.mk file)
+endif
+ifndef IMAGE_NAME
+$(error IMAGE_NAME is not set; check project.mk file)
+endif
+ifndef VERSION_MAJOR
+$(error VERSION_MAJOR is not set; check project.mk file)
+endif
+ifndef VERSION_MINOR
+$(error VERSION_MINOR is not set; check project.mk file)
+endif
+
+# Generate version and tag information from inputs
+COMMIT_NUMBER=$(shell git rev-list `git rev-list --parents HEAD | egrep "^[a-f0-9]{40}$$"`..HEAD --count)
+CURRENT_COMMIT=$(shell git rev-parse --short=8 HEAD)
+OPERATOR_VERSION=$(VERSION_MAJOR).$(VERSION_MINOR).$(COMMIT_NUMBER)-$(CURRENT_COMMIT)
+
+IMG?=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME):v$(OPERATOR_VERSION)
+OPERATOR_IMAGE_URI=${IMG}
+OPERATOR_IMAGE_URI_LATEST=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME):latest
+OPERATOR_DOCKERFILE ?=build/Dockerfile
+
+BINFILE=build/_output/bin/$(OPERATOR_NAME)
+MAINPACKAGE=./cmd/manager
+
+# Containers may default GOFLAGS=-mod=vendor which would break us since
+# we're using modules.
+unexport GOFLAGS
+GOOS?=linux
+GOARCH?=amd64
+GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS=
+
+GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"
+
+# GOLANGCI_LINT_CACHE needs to be set to a directory which is writeable
+# Relevant issue - https://github.com/golangci/golangci-lint/issues/734
+GOLANGCI_LINT_CACHE ?= /tmp/golangci-cache
+
+TESTTARGETS := $(shell ${GOENV} go list -e ./... | egrep -v "/(vendor)/")
+# ex, -v
+TESTOPTS :=
+
+ALLOW_DIRTY_CHECKOUT?=false
+
+default: gobuild
+
+.PHONY: clean
+clean:
+	rm -rf ./build/_output
+
+.PHONY: isclean
+isclean:
+	@(test "$(ALLOW_DIRTY_CHECKOUT)" != "false" || test 0 -eq $$(git status --porcelain | wc -l)) || (echo "Local git checkout is not clean, commit changes and try again." >&2 && exit 1)
+
+.PHONY: build
+build: isclean envtest
+	docker build . -f $(OPERATOR_DOCKERFILE) -t $(OPERATOR_IMAGE_URI)
+	docker tag $(OPERATOR_IMAGE_URI) $(OPERATOR_IMAGE_URI_LATEST)
+
+.PHONY: push
+push:
+	docker push $(OPERATOR_IMAGE_URI)
+	docker push $(OPERATOR_IMAGE_URI_LATEST)
+
+# These names are used by the app-sre pipeline targets
+.PHONY: docker-build
+docker-build: build
+.PHONY: docker-push
+docker-push: push
+
+.PHONY: gocheck
+gocheck: ## Lint code
+	boilerplate/_lib/ensure.sh golangci-lint
+	GOLANGCI_LINT_CACHE=${GOLANGCI_LINT_CACHE} golangci-lint run -c boilerplate/openshift/golang_osd_cluster_operator/golangci.yml ./...
+
+.PHONY: gogenerate
+gogenerate:
+	${GOENV} go generate $(TESTTARGETS)
+	# Don't forget to commit generated files
+
+.PHONY: opgenerate
+opgenerate:
+	operator-sdk generate crds
+	operator-sdk generate k8s
+	# Don't forget to commit generated files
+
+.PHONY: generate
+generate: opgenerate gogenerate
+
+.PHONY: gobuild
+gobuild: gocheck gotest ## Build binary
+	${GOENV} go build ${GOBUILDFLAGS} -o ${BINFILE} ${MAINPACKAGE}
+
+.PHONY: gotest
+gotest:
+	${GOENV} go test $(TESTOPTS) $(TESTTARGETS)
+
+.PHONY: coverage
+coverage:
+	boilerplate/openshift/golang_osd_cluster_operator/codecov.sh
+
+.PHONY: envtest
+envtest: isclean
+	@# test that the env target can be evaluated, required by osd-operators-registry
+	@eval $$($(MAKE) env --no-print-directory) || (echo 'Unable to evaulate output of `make env`.  This breaks osd-operators-registry.' >&2 && exit 1)
+
+.PHONY: test
+test: envtest gotest yaml-validate
+
+.PHONY: env
+.SILENT: env
+env: isclean
+	echo OPERATOR_NAME=$(OPERATOR_NAME)
+	echo OPERATOR_NAMESPACE=$(OPERATOR_NAMESPACE)
+	echo OPERATOR_VERSION=$(OPERATOR_VERSION)
+	echo OPERATOR_IMAGE_URI=$(OPERATOR_IMAGE_URI)
+
+.PHONY: yaml-validate
+yaml-validate:
+	python3 boilerplate/openshift/golang_osd_cluster_operator/validate_yaml.py $(shell git ls-files | egrep -v '^(vendor|boilerplate)/' | egrep '.*\.ya?ml')

--- a/boilerplate/openshift/golang_osd_hive_operator/update
+++ b/boilerplate/openshift/golang_osd_hive_operator/update
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+source $CONVENTION_ROOT/_lib/common.sh
+
+# No PRE
+[[ "$1" == "PRE" ]] && exit 0
+
+# Expect POST
+[[ "$1" == "POST" ]] || err "Got a parameter I don't understand: '$1'. Did the infrastructure change?"
+
+echo "Copying .codecov.yml to your repository root."
+cp ${HERE}/.codecov.yml $REPO_ROOT
+
+echo <<EOF
+=====================
+THINGS YOU NEED TO DO
+=====================
+- Make sure the following line is in your base Makefile:
+
+include boilerplate/$CONVENTION_NAME/includes.mk
+
+- Remove any other 'include' lines, unless they're for things truly
+  unique to your repository. (Otherwise, consider proposing them to
+  boilerplate.)
+
+- Delete any obsolete files you're no longer including.
+EOF

--- a/boilerplate/openshift/golang_osd_hive_operator/validate_yaml.py
+++ b/boilerplate/openshift/golang_osd_hive_operator/validate_yaml.py
@@ -1,0 +1,44 @@
+# Usage
+# python validate_yaml.py path/to/file/or/dir
+
+import sys
+import yaml
+from os import listdir
+from os.path import isdir, isfile, join, splitext
+
+usage = "Usage: {0:s} path/to/file/or/dir...".format(sys.argv[0])
+
+if len(sys.argv) < 2:
+    print(usage)
+    sys.exit(1)
+
+input_paths = sys.argv[1:]
+
+error = False
+
+for path in input_paths:
+    if isfile(path):
+        files = [path]
+    elif isdir(path):
+        files = [join(path, f) for f in listdir(path) if isfile(join(path, f))]
+    else:
+        print("Path {0:s} does not exist".format(path))
+        error=True
+        continue
+
+    for file_path in files:
+        _, ext = splitext(file_path)
+        if ext not in [".yml", ".yaml"]:
+            continue
+
+        print("Validating YAML {}".format(file_path))
+        with open(file_path, "r") as f:
+            data = f.read()
+        try:
+            for y in yaml.safe_load_all(data):
+                pass
+        except Exception as e:
+            print(e)
+            error = True
+
+sys.exit(error)

--- a/test/case/tmp_ensure_cluster_and_hive_are_synced
+++ b/test/case/tmp_ensure_cluster_and_hive_are_synced
@@ -1,0 +1,51 @@
+#!/bin/bash -e
+
+cat <<EOF
+TEMPORARY!
+
+Currently the openshift/golang_osd_cluster_operator and
+openshift/golang_osd_hive_operator conventions are identical (except for
+one line in their READMEs). For the moment, we're simply maintaining two
+copies of the content. At some point in the future, there will be
+smarter management of the common pieces. But until then, this test just
+makes sure that you didn't forget to update both at the same time.
+
+EOF
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+source $REPO_ROOT/test/lib.sh
+
+tmpd=$(mktemp -d)
+add_cleanup "$tmpd"
+
+# We expect the conventions to differ only in the README title
+cat <<EOF>$tmpd/expected_diff
+diff --recursive golang_osd_cluster_operator/README.md golang_osd_hive_operator/README.md
+1c1
+< # Conventions for cluster-deployed OSD operators written in Go
+---
+> # Conventions for hive-deployed OSD operators written in Go
+EOF
+
+cd $REPO_ROOT/boilerplate/openshift
+# Don't let this die from -e
+diff --recursive golang_osd_cluster_operator golang_osd_hive_operator > $tmpd/actual_diff 2>&1 || true
+
+# Diff of diffs
+if ! diff -q $tmpd/expected_diff $tmpd/actual_diff; then
+  echo
+  echo ">>EXPECTED DIFF>>"
+  cat $tmpd/expected_diff
+  echo "<<EXPECTED DIFF<<"
+  echo
+  echo ">>ACTUAL DIFF>>"
+  cat $tmpd/actual_diff
+  echo "<<ACTUAL DIFF<<"
+  echo
+  echo ">>DIFF OF DIFFS>>"
+  diff $tmpd/expected_diff $tmpd/actual_diff || true
+  echo "<<DIFF OF DIFFS<<"
+  echo
+  echo "You need to keep openshift/golang_osd_cluster_operator and openshift/golang_osd_hive_operator in sync!"
+  exit 1
+fi


### PR DESCRIPTION
At this point in history, all the content of the
openshift/golang_osd_cluster_operator convention is actually applicable
to both cluster-installed and hive-installed operators. So there should
be nothing stopping us from publishing both conventions.

Eventually we're going to have a smarter way to maintain the common bits
in a single place. But for now we're dumbly copying the contents of
golang_osd_cluster_operator into golang_osd_hive_operator.

While these conventions are duplicates of each other, it's important
that they stay in sync. So this commit also adds a test case to enforce
that. The test case is expected to be temporary, to be removed as soon
as the aforementioned "smarter way" is implemented.