### PR TITLE
s/update-boilerplate/boilerplate-update/

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ The lifecycle from the consuming repository's perspective:
     +----+----+      |      |                 |    | |
          |           |      v                 v    | |
          v           |   +--+-----------------+--+ | |
-+--------+---------+ |   |make update-boilerplate| | |
++--------+---------+ |   |make boilerplate-update| | |
 |Create            | |   +--+--------------------+ | |
-|update-boilerplate| |      |                      | |
+|boilerplate-update| |      |                      | |
 |make target       | |      v                      | |
 +--------+---------+ |   +--+-----+                | |
          |           |   |Validate|                | |
@@ -98,8 +98,8 @@ path, because one of the things it does is update itself!
 3. Create a `Makefile` target as follows:
 
 ```makefile
-.PHONY: update-boilerplate
-update-boilerplate:
+.PHONY: boilerplate-update
+boilerplate-update:
 	@boilerplate/update
 ```
 
@@ -114,7 +114,7 @@ your console:
 curl --output boilerplate/update --create-dirs https://raw.githubusercontent.com/openshift/boilerplate/master/boilerplate/update
 chmod +x boilerplate/update
 touch boilerplate/update.cfg
-printf "\n.PHONY: update-boilerplate\nupdate-boilerplate:\n\t@boilerplate/update\n" >> Makefile
+printf "\n.PHONY: boilerplate-update\nboilerplate-update:\n\t@boilerplate/update\n" >> Makefile
 ```
 
 Don't forget to commit the changes.
@@ -147,7 +147,7 @@ in their respective READMEs.
 
 ### Update
 
-Periodically, run `make update-boilerplate` on a clean branch in your
+Periodically, run `make boilerplate-update` on a clean branch in your
 consuming repository. If it succeeds, commit the changes, being sure to
 notice if any new files were created. **Sanity check the changes against
 your specific repository to ensure they didn't break anything.** If they

--- a/test/case/01-bootstrap-update
+++ b/test/case/01-bootstrap-update
@@ -11,7 +11,7 @@ bootstrap_repo $repo
 
 cd $repo
 
-make update-boilerplate
+make boilerplate-update
 
 check_update $repo 01-no-convention
 
@@ -20,7 +20,7 @@ if [ $? -ne 0 ] ; then
 fi
 
 add_convention $repo test/test-base-convention
-make update-boilerplate
+make boilerplate-update
 
 check_update $repo 01-with-convention
 

--- a/test/case/02-nonexistent-convention
+++ b/test/case/02-nonexistent-convention
@@ -18,7 +18,7 @@ echo "bogus/convention" >> boilerplate/update.cfg
 LOG=${0##*/}.log
 
 # A little cheat so we can get the RC from `make`
-make update-boilerplate >$LOG 2>&1
+make boilerplate-update >$LOG 2>&1
 rc=$?
 cat $LOG
 

--- a/test/case/03-nexus-makefile-include
+++ b/test/case/03-nexus-makefile-include
@@ -36,7 +36,7 @@ bootstrap_repo $repo
 cd $repo
 
 sub_hdr "Baseline"
-make update-boilerplate
+make boilerplate-update
 check_update $repo
 
 sub_hdr "Include with no conventions"
@@ -52,7 +52,7 @@ diff $expected/nmi-header $NEXUS_MK
 
 sub_hdr "Convention with no includes"
 add_convention $repo test/nexus-makefile-include/no-includes
-make update-boilerplate
+make boilerplate-update
 check_update $repo
 # Nexus Makefile include should have only the header
 diff $expected/nmi-header $NEXUS_MK
@@ -63,7 +63,7 @@ bootstrap_repo $repo
 sub_hdr "Convention with one include"
 convention=test/nexus-makefile-include/one-include
 add_convention $repo $convention
-make update-boilerplate
+make boilerplate-update
 check_update $repo
 cat $expected/nmi-header > $exp_nmi
 echo "include boilerplate/$convention/one.mk" >> $exp_nmi
@@ -85,7 +85,7 @@ bootstrap_repo $repo
 sub_hdr "Convention with multiple includes"
 convention=test/nexus-makefile-include/multiple-includes
 add_convention $repo $convention
-make update-boilerplate
+make boilerplate-update
 check_update $repo
 cat $expected/nmi-header > $exp_nmi
 # NOTE: These are added in lexical sort order!
@@ -107,7 +107,7 @@ sub_hdr "Multiple conventions"
 for c in no-includes one-include multiple-includes; do
     add_convention $repo test/nexus-makefile-include/$c
 done
-make update-boilerplate
+make boilerplate-update
 check_update $repo
 cat $expected/nmi-header > $exp_nmi
 # NOTE: The *convention* order is honored, even though the *includes*

--- a/test/case/04-update-from-master-and-revert
+++ b/test/case/04-update-from-master-and-revert
@@ -27,15 +27,15 @@ boilerplate_master=$(new_boilerplate_clone)
 override_boilerplate_repo $boilerplate_master || exit $?
 
 add_convention $repo test/test-base-convention
-make update-boilerplate || exit $?
+make boilerplate-update || exit $?
 check_update $repo 03-check-after-init || exit $?
 
 reset_boilerplate_repo
 
-make update-boilerplate || exit $?
+make boilerplate-update || exit $?
 check_update $repo 03-check-new-version-update || exit $?
 
 override_boilerplate_repo $boilerplate_master || exit $?
 
-make update-boilerplate || exit $?
+make boilerplate-update || exit $?
 check_update $repo 03-check-new-version-update || exit $?

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -52,7 +52,7 @@ empty_repo() {
 #
 # Gets a git repo ready for boilerplate:
 # - Copies in boilerplate/update from $REPO_ROOT
-# - Seeds the Makefile with the update-boilerplate target
+# - Seeds the Makefile with the boilerplate-update target
 # - Creates an empty boilerplate/update.cfg
 # It does not run the update.
 #
@@ -65,8 +65,8 @@ bootstrap_repo() {
         mkdir -p boilerplate
         cp $REPO_ROOT/boilerplate/update boilerplate
         cat <<EOF > Makefile
-.PHONY: update-boilerplate
-update-boilerplate:
+.PHONY: boilerplate-update
+boilerplate-update:
 	@boilerplate/update
 EOF
         > $UPDATE_CFG


### PR DESCRIPTION
Rename the `make` target according to the noun-verb format we've been standardizing on.