### PR TITLE
Add a subscribers file

### DIFF
--- a/boilerplate/_lib/common.sh
+++ b/boilerplate/_lib/common.sh
@@ -3,6 +3,13 @@ err() {
   exit 1
 }
 
+banner() {
+    echo
+    echo "=============================="
+    echo "$@"
+    echo "=============================="
+}
+
 ## osdk_version BINARY
 #
 # Print the version of the specified operator-sdk BINARY
@@ -40,6 +47,16 @@ repo_name() {
     # - upstream or origin
     # - ssh ("git@host.com:org/name.git") or https ("https://host.com/org/name.git")
     (git -C $1 config --get remote.upstream.url || git -C $1 config --get remote.origin.url) | sed 's,git@[^:]*:,,; s,https://[^/]*/,,; s/\.git$//'
+}
+
+## current_branch REPO
+#
+# Outputs the name of the current branch in the REPO directory
+current_branch() {
+    (
+        cd $1
+        git rev-parse --abbrev-ref HEAD
+    )
 }
 
 if [ "$BOILERPLATE_SET_X" ]; then

--- a/boilerplate/_lib/subscriber
+++ b/boilerplate/_lib/subscriber
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+source $REPO_ROOT/boilerplate/_lib/common.sh
+
+declare -A SUBCOMMANDS
+SUBCOMMANDS=(
+    [propose]='Propose pull/merge requests for subscribers'
+    [report]='Print information about subscribers'
+)
+
+source $REPO_ROOT/boilerplate/_lib/subscriber.sh

--- a/boilerplate/_lib/subscriber-propose
+++ b/boilerplate/_lib/subscriber-propose
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+source $REPO_ROOT/boilerplate/_lib/common.sh
+
+declare -A SUBCOMMANDS
+SUBCOMMANDS=(
+    # TODO:
+    # [bootstrap]='Bootstrap a new subscriber'
+    # [codecov-secret-mapping]='Propose codecov secret mapping to openshift/release'
+    # [prow-config]='Propose standardized prow configuration to openshift/release'
+    [update]='Update an already-onboarded subscriber'
+)
+
+source $REPO_ROOT/boilerplate/_lib/subscriber.sh

--- a/boilerplate/_lib/subscriber-propose-update
+++ b/boilerplate/_lib/subscriber-propose-update
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+source $REPO_ROOT/boilerplate/_lib/common.sh
+
+usage() {
+    cat <<EOF
+$CMD SUBSCRIBER ...
+
+Generate and propose a boilerplate update commit to one or more
+subscribers.
+
+Arguments:
+    SUBSCRIBER  One or more subscriber repositories of the form
+                "org/name" (e.g. "openshift/deadmanssnitch-operator");
+                or the special keyword "ALL" to update all onboarded
+                subscribers that need it.
+
+Quirks and Limitations:
+- Requires a functional and authenticated gh CLI, with git_protocol
+  appropriately configured for however you push.
+      gh config set git_protocol {ssh|https}
+- For each subscriber we actually try to propose to, UPDATES YOUR FORK'S
+  DEFAULT BRANCH to be in sync with upstream's.
+- Is still slightly interactive, because 'gh pr create' likes to ask
+  questions about your origin and upstream.
+EOF
+    exit -1
+}
+
+source $REPO_ROOT/boilerplate/_lib/subscriber.sh
+
+# Arguments are required
+[[ $# -eq 0 ]] && usage
+
+declare -A to_update
+
+ALL=0
+if [[ $# -eq 1 ]] && [[ "$1" == ALL ]]; then
+    ALL=1
+    shift
+fi
+for subscriber in $(subscriber_list onboarded); do
+    to_update[$subscriber]=$ALL
+done
+
+# Parse specified subscribers
+for a in "$@"; do
+    [[ $a == ALL ]] && err "Can't specify ALL with explicit subscribers"
+
+    [[ -n "${to_update[$a]}" ]] || err "Not an onboarded subscriber: '$a'"
+    if [[ "${to_update[$a]}" -eq 1 ]]; then
+        echo "Ignoring duplicate: '$a'"
+        continue
+    fi
+    to_update[$a]=1
+done
+
+TMPD=$(mktemp -d)
+trap "rm -fr $TMPD" EXIT
+
+propose_update() {
+    local subscriber=$1
+    local proj=${subscriber#*/}
+
+    (
+        # Clone my fork of the subscriber repo
+        cd $TMPD
+        # This
+        # - uses the existing fork if one exists
+        # - sets 'origin' and 'upstream' remotes
+        gh repo fork $subscriber --clone=true --remote=true
+        cd $proj
+
+        # Current branch is 'master' or 'main'
+        cur_branch=$(current_branch .)
+        # Make sure our origin is synced with upstream, so our update
+        # commit is based off of the latest code.
+        # WARNING: This changes your fork!
+        git pull upstream $cur_branch
+        git push origin $cur_branch
+
+        # Create the update commit
+        make boilerplate-update
+        make boilerplate-commit
+
+        # And create the PR
+        # TODO: This is interactive. How do we tell gh "Yes, please use
+        # upstream as upstream and origin as origin?"
+        gh pr create -f
+    )
+}
+
+bp_master=$(git rev-parse master)
+
+for subscriber in "${!to_update[@]}"; do
+    [[ "${to_update[$subscriber]}" -eq 1 ]] || continue
+
+    # Does this one need an update?
+    lbc=$(last_bp_commit $subscriber)
+    [[ -n "$lbc" ]] || err "No last-boilerplate-commit file for onboarded subscriber '$subscriber'"
+
+    banner "Processing $subscriber"
+
+    cbm=$(commits_behind_bp_master $lbc)
+    if [[ $cbm -eq 0 ]]; then
+        echo "Subscriber already up to date; skipping: '$subscriber'"
+        continue
+    fi
+
+    # Is there already a PR proposed for this level?
+    existing_pr=$(gh pr list --repo $subscriber | grep -P ":boilerplate-\S+-$bp_master\s")
+    if [[ -n "$existing_pr" ]]; then
+        echo "Subscriber '$subscriber' already has an open PR:"
+        echo "https://github.com/$subscriber/pull/$existing_pr"
+        continue
+    fi
+
+    # Pull the trigger
+    propose_update "$subscriber"
+done

--- a/boilerplate/_lib/subscriber-report
+++ b/boilerplate/_lib/subscriber-report
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+source $REPO_ROOT/boilerplate/_lib/common.sh
+
+declare -A SUBCOMMANDS
+SUBCOMMANDS=(
+    [onboarding]='Prints a CSV report of onboarded boilerplate subscribers.'
+    [pr]='Finds boilerplate-related pull requests for registered subscribers.'
+    [release]='Checks openshift/release configuration for onboarded subscribers.'
+)
+
+source $REPO_ROOT/boilerplate/_lib/subscriber.sh
+

--- a/boilerplate/_lib/subscriber-report-onboarding
+++ b/boilerplate/_lib/subscriber-report-onboarding
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+source $REPO_ROOT/boilerplate/_lib/common.sh
+
+usage() {
+    cat <<EOF
+$CMD
+
+Prints a CSV report of onboarded boilerplate subscribers. Each record is of
+the form:
+      org/proj,hash (-N),link
+where:
+      org:    Github org (e.g. openshift)
+      proj:   Github project (e.g. my-wizbang-operator)
+      hash:   Short (7c) hash of the project's last boilerplate commit
+      N:      How many merge commits {hash} is behind master
+      link:   Github URL comparing {hash} to master (empty if N==0)
+EOF
+    exit -1
+}
+
+source $REPO_ROOT/boilerplate/_lib/subscriber.sh
+
+## bp_range_url HASH
+#
+# Prints the github URL for the commit range from HASH to master.
+bp_range_url() {
+    local hash=$1
+    [[ -n "$hash" ]] || return
+    echo "https://github.com/openshift/boilerplate/compare/$hash...master"
+}
+
+for subscriber in $(subscriber_list onboarded); do
+    lbc=$(last_bp_commit $subscriber)
+    [[ -n "$lbc" ]] || continue
+    printf "%s,%s (-%d),%s\n" $subscriber $lbc $(commits_behind_bp_master $lbc) $(bp_range_url $lbc)
+done

--- a/boilerplate/_lib/subscriber-report-pr
+++ b/boilerplate/_lib/subscriber-report-pr
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+source $REPO_ROOT/boilerplate/_lib/common.sh
+
+usage() {
+    cat <<EOF
+$CMD
+
+Finds boilerplate-related pull requests for registered subscribers.
+Prints a report of the following form for each subscriber:
+
+      org/proj:
+        link  title  user:branch  state
+        ...
+
+where:
+      org:    Github org (e.g. openshift)
+      proj:   Github project (e.g. my-wizbang-operator)
+      link:   Link to the pull request on GitHub
+      title:  Pull request title
+      user:   Author of the pull request
+      branch: Branch name in author's fork
+      state:  State of the PR (should always be OPEN)
+EOF
+    exit -1
+}
+
+source $REPO_ROOT/boilerplate/_lib/subscriber.sh
+
+for subscriber in $(subscriber_list all); do
+    echo $subscriber:
+    # This awk takes advantage of the fact that these lines start with the
+    # PR number and end with /\w+user:branch\w+OPEN$/;
+    # and we name our branches starting with 'boilerplate-'
+    gh pr list --repo $subscriber | awk -F: '$NF ~ /^boilerplate-/ {print "  https://github.com/'$subscriber'/pull/"$0}'
+    echo
+done

--- a/boilerplate/_lib/subscriber-report-release
+++ b/boilerplate/_lib/subscriber-report-release
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+source $REPO_ROOT/boilerplate/_lib/common.sh
+source $REPO_ROOT/boilerplate/_lib/release.sh
+
+usage() {
+    cat <<EOF
+$CMD
+
+Analyzes the openshift/release footprint of onboarded boilerplate
+subscribers. For each subscriber, prints the delta, if any, between the
+existing and expected prow configuration.
+EOF
+    exit -1
+}
+
+source $REPO_ROOT/boilerplate/_lib/subscriber.sh
+
+## prow_config ORG PROJ
+#
+# Downloads the ci-operator configuration file from openshift/release for the
+# specified consuming project. Prints to stdout the path to the file. If the
+# file does not exist on the server, there is no output.
+#
+# Set the TMPD global before invoking this.
+prow_config() {
+    local org=$1
+    local proj=$2
+    local p=https://raw.githubusercontent.com/$RELEASE_REPO/master/ci-operator/config/$org/$proj
+    local f
+    for branch in master main; do
+        f=$org-$proj-$branch.yaml
+        local c="$(curl -s $p/$f)"
+        if [[ "$c" != "404: Not Found" ]]; then
+            # Remove the zz_generated_metadata section
+            echo "$c" | yq d - zz_generated_metadata > $TMPD/$f
+            echo $TMPD/$f
+            return
+        fi
+    done
+}
+
+## expected_prow_config PROJ
+#
+# Prints to stdout (most of) the expected prow configuration for the specified
+# PROJ. The `zz_generated_metadata` section is omitted.
+expected_prow_config() {
+    local consumer_name=$1
+    # TODO: DRY this with what's in prow-config.
+    # Do it by making it a template in the convention dir.
+    cat <<EOF
+build_root:
+  from_repository: true
+images:
+- dockerfile_path: build/Dockerfile
+  to: unused
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: coverage
+  commands: |
+    export CODECOV_TOKEN=\$(cat /tmp/secret/CODECOV_TOKEN)
+    make coverage
+  container:
+    from: src
+  secret:
+    mount_path: /tmp/secret
+    name: ${consumer_name}-codecov-token
+- as: publish-coverage
+  commands: |
+    export CODECOV_TOKEN=\$(cat /tmp/secret/CODECOV_TOKEN)
+    make coverage
+  container:
+    from: src
+  postsubmit: true
+  secret:
+    mount_path: /tmp/secret
+    name: ${consumer_name}-codecov-token
+- as: lint
+  commands: make lint
+  container:
+    from: src
+- as: test
+  commands: make test
+  container:
+    from: src
+- as: validate
+  commands: make validate
+  container:
+    from: src
+EOF
+}
+
+TMPD=$(mktemp -d)
+trap "rm -fr $TMPD" EXIT
+
+for subscriber in $(subscriber_list onboarded); do
+    banner $subscriber
+    org=${subscriber%/*}
+    proj=${subscriber#*/}
+    pc=$(prow_config $org $proj)
+    if [[ -z "$pc" ]]; then
+        echo "=== No configuration ==="
+    else
+        d="$(expected_prow_config $proj | diff -w - $pc)"
+        if [[ -z "$d" ]]; then
+            echo "=== A-OK ==="
+        else
+            echo "$d"
+        fi
+    fi
+done

--- a/boilerplate/_lib/subscriber.sh
+++ b/boilerplate/_lib/subscriber.sh
@@ -1,0 +1,113 @@
+# Helpers and variables for subscriber automation
+#
+# Source this file from subscriber[-*].
+#
+# If your command has subcommands, define SUBCOMMANDS as a map of
+# [subcmd_name]='Description one-liner' *before* sourcing this library
+# and it will parse the command line up to that point for you, setting
+# the SUBCOMMAND variable and leaving everything else in $@. No explicit
+# usage function is necessary.
+#
+# Otherwise, define your usage() function *before* sourcing this library
+# and it will handle variants of [-[-]]h[elp] for you.
+
+CMD=${SOURCER##*/}
+
+_subcommand_usage() {
+    echo "Usage: $CMD SUBCOMMAND ..."
+    for subcommand in "${!SUBCOMMANDS[@]}"; do
+        echo
+        echo "==========="
+        echo "$CMD $subcommand"
+        echo "    ${SUBCOMMANDS[$subcommand]}"
+    done
+    exit -1
+}
+
+# Regex for help, -h, -help, --help, etc.
+# NOTE: This will match a raw 'h'. That's probably okay, since if
+# there's a conflict, 'h' would be ambiguous anyway.
+_helpre='^-*h(elp)?$'
+
+# Subcommand processing
+if [[ ${#SUBCOMMANDS[@]} -ne 0 ]]; then
+
+    # No subcommand specified
+    [[ $# -eq 0 ]] && _subcommand_usage
+
+    subcmd=$1
+    shift
+
+    [[ "$subcmd" =~ $_helpre ]] && _subcommand_usage
+
+    # Allow unique prefixes
+    SUBCOMMAND=
+    for key in "${!SUBCOMMANDS[@]}"; do
+        if [[ $key == "$subcmd"* ]]; then
+            # If SUBCOMMAND is already set, this is an ambiguous prefix.
+            if [[ -n "$SUBCOMMAND" ]]; then
+                err "Ambiguous subcommand prefix: '$subcmd' matches (at least): ['$SUBCOMMAND', '$key']"
+            fi
+            SUBCOMMAND=$key
+        fi
+    done
+    [[ -n "$SUBCOMMAND" ]] || err "Unknown subcommand '$subcmd'. Try 'help' for usage."
+
+    # We got a valid, unique subcommand. Run the helper with the remaining CLI args.
+    exec $HERE/$CMD-$SUBCOMMAND "$@"
+fi
+
+[[ "$1" =~ $_helpre ]] && usage
+
+SUBSCRIBERS_FILE=$REPO_ROOT/subscribers.yaml
+
+## subscriber_list FILTER
+#
+# Prints a list of subscribers registered in the $SUBSCRIBERS_FILE.
+#
+# FILTER:
+#       all:        Prints all subscribers
+#       onboarded:  Prints only onboarded subscribers
+subscriber_list() {
+    local filt
+    case $1 in
+        all) filt='[*]';;
+        # TODO: Right now subscribers are only "manual".
+        onboarded) filt='(conventions.**.status==manual)';;
+    esac
+    yq r $SUBSCRIBERS_FILE "subscribers${filt}.name"
+}
+
+## last_bp_commit ORG/PROJ
+#
+# Prints the commit hash of the specified repository's boilerplate
+# level, or the empty string if the repository is not onboarded.
+#
+# ORG/PROJ: github organization and project name, e.g.
+#           "openshift/my-wizbang-operator".
+last_bp_commit() {
+    local repo=$1
+    local lbc
+    for default_branch in master main; do
+        lbc=$(curl -s https://raw.githubusercontent.com/$repo/$default_branch/boilerplate/_data/last-boilerplate-commit)
+        if [[ "$lbc" != "404: Not Found" ]]; then
+            echo $lbc | cut -c 1-7
+            return
+        fi
+    done
+}
+
+## commits_behind_bp_master HASH
+#
+# Prints how many merge commits behind boilerplate master HASH is. If
+# HASH is empty/unspecified, prints the total number of merge commits in
+# the boilerplate repo.
+commits_behind_bp_master() {
+    local hash=$1
+    local range=master
+    if [[ -n "$hash" ]]; then
+        range=$hash..master
+    fi
+    git rev-list --count --merges $range
+}
+

--- a/subscribers.yaml
+++ b/subscribers.yaml
@@ -1,0 +1,112 @@
+# List of repositories consuming, or wishing to consume, boilerplate
+# conventions.
+#
+# Note:
+# - This file is currently maintained by hand (not by tooling). It's
+#   YAML so it can used by tooling in the future.
+# - At the time of this writing, there is only one convention:
+#   openshift/golang-osd-operator.
+# - At the time of this writing, the subscribers[].conventions[].status
+#   "automated" isn't a thing yet.
+#
+# Pseudo-schema:
+#   subscribers: List of dicts, each representing the state of a
+#                repository subscribing, or wishing to subscribe, to one
+#                or more boilerplate conventions.
+#     - name: The org/name of the consuming repository.
+#       conventions: List of conventions and the state of this
+#                    repository's subscription.
+#         - name: The name of the convention.
+#           status: One of:
+#                   "candidate": We expect this repository to subscribe
+#                       to boilerplate eventually, but nothing has been
+#                       done yet.
+#                   "proposed": At least one PR is proposed to onboard
+#                       the convention, but none have merged.
+#                   "manual": The repository has merged one or more
+#                       PRs subscribing to the convention. However,
+#                       updates must still be performed manually.
+#                   "automated": Tooling automatically proposes changes
+#                       to the repository when changes to the subscribed
+#                       convention and/or boilerplate framework merge.
+
+subscribers:
+  - name: app-sre/deployment-validation-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: manual
+
+  - name: openshift/aws-account-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: proposed
+
+  - name: openshift/aws-efs-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: candidate
+
+  - name: openshift/certman-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: candidate
+
+  - name: openshift/cloud-ingress-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: candidate
+
+  - name: openshift/configure-alertmanager-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: manual
+
+  - name: openshift/custom-domains-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: manual
+
+  - name: openshift/deadmanssnitch-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: manual
+
+  - name: openshift/gcp-project-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: proposed
+
+  - name: openshift/managed-upgrade-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: candidate
+
+  - name: openshift/managed-velero-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: manual
+
+  - name: openshift/must-gather-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: manual
+
+  - name: openshift/osd-metrics-exporter
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: manual
+
+  - name: openshift/pagerduty-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: manual
+
+  - name: openshift/rbac-permissions-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: candidate
+
+  - name: openshift/route-monitor-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: proposed


### PR DESCRIPTION
Adds `subscribers.yaml`, a simple YAML file to keep track of the repositories that are or will be consuming boilerplate conventions.

Adds a `subscriber` utility to do helpful things with these subscribers:
- Report how far behind boilerplate master onboarded subscribers are.
- Look for open boilerplate-related PRs.
- Analyze the consumer's prow configuration.
- Propose boilerplate update PRs.
