### PR TITLE
Fixed the build and push with skopeo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 ALLOW_DIRTY_CHECKOUT?=false
 IMG?=boilerplate
+IMG_TAG?=latest
 QUAY_IMAGE?=quay.io/app-sre/$(IMG)
 CONTAINER_ENGINE?=$(shell command -v podman 2>/dev/null || echo "docker")
 
@@ -21,15 +22,15 @@ pr-check: test
 .PHONY: docker-build
 docker-build:
 	GIT_HASH=$(shell git rev-parse --short=7 HEAD)
-	cd config; $(CONTAINER_ENGINE) build -t $(IMG) .	
+	cd config; $(CONTAINER_ENGINE) build -t $(IMG):$(IMG_TAG) .	
 
 .PHONY: docker-push
 docker-push:
 	skopeo copy --dest-creds "$(QUAY_USER):$(QUAY_TOKEN)" \
-	    "docker-daemon:$(IMG)" \
-	    "docker://$(QUAY_IMAGE):latest"
+	    "docker-daemon:$(IMG):$(IMG_TAG) \
+	    "docker://$(QUAY_IMAGE):$(IMG_TAG)"
 	skopeo copy --dest-creds "$(QUAY_USER):$(QUAY_TOKEN)" \
-	    "docker-daemon:$(IMG)" \
+	    "docker-daemon:$(IMG):$(IMG_TAG)" \
 	    "docker://$(QUAY_IMAGE):$(GIT_HASH)"
 
 .PHONY: build-push


### PR DESCRIPTION
`skopeo` expects a tag when given an image to push. This was missing. Also parameterized the build image tag.