### PR TITLE
golang-osd-operator update calls out codecov integration

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/README.md
+++ b/boilerplate/openshift/golang-osd-operator/README.md
@@ -33,7 +33,7 @@ ready to be SaaS-deployed.
 
 ## Code coverage
 - A `codecov.sh` script, referenced by the `coverage` `make` target, to
-run code coverage analysis per [this SOP](https://github.com/openshift/ops-sop/blob/ff297220d1a6ac5d3199d242a1b55f0d4c433b87/services/codecov.md).
+run code coverage analysis per [this SOP](https://github.com/openshift/ops-sop/blob/93d100347746ce04ad552591136818f82043c648/services/codecov.md).
 
 - A `.codecov.yml` configuration file for
   [codecov.io](https://docs.codecov.io/docs/codecov-yaml). Note that

--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -25,6 +25,9 @@ include boilerplate/generated-includes.mk
 
 - Delete any obsolete files you're no longer including.
 
+- Make sure you are properly integrated with codecov.io:
+  https://github.com/openshift/ops-sop/blob/93d100347746ce04ad552591136818f82043c648/services/codecov.md#generate-the-codecovio-token
+
 - Make sure your prow and app-sre pipeline configurations use the standard
   targets described in the README.
 EOF


### PR DESCRIPTION
Update the output of the `openshift/golang-osd-operator` convention's `update` script to point to the code coverage integration SOP.

Jira: [OSD-5134](https://issues.redhat.com/browse/OSD-5134)