### PR TITLE
Make `make validate` include `freeze-check`

### DIFF
--- a/boilerplate/_lib/boilerplate.mk
+++ b/boilerplate/_lib/boilerplate.mk
@@ -1,3 +1,7 @@
 .PHONY: boilerplate-commit
 boilerplate-commit:
 	@boilerplate/_lib/boilerplate-commit
+
+.PHONY: boilerplate-freeze-check
+boilerplate-freeze-check:
+	@boilerplate/_lib/freeze-check

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -129,10 +129,9 @@ olm-deploy-yaml-validate: python-venv
 # validate: Ensure code generation has not been forgotten; and ensure
 # generated and boilerplate code has not been modified.
 # TODO:
-# - isclean; generate; isclean
-# - boilerplate/_lib/freeze-check
+# - move `generate-check` here
 .PHONY: validate
-validate: ;
+validate: boilerplate-freeze-check
 
 # lint: Perform static analysis.
 .PHONY: lint

--- a/test/case/convention/openshift/golang-osd-operator/02-make-boilerplate-freeze-check
+++ b/test/case/convention/openshift/golang-osd-operator/02-make-boilerplate-freeze-check
@@ -1,0 +1,46 @@
+#!/bin/bash -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+source $REPO_ROOT/test/lib.sh
+
+echo "Testing freeze-check"
+repo=$(empty_repo)
+add_cleanup $repo
+# There's nothing special about file-generate -- we could as easily use
+# an empty repo -- but this is convenient.
+test_project="file-generate"
+
+convention=openshift/golang-osd-operator
+bootstrap_project $repo ${test_project} ${convention}
+cd $repo
+
+echo "'make boilerplate-freeze-check' should succeed directly after bootstrap."
+make boilerplate-freeze-check
+
+cur_branch=$(current_branch $repo)
+
+echo "Expect failure when changing boilerplate-owned files"
+# Validate for a file in the convention *and* for a file that the
+# convention's `update` copies out into the main part of the repo.
+for f in boilerplate/${convention}/codecov.sh .codecov.yml; do
+  # Make dirty, and expect validation to fail via `isclean`.
+  echo "# foo" >> $f
+  expect_failure "Can't validate boilerplate in a dirty repository. Please commit your changes and try again." make boilerplate-freeze-check
+  # Commit the change, and expect validation to fail via freeze-check.
+  git checkout -b dirty
+  git commit -a -m dirty
+  expect_failure "Your boilerplate is dirty!" make boilerplate-freeze-check
+  # Get back to the original commit
+  git reset --hard HEAD
+  git checkout $cur_branch
+  git branch -D dirty
+done
+
+# Now let's make sure a non-bp-owned file doesn't fail
+# Make dirty
+echo "# foo" >> Makefile
+expect_failure "Can't validate boilerplate in a dirty repository. Please commit your changes and try again." make boilerplate-freeze-check
+git checkout -b clean
+git commit -a -m clean
+make boilerplate-freeze-check

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -295,3 +295,31 @@ last_commit_message() {
         git log -1 | tail -n +5
     )
 }
+
+## expect_failure ERROR_STRING CMD ARGS...
+#
+# Runs CMD with ARGS...
+# Fails if CMD succeeds.
+# If CMD fails, the output (stdout+stderr) is grepped for ERROR_STRING,
+# and we succeed iff it is found.
+# CMD ARGS... is run via eval "$@". Quote accordingly.
+expect_failure () {
+    local errstr=$1
+    shift
+    local logf=$(mktemp -p $LOG_DIR)
+    rc=0
+    echo "Running command:"
+    echo "   $@"
+    echo "And expecting failure including output:"
+    echo "   $errstr"
+    eval "$@" >$logf 2>&1 || rc=$?
+    if [[ $rc -eq 0 ]]; then
+        echo "Expected failure but got success!" >&2
+        return 1
+    fi
+    if ! grep -q "$errstr" $logf; then
+        echo "Expected output not found!" >&2
+        return 1
+    fi
+    return 0
+}


### PR DESCRIPTION
...to ensure boilerplate-owned files are not changed.

This adds a `make` target in the boilerplate framework itself called `boilerplate-freeze-check` and includes it in the chain of the `validate` target in the `openshift/golang-osd-operator` convention.

Jira: [OSD-5366](https://issues.redhat.com/browse/OSD-5366)