### PR TITLE
Organize targets for prow and appsre

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/README.md
+++ b/boilerplate/openshift/golang-osd-operator/README.md
@@ -12,6 +12,25 @@ The following components are included:
 include boilerplate/generated-includes.mk
 ```
 
+One of the primary purposes of these `make` targets is to allow you to
+standardize your prow and app-sre pipeline configurations. They should be as
+follows:
+
+### Prow
+
+| Test name / `make` target | Purpose                                                                                                         |
+|---------------------------|-----------------------------------------------------------------------------------------------------------------|
+| `validate`                | Ensure code generation has not been forgotten; and ensure generated and boilerplate code has not been modified. |
+| `lint`                    | Perform static analysis.                                                                                        |
+| `test`                    | "Local" unit and functional testing.                                                                            |
+| `coverage`                | (Code coverage)[#code-coverage] analysis and reporting.                                                         |
+| `build`                   | Code compilation and bundle generation.                                                                         |
+
+### app-sre
+
+The `build-push` target builds and pushes the operator and OLM registry images,
+ready to be SaaS-deployed.
+
 ## Code coverage
 - A `codecov.sh` script, referenced by the `coverage` `make` target, to
 run code coverage analysis per [this SOP](https://github.com/openshift/ops-sop/blob/ff297220d1a6ac5d3199d242a1b55f0d4c433b87/services/codecov.md).

--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -24,4 +24,7 @@ include boilerplate/generated-includes.mk
   boilerplate.)
 
 - Delete any obsolete files you're no longer including.
+
+- Make sure your prow and app-sre pipeline configurations use the standard
+  targets described in the README.
 EOF


### PR DESCRIPTION
Per the referenced Jira, we want to standardize the prow configurations for all repositories consuming openshift/golang-osd-operator. This commit refactors the targets to have the desired names and (mostly) do the right things for both prow and appsre. (Since this is primarily a refactor, it leaves TODOs for several things requiring heavy lifting.)

Jira: [OSD-4673](https://issues.redhat.com/browse/OSD-4673)