### PR TITLE
Review updates from PR #56

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ $ make boilerplate-update
 include boilerplate/generated-includes.mk
 ```
 
-6. Commit, using the `boilerplate-commit` target provided by boilerplate:
+6. Commit. For convenience, you can use the `boilerplate-commit` target
+   provided by boilerplate:
 
 ```shell
 $ make boilerplate-commit
@@ -209,8 +210,9 @@ boilerplate framework itself.
 1. Run `make boilerplate-update` on a clean branch in your consuming
    repository.
 
-2. Run `make boilerplate-commit`. This will create a new topic branch
-   and commit any changes resulting from the update.
+2. Commit the changes. For convenience, you can use `make boilerplate-commit`
+   to automatically create a new topic branch and commit any changes
+   resulting from the update.
 
 3. Sanity check the changes against your specific repository, fixing any
    breakages and making local changes appropriate to the substance of
@@ -220,9 +222,10 @@ boilerplate framework itself.
    content must be made in the boilerplate repo itself.
 
 4. If local changes were necessary, commit them manually. You should
-   commit to the topic branch generated above so that your PR is
-   internally consistent and will build. You may choose to keep the
-   two commits separate (preferred), or combine them.
+   commit to the topic branch you (or `make boilerplate-commit`) created
+   above so that your PR is internally consistent and will build. You
+   may choose to keep the two commits separate (preferred), or combine
+   them.
 
 5. Push the branch to create a PR as usual.
 
@@ -248,11 +251,6 @@ In your fork of this repository (not a consuming repository):
     - **Note:** The entire convention directory is wiped out and
       replaced between `PRE` and `POST`, so e.g. don't try to store any
       information there.
-  - If your `update` script copies or modifies any files outside of the
-    convention subdirectory, you must add those paths to
-    `.boilerplate-ignore-files` in your convention. This tells the main
-    `update` driver that it's okay for those files to be dirty prior to
-    performing an update.
   - It must indicate success or failure by exiting with zero or nonzero
     status, respectively. Failure will cause the main driver to abort.
   - The main driver exports the following variables for use by

--- a/boilerplate/_lib/boilerplate-commit
+++ b/boilerplate/_lib/boilerplate-commit
@@ -53,12 +53,6 @@ elif grep -q '^ M boilerplate/_data/last-boilerplate-commit$' $git_status; then
   bp_compare_url="https://github.com/openshift/boilerplate/compare/$bp_commit_change"
   # Generate the commit history for this range. This will go in the commit message.
   (
-    if [ -z "$BOILERPLATE_GIT_REPO" ]; then
-      BOILERPLATE_GIT_REPO=git@github.com:openshift/boilerplate.git
-    fi
-    if [ -z "$BOILERPLATE_GIT_CLONE" ]; then
-      BOILERPLATE_GIT_CLONE="git clone $BOILERPLATE_GIT_REPO"
-    fi
     $BOILERPLATE_GIT_CLONE $bp_clone
     cd $bp_clone
     # Matches promote.sh
@@ -132,6 +126,13 @@ fi
 # Generate the commit title and branch name indicating the *main* action
 # we're taking. This is 'bootstrap' or 'update'; or if we're doing
 # neither of those things and only changing config, 'subscribe'.
+# => Commit titles will be of one of the following forms:
+#       "Boilerplate: Bootstrap at {hash}"
+#       "Boilerplate: Update to {hash}"
+#       "Boilerplate: Subscribe at {hash}"
+# => Branch names will be of the form:
+#       boilerplate-{bootstrap|update|subscribe}-{N}-{hash}
+#    where {N} is the number of configured conventions (omitted if zero)
 title="Boilerplate:"
 branch=boilerplate
 if [[ -n "$bootstrap" ]]; then

--- a/boilerplate/_lib/common.sh
+++ b/boilerplate/_lib/common.sh
@@ -46,3 +46,9 @@ if [[ "$HERE" == "$CONVENTION_ROOT/"* ]]; then
   [[ -n "$CONVENTION_NAME" ]] || err "$_lib couldn't discover the name of the sourcing convention"
 fi
 
+if [ -z "$BOILERPLATE_GIT_REPO" ]; then
+  export BOILERPLATE_GIT_REPO=git@github.com:openshift/boilerplate.git
+fi
+if [ -z "$BOILERPLATE_GIT_CLONE" ]; then
+  export BOILERPLATE_GIT_CLONE="git clone $BOILERPLATE_GIT_REPO"
+fi

--- a/boilerplate/_lib/freeze-check
+++ b/boilerplate/_lib/freeze-check
@@ -2,9 +2,8 @@
 
 set -e
 
-if [ "$BOILERPLATE_FREEZE_CHECK_DEBUG" ]; then
-  set -x
-fi
+REPO_ROOT=$(git rev-parse --show-toplevel)
+source $REPO_ROOT/boilerplate/_lib/common.sh
 
 # Validate that no subscribed boilerplate artifacts have been changed.
 # PR checks may wish to gate on this.
@@ -29,14 +28,12 @@ fi
 # seriously ticked off if something went wrong and lost my in-flight
 # changes.
 if ! [ -z "$(git status --porcelain)" ]; then
-  echo "Can't validate boilerplate in a dirty repository. Please commit your changes and try again."
-  exit 1
+  err "Can't validate boilerplate in a dirty repository. Please commit your changes and try again."
 fi
 
 # We glean the last boilerplate commit from the
 # last-boilerplate-commit file, which gets laid down by the main
 # `update` driver each time it runs.
-REPO_ROOT=$(git rev-parse --show-toplevel)
 LBCF=${REPO_ROOT}/boilerplate/_data/last-boilerplate-commit
 if ! [[ -f "$LBCF" ]]; then
   echo "Couldn't discover last boilerplate commit! Assuming you're bootstrapping."
@@ -45,9 +42,6 @@ fi
 LBC=$(cat $LBCF)
 
 # Download just that commit
-if [ -z "$BOILERPLATE_GIT_REPO" ]; then
-  BOILERPLATE_GIT_REPO=git@github.com:openshift/boilerplate.git
-fi
 echo "Fetching $LBC from $BOILERPLATE_GIT_REPO"
 # boilerplate/update cleans up this temp dir
 TMPD=$(mktemp -d)
@@ -66,11 +60,11 @@ boilerplate/update $TMPD
 
 # Okay, if anything has changed, that's bad.
 if [[ $(git status --porcelain | wc -l) -ne 0 ]]; then
-  echo "Your boilerplate is dirty!"
-  echo "Run 'git diff' to see what we think you shouldn't have changed."
-  echo "You can commit those changes to pass this check."
-  echo "Or you can run 'git reset --hard HEAD' to get back to where you were before."
-  exit 1
+  err "Your boilerplate is dirty!
+Run 'git diff' to see what we think you shouldn't have changed.
+You can commit those changes to pass this check.
+Or you can run 'git reset --hard HEAD' to get back to where you were before."
+
 fi
 
 echo "Your boilerplate is clean!"

--- a/boilerplate/openshift/golang-osd-operator/.boilerplate-ignore-files
+++ b/boilerplate/openshift/golang-osd-operator/.boilerplate-ignore-files
@@ -1,1 +1,0 @@
-.codecov.yml

--- a/boilerplate/update
+++ b/boilerplate/update
@@ -49,18 +49,26 @@ scrubbed_conventions() {
   done < "$CONFIG_FILE"
 }
 
-# unacceptable_deltas [GREP_FLAGS]
+## unacceptable_deltas [GREP_FLAGS]
+#
+# Looks for uncommitted changes in the current checkout, ignoring certain
+# things as noted below.
+#
+# If changes are found, they are printed (à la `git status --porcelain`)
+# and the function returns nonzero.
+#
+# If no changes are found, the function is silent and returns zero.
+#
+# Ignores:
+# This function ignores uncommitted changes to:
+# - Makefile: Editing this file is part of bootstrapping, and we don't
+#   want to force an additional commit in the bootstrapping process.
+# - ?? boilerplate/: I.e. the boilerplate subdirectory is brand new,
+#   meaning you're bootstrapping. See above.
+# - boilerplate/update.cfg: Changing this file prior to an update is
+#   part of the process of subscribing to new conventions.
 unacceptable_deltas() {
-  # Allow dirty checkout only when bootstrapping, or when modifying the
-  # config (e.g. subscribing to a new convention).
-  # These are always ignoreable:
-  ignores="Makefile|boilerplate/(update\.cfg)?|go.mod|go.sum"
-  # Now add any ignores from subscribed conventions
-  for convention in $(scrubbed_conventions); do
-    ignorefile=$CONVENTION_ROOT/$convention/.boilerplate-ignore-files
-    [[ -s $ignorefile ]] || continue
-    ignores="$ignores|$(paste -d '|' -s $ignorefile)"
-  done
+  ignores="Makefile|boilerplate/(update\.cfg)?"
   git status --porcelain | grep -E -v $1 " ($ignores)$"
 }
 

--- a/test/case/convention/openshift/golang-osd-operator/01_generated_files_checker
+++ b/test/case/convention/openshift/golang-osd-operator/01_generated_files_checker
@@ -12,11 +12,11 @@ for version in v0.15.1 v0.16.0 v0.17.0 v0.17.1 ; do
 
     bootstrap_project $repo ${test_project} openshift/golang-osd-operator
     cd $repo
+    make boilerplate-update
     sed s/__operator_sdk_version__/${version}/g go.mod.tmpl > go.mod
     export GOPATH=$GOPATH:`pwd`
 
     # Check failure when project is not committed
-    make update-boilerplate
     make generate-check && err "make generate-check should have failed" || echo "Project is not committed. Checks failed as expected"
     
     # Checking files haven't been generated and the project is not committed

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -73,11 +73,14 @@ bootstrap_project() {
         git commit -m "Commit baseline test project files"
         mkdir boilerplate
         cp $REPO_ROOT/boilerplate/update boilerplate
+        printf "\n.PHONY: boilerplate-update\nboilerplate-update:\n\t@boilerplate/update\n" >> Makefile
         touch boilerplate/update.cfg
         for convention in $3 ; do
             add_convention . $convention
         done
-        boilerplate/update
+        make boilerplate-update
+        sed -i '1s,^,include boilerplate/generated-includes.mk\n\n,' Makefile
+        make boilerplate-commit
     )
 }
 

--- a/test/projects/file-generate/Makefile
+++ b/test/projects/file-generate/Makefile
@@ -1,6 +1,1 @@
-include boilerplate/generated-includes.mk
-
-.PHONY: update-boilerplate
-update-boilerplate:
-	@boilerplate/update
-
+# placeholder


### PR DESCRIPTION
- Soften README wording around using `make boilerplate-commit` to make it sound less mandatory.
- Remove `go.mod`, `go.sum`, and per-convention `.boilerplate-ignore-files` from the ignore list when ensuring a "clean" checkout prior to `update`. These were causing a test failure, but the right thing was to fix the test, which this commit does.
- Add some comments around non-obvious chunks of code.
- Factor out `BOILERPLATE_GIT_REPO` and `BOILERPLATE_GIT_CLONE` defaulting. (Note that this still isn't used by the main `update` driver, because that needs to be self-contained for bootstrapping.)
- Use common.sh for freeze-check, as part of the above.