### PR TITLE
`operator-sdk generate` at the proper version 

### DIFF
--- a/boilerplate/_lib/common.sh
+++ b/boilerplate/_lib/common.sh
@@ -3,6 +3,19 @@ err() {
   exit 1
 }
 
+## osdk_version BINARY
+#
+# Print the version of the specified operator-sdk BINARY
+osdk_version() {
+    local osdk=$1
+    # `operator-sdk version` output looks like
+    #       operator-sdk version: v0.8.2, commit: 28bd2b0d4fd25aa68e15d928ae09d3c18c3b51da
+    # or
+    #       operator-sdk version: "v0.16.0", commit: "55f1446c5f472e7d8e308dcdf36d0d7fc44fc4fd", go version: "go1.13.8 linux/amd64"
+    # Peel out the version number, accounting for the optional quotes.
+    $osdk version | sed 's/operator-sdk version: "*\([^,"]*\)"*,.*/\1/'
+}
+
 # Only used for error messages
 _lib=${BASH_SOURCE##*/}
 

--- a/boilerplate/_lib/ensure.sh
+++ b/boilerplate/_lib/ensure.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
+source ${0%/*}/common.sh
+
 GOLANGCI_LINT_VERSION="1.30.0"
 DEPENDENCY=${1:-}
 GOOS=$(go env GOOS)
 
 case "${DEPENDENCY}" in
+
 golangci-lint)
     GOPATH=$(go env GOPATH)
     if which golangci-lint ; then
@@ -22,6 +25,54 @@ golangci-lint)
         curl -sfL "${DOWNLOAD_URL}" | tar -C "${GOPATH}/bin" -zx --strip-components=1 "golangci-lint-${GOLANGCI_LINT_VERSION}-${GOOS}-amd64/golangci-lint"
     fi
     ;;
+
+operator-sdk)
+    #########################################################
+    # Ensure operator-sdk is installed at the desired version
+    # When done, ./.operator-sdk/bin/operator-sdk will be a
+    # symlink to the appropriate executable.
+    #########################################################
+    # First discover the desired version from go.mod
+    # The following properly takes `replace` directives into account.
+    wantver=$(go list -json -m github.com/operator-framework/operator-sdk | jq -r 'if .Replace != null then .Replace.Version else .Version end')
+    echo "go.mod says you want operator-sdk $wantver"
+    # Where we'll put our (binary and) symlink
+    mkdir -p .operator-sdk/bin
+    cd .operator-sdk/bin
+    # Discover existing, giving preference to one already installed in
+    # this path, because that has a higher probability of being the
+    # right one.
+    if [[ -x ./operator-sdk ]] && [[ "$(osdk_version ./operator-sdk)" == "$wantver" ]]; then
+        echo "operator-sdk $wantver already installed"
+        exit 0
+    fi
+    # Is there one in $PATH?
+    if which operator-sdk && [[ $(osdk_version $(which operator-sdk)) == "$wantver" ]]; then
+        osdk=$(realpath $(which operator-sdk))
+        echo "Found at $osdk"
+    else
+        case "$(uname -s)" in
+            Linux*)
+                binary="operator-sdk-${wantver}-x86_64-linux-gnu"
+                ;;
+            Darwin*)
+                binary="operator-sdk-${wantver}-x86_64-apple-darwin"
+                ;;
+            *)
+                echo "OS unsupported"
+                exit 1
+                ;;
+        esac
+        echo "Downloading $binary"
+        curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${wantver}/${binary}
+        chmod +x ${binary}
+        osdk=${binary}
+    fi
+    # Create (or overwrite) the symlink to the binary we discovered or
+    # downloaded above.
+    ln -sf $osdk operator-sdk
+    ;;
+
 venv)
     # Set up a python virtual environment
     python3 -m venv .venv
@@ -30,6 +81,7 @@ venv)
         .venv/bin/python3 -m pip install -r "$2"
     fi
     ;;
+
 *)
     echo "Unknown dependency: ${DEPENDENCY}"
     exit 1

--- a/boilerplate/openshift/golang-osd-operator/operator-sdk-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator/operator-sdk-generate.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+###
+# Run operator-sdk generate commands appropriate to the version of
+# operator-sdk configured in the consuming repository.
+###
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+LIB=$REPO_ROOT/boilerplate/_lib
+
+source $LIB/common.sh
+
+$LIB/ensure.sh operator-sdk
+
+# Symlink to operator-sdk binary set up by `ensure.sh operator-sdk`:
+OSDK=$REPO_ROOT/.operator-sdk/bin/operator-sdk
+
+VER=$(osdk_version $OSDK)
+
+# This explicitly lists the versions we know about. We don't support
+# anything outside of that.
+case $VER in
+  'v0.8.2')
+      $OSDK generate openapi
+      $OSDK generate k8s
+      ;;
+  'v0.15.1'|'v0.16.0'|'v0.17.0'|'v0.17.1')
+      $OSDK generate crds
+      $OSDK generate k8s
+      ;;
+  *) err "Unsupported operator-sdk version $VER" ;;
+esac

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -91,8 +91,7 @@ go-generate:
 
 .PHONY: op-generate
 op-generate:
-	operator-sdk generate crds
-	operator-sdk generate k8s
+	${CONVENTION_DIR}/operator-sdk-generate.sh
 	# Don't forget to commit generated files
 
 .PHONY: generate


### PR DESCRIPTION
Enhances ensure.sh to recognize the `operator-sdk` directive. This discovers the version of operator-sdk used by the consuming repository (from go.mod) and makes it available via a symlink at `./.operator-sdk/bin/operator-sdk`. If there's already one installed in your `$PATH`, and it's the right version, we just symlink to it. Otherwise we download the appropriate binary.

Adds a script to the `openshift/golang-osd-operator` convention called `operator-sdk-generate.sh` that uses the above, and then executes the `operator-sdk generate` commands appropriate to the version.

Swaps out the guts of `make opgenerate` to invoke the above.