### PR TITLE
Move ensure.sh into openshift/golang-osd-operator

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/ensure.sh
+++ b/boilerplate/openshift/golang-osd-operator/ensure.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-source ${0%/*}/common.sh
+REPO_ROOT=$(git rev-parse --show-toplevel)
+source $REPO_ROOT/boilerplate/_lib/common.sh
 
 GOLANGCI_LINT_VERSION="1.30.0"
 DEPENDENCY=${1:-}

--- a/boilerplate/openshift/golang-osd-operator/operator-sdk-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator/operator-sdk-generate.sh
@@ -7,11 +7,10 @@ set -euo pipefail
 ###
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-LIB=$REPO_ROOT/boilerplate/_lib
 
-source $LIB/common.sh
+source $REPO_ROOT/boilerplate/_lib/common.sh
 
-$LIB/ensure.sh operator-sdk
+$HERE/ensure.sh operator-sdk
 
 # Symlink to operator-sdk binary set up by `ensure.sh operator-sdk`:
 OSDK=$REPO_ROOT/.operator-sdk/bin/operator-sdk

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -81,7 +81,7 @@ docker-push: push
 
 .PHONY: go-check
 go-check: ## Lint code
-	boilerplate/_lib/ensure.sh golangci-lint
+	${CONVENTION_DIR}/ensure.sh golangci-lint
 	GOLANGCI_LINT_CACHE=${GOLANGCI_LINT_CACHE} golangci-lint run -c ${CONVENTION_DIR}/golangci.yml ./...
 
 .PHONY: go-generate
@@ -114,7 +114,7 @@ test: go-test olm-deploy-yaml-validate
 
 .PHONY: python-venv
 python-venv:
-	boilerplate/_lib/ensure.sh venv ${CONVENTION_DIR}/py-requirements.txt
+	${CONVENTION_DIR}/ensure.sh venv ${CONVENTION_DIR}/py-requirements.txt
 	$(eval PYTHON := .venv/bin/python3)
 
 .PHONY: yaml-validate


### PR DESCRIPTION
This script is used by `make` targets in `openshift/golang-osd-operator`, not by boilerplate infrastructure, so it makes more sense for it to live in the convention.