### PR TITLE
Ensure PyYAML is installed for yaml-validate

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -122,4 +122,5 @@ env: isclean
 
 .PHONY: yaml-validate
 yaml-validate:
+	python3 -mpip install pyyaml
 	python3 boilerplate/openshift/golang-osd-operator/validate-yaml.py $(shell git ls-files | egrep -v '^(vendor|boilerplate)/' | egrep '.*\.ya?ml')


### PR DESCRIPTION
Eventually, we ought to ensure that boilerplate consumers all satisfy
their check/test/build targets via a standardized container that has
these things in it. But for now...