### PR TITLE
Don't break lint if there is no yaml to validate.

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/validate-yaml.py
+++ b/boilerplate/openshift/golang-osd-operator/validate-yaml.py
@@ -10,7 +10,7 @@ usage = "Usage: {0:s} path/to/file/or/dir...".format(sys.argv[0])
 
 if len(sys.argv) < 2:
     print(usage)
-    sys.exit(1)
+    sys.exit(0)
 
 input_paths = sys.argv[1:]
 


### PR DESCRIPTION
Make targets pass in files to validate but not all repos have yaml that needs validating.
In that case the yaml validation fails because it prints usage and exits with 1.

This PR simply changes the exit code to 0 so it's not going to fail.

There is no great alternative to this, we don't know where yaml might be or if there might be a directory to pass in etc.  Proposing we simply don't fail without arguments.

blocks https://github.com/openshift/configure-alertmanager-operator/pull/101 