### PR TITLE
Configure golangci-lint to keep going

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/golangci.yml
+++ b/boilerplate/openshift/golang-osd-operator/golangci.yml
@@ -4,3 +4,10 @@ run:
   concurrency: 10
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 2m
+
+issues:
+  # We want to make sure we get a full report every time. Setting these
+  # to zero disables the limit.
+  max-issues-per-linter: 0
+  max-same-issues: 0
+


### PR DESCRIPTION
By default, golangci-lint will stop printing errors after a certain limit. This can be annoying, especially in CI, as you would have to keep running it repeatedly to fix all the problems. So this commit adds configuration values to disable those limits, meaning *all* errors will be printed on each run.