### PR TITLE
Added dockerfile with dependencies

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,0 +1,4 @@
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13
+
+COPY build.sh /build.sh
+RUN /build.sh && rm -f /build.sh

--- a/config/build.sh
+++ b/config/build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+
+GOCILINT_VERSION="1.31.0"
+GOCILINT_SHA256SUM="9a5d47b51442d68b718af4c7350f4406cdc087e2236a5b9ae52f37aebede6cb3"
+GOCILINT_LOCATION=https://github.com/golangci/golangci-lint/releases/download/v${GOCILINT_VERSION}/golangci-lint-${GOCILINT_VERSION}-linux-amd64.tar.gz
+
+OPERATOR_SDK_VERSION="0.16.0"
+OPERATOR_SDK_SHA256SUM="3df782f341749f7962ab0fcfedd2961c18b21ad34ff7acd194b49a152f59abcb"
+OPERATOR_SDK_LOCATION=https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk-v${OPERATOR_SDK_VERSION}-x86_64-linux-gnu
+
+OPM_VERSION="1.13.8"
+OPM_SHASUM="a48aa9d69b0be3439220e818edde4b36b3b9eceb2a058d86b4fdf0ca9dcd21c8"
+OPM_LOCATION=https://github.com/operator-framework/operator-registry/releases/download/v${OPM_VERSION}/linux-amd64-opm
+
+curl -L -o golangci-lint.tar.gz $GOCILINT_LOCATION
+echo ${GOCILINT_SHA256SUM} golangci-lint.tar.gz | sha256sum -c
+tar xzf golangci-lint.tar.gz golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint
+mv golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint /usr/local/bin
+rm -rf golangci-lint-${GOCILINT_VERSION}-linux-amd64
+rm -f golangci-lint.tar.gz
+
+curl -L -o operator-sdk $OPERATOR_SDK_LOCATION
+echo ${OPERATOR_SDK_SHA256SUM} operator-sdk | sha256sum -c
+mv operator-sdk /usr/local/bin
+
+curl -L -o opm $OPM_LOCATION && \
+echo ${OPM_SHASUM} opm | sha256sum -c
+mv opm /usr/local/bin
+
+python3 -m pip install PyYAML==5.3.1
+
+GIT_VERSION="2.28.0"
+GIT_SHASUM="02016d16dbce553699db5c9c04f6d13a3f50727c652061b7eb97a828d045e534"
+GIT_DEPENDENCIES="epel-release perl-CPAN gettext-devel perl-devel openssl-devel zlib-devel curl-devel expat-devel getopt asciidoc xmlto docbook2X"
+yum remove -y git*
+yum -y install ${GIT_DEPENDENCIES}
+yum -y groupinstall "Development Tools"
+curl -L -o git.tar.gz https://github.com/git/git/archive/v${GIT_VERSION}.tar.gz
+echo "${GIT_SHASUM}" git.tar.gz | sha256sum -c
+tar xzf git.tar.gz
+make --directory "git-${GIT_VERSION}" configure
+./git-${GIT_VERSION}/configure --prefix=/usr
+make --directory "git-${GIT_VERSION}"
+make --directory "git-${GIT_VERSION}" install 
+rm -rf "git-${GIT_VERSION}"
+yum groupremove -y "Development Tools" && \
+yum -y remove ${GIT_DEPENDENCIES}
+yum clean all
+yum -y autoremove
+rm -rf /var/cache/yum


### PR DESCRIPTION
The docker image would contain the following dependencies:

1. golangci-lint
2. operator-sdk CLI
3. opm
4. PyYAML for python3
5. git v2.28.0

Once the Docker is merged into master it can be built and published by PROW. Once published we can use specify that image in the `docker run`/`podman run` parts. This will be done in subsequent PRs.