### PR TITLE
Test: convention update invocation and variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 ALLOW_DIRTY_CHECKOUT?=false
 
+# Tests rely on this starting off unset. (And if it is set, it's usually
+# not for the reasons we care about.)
+unexport REPO_NAME
+
 .PHONY: isclean
 isclean:
 	@(test "$(ALLOW_DIRTY_CHECKOUT)" != "false" || test 0 -eq $$(git status --porcelain | wc -l)) || (echo "Local git checkout is not clean, commit changes and try again." >&2 && exit 1)

--- a/boilerplate/test/test-base-convention/update
+++ b/boilerplate/test/test-base-convention/update
@@ -1,29 +1,22 @@
 #!/bin/bash -e
 
-source $CONVENTION_ROOT/_lib/common.sh
+# This script validates the vars we expect from the main `update` driver, and
+# many of those are set by common.sh, so don't source it.
+err() {
+  echo "$@" >&2
+  exit 1
+}
 
-HERE=${0%/*}
+echo "Validating CLI arguments"
+# Should always get exactly one arg
+[[ $# -eq 1 ]] || err "Expected exactly one CLI arg, but got $#: $@"
+case "$1" in
+    PRE|POST) ;;
+    *) err "Got an invalid CLI argument: '$1'"
+esac
 
-# No PRE
-[[ "$1" == "PRE" ]] && exit 0
-
-# Expect POST
-[[ "$1" == "POST" ]] || err "Got a parameter I don't understand: '$1'. Did the infrastructure change?"
-
-echo "Copying .codecov.yml to your repository root."
-cp ${HERE}/.codecov.yml $REPO_ROOT
-
-echo <<EOF
-=====================
-THINGS YOU NEED TO DO
-=====================
-- Make sure the following line is in your base Makefile:
-
-include boilerplate/openshift/golang_osd_cluster_operator/includes.mk
-
-- Remove any other 'include' lines, unless they're for things truly
-  unique to your repository. (Otherwise, consider proposing them to
-  boilerplate.)
-
-- Delete any obsolete files you're no longer including.
-EOF
+echo "Validating variables exported from the main update driver"
+[[ -z "$REPO_ROOT" ]] && err "Bad REPO_ROOT: '$REPO_ROOT'"
+[[ "$CONVENTION_ROOT" == "$REPO_ROOT/boilerplate" ]] || err "Bad CONVENTION_ROOT: '$CONVENTION_ROOT'"
+# Test framework sets this via the `empty_repo` helper.
+[[ "$REPO_NAME" == "test-repo" ]] || err "Bad REPO_NAME: '$REPO_NAME'"

--- a/boilerplate/update
+++ b/boilerplate/update
@@ -54,7 +54,7 @@ export CONVENTION_ROOT=$DIR
 # repo doesn't have an `origin` remote.
 if [ -z "$REPO_NAME" ]; then
   # This is a tad ambitious, but it should usually work.
-  export REPO_NAME=$(git remote get-url origin | sed 's,.*/,,; s/\.git$//')
+  export REPO_NAME=$(git config --get remote.origin.url | sed 's,.*/,,; s/\.git$//')
   # If that still didn't work, warn (but proceed)
   if [ -z "$REPO_NAME" ]; then
     echo 'Failed to discover repository name! $REPO_NAME not set!'

--- a/test/case/01-bootstrap-update
+++ b/test/case/01-bootstrap-update
@@ -11,10 +11,6 @@ bootstrap_repo $repo
 
 cd $repo
 
-# TODO: test REPO_NAME detection by setting an appropriately-formatted
-# git remote
-export REPO_NAME=${0##*/}
-
 make update-boilerplate
 
 check_update $repo 01-no-convention

--- a/test/case/02-nonexistent-convention
+++ b/test/case/02-nonexistent-convention
@@ -15,10 +15,6 @@ cd $repo
 # Subscribe to a "convention" that doesn't exist upstream
 echo "bogus/convention" >> boilerplate/update.cfg
 
-# TODO: test REPO_NAME detection by setting an appropriately-formatted
-# git remote
-export REPO_NAME=${0##*/}
-
 LOG=${0##*/}.log
 
 # A little cheat so we can get the RC from `make`

--- a/test/case/03-nexus-makefile-include
+++ b/test/case/03-nexus-makefile-include
@@ -35,10 +35,6 @@ bootstrap_repo $repo
 
 cd $repo
 
-# TODO: test REPO_NAME detection by setting an appropriately-formatted
-# git remote
-export REPO_NAME=${0##*/}
-
 sub_hdr "Baseline"
 make update-boilerplate
 check_update $repo

--- a/test/case/04-update-from-master-and-revert
+++ b/test/case/04-update-from-master-and-revert
@@ -22,11 +22,6 @@ bootstrap_repo $repo
 
 cd $repo
 
-# TODO: test REPO_NAME detection by setting an appropriately-formatted
-# git remote
-export REPO_NAME=${0##*/}
-LOG=${0##*/}.log
-
 boilerplate_master=$(new_boilerplate_clone)
 
 override_boilerplate_repo $boilerplate_master || exit $?

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -40,7 +40,11 @@ add_cleanup() {
 # Outputs the directory. Does not register it for cleanup.
 empty_repo() {
     tmpd=$(mktemp -d -t boilerplate-test-XXXXXXXX)
-    git init $tmpd >&2
+    pushd $tmpd >&2
+    git init >&2
+    # Add a remote for REPO_NAME discovery
+    git remote add origin git@example.com:example-org/test-repo.git
+    popd >&2
     echo $tmpd
 }
 


### PR DESCRIPTION
This rewrites the `update` script in the `test/test-base-convention`
convention to test that the following documented behaviors of the main
update driver are observed when it is invoked:

- Exactly one command line argument, either `PRE` or `POST`.
- Exported variables `REPO_ROOT`, `REPO_NAME`, and `CONVENTION_ROOT`.