### PR TITLE
`make clone-this`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,11 @@ test: isclean
 
 .PHONY: pr-check
 pr-check: test
+
+# Use as:
+#     eval $(make clone-this)
+# Then you can go to a consuming repo (in the same shell) and run
+# `make update-boilerplate` to test your local changes.
+.PHONY: clone-this
+clone-this:
+	@echo export BOILERPLATE_GIT_REPO=$(shell realpath .)

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ In your fork of this repository (not a consuming repository):
 To test your changes, you can use the `BOILERPLATE_GIT_REPO` environment
 variable and set it to your local clone in order to override the version of
 boilerplate used (Example: `export BOILERPLATE_GIT_REPO=~/git/boilerplate`).
-
+Shortcut: `eval $(make clone-this)`
 
 Default `update` behaviour consists of cloning the git repo, so ensure you have
 your changes locally committed for your testing.


### PR DESCRIPTION
To facilitate testing local changes, you can now run

```shell
$ eval `make clone-this`
```

and it will set the `BOILERPLATE_GIT_REPO` environment variable to point to your local boilerplate clone.