### PR TITLE
Make `make` targets $noun-$verb where reasonable

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/README.md
+++ b/boilerplate/openshift/golang-osd-operator/README.md
@@ -23,7 +23,7 @@ run code coverage analysis per [this SOP](https://github.com/openshift/ops-sop/b
 
 ## Linting and other static analysis with `golangci-lint`
 
-- A `gocheck` `make` target, which
+- A `go-check` `make` target, which
 - ensures the proper version of `golangci-lint` is installed, and
 - runs it against
 - a `golangci.yml` config.

--- a/boilerplate/openshift/golang-osd-operator/codecov.sh
+++ b/boilerplate/openshift/golang-osd-operator/codecov.sh
@@ -9,7 +9,7 @@ CI_SERVER_URL=https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test
 COVER_PROFILE=${COVER_PROFILE:-coverage.out}
 JOB_TYPE=${JOB_TYPE:-"local"}
 
-make -C "${REPO_ROOT}" gotest TESTOPTS="-coverprofile=${COVER_PROFILE}.tmp -covermode=atomic -coverpkg=./..."
+make -C "${REPO_ROOT}" go-test TESTOPTS="-coverprofile=${COVER_PROFILE}.tmp -covermode=atomic -coverpkg=./..."
 
 # Remove generated files from coverage profile
 grep -v "zz_generated" "${COVER_PROFILE}.tmp" > "${COVER_PROFILE}"

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -53,7 +53,7 @@ ALLOW_DIRTY_CHECKOUT?=false
 # TODO: Figure out how to discover this dynamically
 CONVENTION_DIR := boilerplate/openshift/golang-osd-operator
 
-default: gobuild
+default: go-build
 
 .PHONY: clean
 clean:
@@ -79,31 +79,31 @@ docker-build: build
 .PHONY: docker-push
 docker-push: push
 
-.PHONY: gocheck
-gocheck: ## Lint code
+.PHONY: go-check
+go-check: ## Lint code
 	boilerplate/_lib/ensure.sh golangci-lint
 	GOLANGCI_LINT_CACHE=${GOLANGCI_LINT_CACHE} golangci-lint run -c ${CONVENTION_DIR}/golangci.yml ./...
 
-.PHONY: gogenerate
-gogenerate:
+.PHONY: go-generate
+go-generate:
 	${GOENV} go generate $(TESTTARGETS)
 	# Don't forget to commit generated files
 
-.PHONY: opgenerate
-opgenerate:
+.PHONY: op-generate
+op-generate:
 	operator-sdk generate crds
 	operator-sdk generate k8s
 	# Don't forget to commit generated files
 
 .PHONY: generate
-generate: opgenerate gogenerate
+generate: op-generate go-generate
 
-.PHONY: gobuild
-gobuild: gocheck gotest ## Build binary
+.PHONY: go-build
+go-build: go-check go-test ## Build binary
 	${GOENV} go build ${GOBUILDFLAGS} -o ${BINFILE} ${MAINPACKAGE}
 
-.PHONY: gotest
-gotest:
+.PHONY: go-test
+go-test:
 	${GOENV} go test $(TESTOPTS) $(TESTTARGETS)
 
 .PHONY: coverage
@@ -111,7 +111,7 @@ coverage:
 	${CONVENTION_DIR}/codecov.sh
 
 .PHONY: test
-test: gotest validate-olm-deploy-yaml
+test: go-test olm-deploy-yaml-validate
 
 .PHONY: python-venv
 python-venv:
@@ -122,6 +122,6 @@ python-venv:
 yaml-validate: python-venv
 	${PYTHON} ${CONVENTION_DIR}/validate-yaml.py $(shell git ls-files | egrep -v '^(vendor|boilerplate)/' | egrep '.*\.ya?ml')
 
-.PHONY: validate-olm-deploy-yaml
-validate-olm-deploy-yaml: python-venv
+.PHONY: olm-deploy-yaml-validate
+olm-deploy-yaml-validate: python-venv
 	${PYTHON} ${CONVENTION_DIR}/validate-yaml.py $(shell git ls-files 'deploy/*.yaml' 'deploy/*.yml')


### PR DESCRIPTION
In the spirit of e.g. `docker-build`, rename `make` targets to conform to a `$noun-$verb` format where it makes sense.