### PR TITLE
Consumers build/test with tagged images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
 ALLOW_DIRTY_CHECKOUT?=false
 IMG?=boilerplate
-IMG_TAG?=latest
-QUAY_IMAGE?=quay.io/app-sre/$(IMG)
 CONTAINER_ENGINE?=$(shell command -v podman 2>/dev/null || echo "docker")
-GIT_HASH?=$(shell git rev-parse --short=7 HEAD)
 
 # Tests rely on this starting off unset. (And if it is set, it's usually
 # not for the reasons we care about.)
@@ -13,8 +10,12 @@ unexport REPO_NAME
 isclean:
 	@(test "$(ALLOW_DIRTY_CHECKOUT)" != "false" || test 0 -eq $$(git status --porcelain | wc -l)) || (echo "Local git checkout is not clean, commit changes and try again." >&2 && exit 1)
 
+.PHONY: tag-check
+tag-check:
+	config/tag-check.sh
+
 .PHONY: test
-test: isclean
+test: isclean tag-check
 	test/driver
 
 .PHONY: pr-check
@@ -22,17 +23,11 @@ pr-check: test
 
 .PHONY: docker-build
 docker-build:
-	GIT_HASH=$(shell git rev-parse --short=7 HEAD)
-	cd config; $(CONTAINER_ENGINE) build -t $(IMG):$(IMG_TAG) .	
+	cd config; $(CONTAINER_ENGINE) build -t $(IMG):latest .
 
 .PHONY: docker-push
 docker-push:
-	skopeo copy --dest-creds "$(QUAY_USER):$(QUAY_TOKEN)" \
-	    "docker-daemon:$(IMG):$(IMG_TAG)" \
-	    "docker://$(QUAY_IMAGE):$(IMG_TAG)"
-	skopeo copy --dest-creds "$(QUAY_USER):$(QUAY_TOKEN)" \
-	    "docker-daemon:$(IMG):$(IMG_TAG)" \
-	    "docker://$(QUAY_IMAGE):$(GIT_HASH)"
+	config/push.sh quay.io app-sre $(IMG)
 
 .PHONY: build-push
 build-push: docker-build docker-push

--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ In your fork of this repository (not a consuming repository):
       `update` driver and the convention subdirectories themselves. Of
       note, `${CONVENTION_ROOT}/_lib/` contains some utilities that may
       be useful for `update`s.
+    - `LATEST_IMAGE_TAG`: The tag for the most recent build image
+      produced by boilerplate.
 
 ### Environment setup
 To test your changes, you can use the `BOILERPLATE_GIT_REPO` environment
@@ -291,3 +293,27 @@ subdirectory. These are discovered and executed in lexicographic order by
 indicate failure. The [test/lib.sh](test/lib.sh) library defines convenient
 variables and functions you can use if your test case is written in `bash`.
 See existing test cases for examples.
+
+### Build Images
+If you make a change to the build image produced by boilerplate -- i.e.
+by changing anything in [config/](config/) -- you must:
+
+1. Publish a new tag. This will be picked up by appsre and used to
+   publish a new tagged image for consumption via `LATEST_IMAGE_TAG` in
+   conventions. The tag must be named `image-v{X}.{Y}.{Z}`, using
+   [semver](https://semver.org/) principles when deciding what
+   `{X}.{Y}.{Z}` should be.
+
+Example:
+
+```shell
+$ git tag image-v1.2.3
+$ git push upstream --tags
+```
+
+**NOTE:** You must do this *after* creating your PR. Otherwise the
+tagged commit will not exist upstream.
+
+2. Import that tag via boilerplate's ImageStream in `openshift/release`
+   by adding an element to the `spec.tags` list in
+   [this configuration file](https://github.com/openshift/release/blob/master/core-services/supplemental-ci-images/boilerplate.yaml).

--- a/boilerplate/_lib/common.sh
+++ b/boilerplate/_lib/common.sh
@@ -52,3 +52,9 @@ fi
 if [ -z "$BOILERPLATE_GIT_CLONE" ]; then
   export BOILERPLATE_GIT_CLONE="git clone $BOILERPLATE_GIT_REPO"
 fi
+
+# The namespace of the ImageStream by which prow will import the image.
+IMAGE_NAMESPACE=openshift
+IMAGE_NAME=boilerplate
+# The public image location
+IMAGE_PULL_PATH=quay.io/app-sre/$IMAGE_NAME:$LATEST_IMAGE_TAG

--- a/boilerplate/_lib/freeze-check
+++ b/boilerplate/_lib/freeze-check
@@ -49,7 +49,7 @@ cd $TMPD
 git init
 # TODO(efried): DRY this remote. Make it configurable?
 git remote add origin $BOILERPLATE_GIT_REPO
-git fetch origin $(cat $LBCF)
+git fetch origin $(cat $LBCF) --tags
 git reset --hard FETCH_HEAD
 
 # Now invoke the update script, bypassing the exec step because we

--- a/boilerplate/openshift/golang-osd-operator/.ci-operator.yaml
+++ b/boilerplate/openshift/golang-osd-operator/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
-  namespace: openshift
-  name: release
-  tag: golang-1.13
+  namespace: __NAMESPACE__
+  name: __NAME__
+  tag: __TAG__

--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -8,10 +8,18 @@ source $CONVENTION_ROOT/_lib/common.sh
 # Expect POST
 [[ "$1" == "POST" ]] || err "Got a parameter I don't understand: '$1'. Did the infrastructure change?"
 
-for f in .codecov.yml .ci-operator.yaml; do
-    echo "Copying $f to your repository root."
-    cp ${HERE}/$f $REPO_ROOT
-done
+echo "Copying .codecov.yml to your repository root."
+cp ${HERE}/.codecov.yml $REPO_ROOT
+
+# TODO: boilerplate more of Dockerfile
+echo "Overwriting build/Dockerfile's initial FROM with $IMAGE_PULL_PATH"
+sed -i "1s,.*,FROM $IMAGE_PULL_PATH AS builder," build/Dockerfile
+
+echo "Writing .ci-operator.yaml in your repository root with:"
+echo "    namespace: $IMAGE_NAMESPACE"
+echo "    name: $IMAGE_NAME"
+echo "    tag: $LATEST_IMAGE_TAG"
+sed "s/__NAMESPACE__/$IMAGE_NAMESPACE/; s/__NAME__/$IMAGE_NAME/; s/__TAG__/$LATEST_IMAGE_TAG/" ${HERE}/.ci-operator.yaml > $REPO_ROOT/.ci-operator.yaml
 
 cat <<EOF
 =====================

--- a/boilerplate/test/test-base-convention/update
+++ b/boilerplate/test/test-base-convention/update
@@ -20,3 +20,5 @@ echo "Validating variables exported from the main update driver"
 [[ "$CONVENTION_ROOT" == "$REPO_ROOT/boilerplate" ]] || err "Bad CONVENTION_ROOT: '$CONVENTION_ROOT' ; expected $REPO_ROOT/boilerplate"
 # Test framework sets this via the `empty_repo` helper.
 [[ "$REPO_NAME" == "test-repo" ]] || err "Bad REPO_NAME: '$REPO_NAME'"
+# Update this when publishing a new image tag
+[[ "$LATEST_IMAGE_TAG" == "image-v0.1.0" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"

--- a/boilerplate/update
+++ b/boilerplate/update
@@ -140,6 +140,9 @@ if [ ! -f "$CONFIG_FILE" ]; then
   exit 1
 fi
 
+# The most recent build image tag. Export this for individual `update` scripts.
+export LATEST_IMAGE_TAG=$(cd $BP_CLONE; git describe --tags --abbrev=0 --match image-v*)
+
 # Prepare the "nexus makefile include".
 NEXUS_MK="${CONVENTION_ROOT}/generated-includes.mk"
 cat <<EOF>"${NEXUS_MK}"

--- a/config/push.sh
+++ b/config/push.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -e
+
+# Usage: push.sh REGISTRY NAMESPACE NAME
+# e.g. push.sh quay.io app-sre boilerplate
+# Assumes $QUAY_USER and $QUAY_TOKEN are set in the env.
+# Assumes ${NAME}:latest has already been built locally.
+
+registry=$1
+namespace=$2
+name=$3
+
+quay_image=$registry/$namespace/$name
+git_hash=$(git rev-parse --short=7 HEAD)
+
+push_for_tag() {
+    local tag=$1
+    echo "Pushing for tag $tag"
+    skopeo copy --dest-creds "$(QUAY_USER):$(QUAY_TOKEN)" \
+        "docker-daemon:$(name):latest" \
+        "docker://$(quay_image):$tag"
+}
+
+push_for_tag latest
+
+push_for_tag $git_hash
+
+# Now decide whether we need to push a new image "release" tag.
+# This gets us the last non-merge commit:
+commit=$(git rev-list --no-merges -n 1 HEAD)
+# If that commit corresponds to an image tag, this gets the tag:
+tag=$(git describe --exact-match --tag --match image-v* $commit 2>/dev/null || true)
+if [[ -n "$tag" ]]; then
+    push_for_tag $tag
+else
+    echo "No tag here. All done."
+fi
+exit 0
+

--- a/config/tag-check.sh
+++ b/config/tag-check.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -xe
+
+# If you mess with the build image, you must publish a new
+# image-v{X}.{Y}.{Z} tag. We can't automatically generate that tag,
+# because we can't figure out what the semver should be, because we
+# don't know the impact of what you've changed. So this script makes
+# sure that you created the tag. And since we're running this in prow,
+# it also makes sure that the tag has been pushed to upstream.
+
+# This gets us the last non-merge commit:
+commit=$(git rev-list --no-merges -n 1 HEAD)
+# If that commit corresponds to an image tag, this gets the tag:
+tag=$(git describe --exact-match --tag --match image-v* $commit 2>/dev/null || true)
+
+if [[ -n "$tag" ]]; then
+    echo "Found tag $tag at current commit :)"
+    exit 0
+fi
+
+# No tag here. That's okay as long as there were no changes to the build
+# image.
+
+# Since we're in a PR, and there may be multiple commits, we want to
+# check all of them; so compare against the last merge commit before
+# this one. This should work both locally (that should correspond to
+# upstream/master) and in CI (which creates a merge commit to test
+# against).
+# NOTE: This assumes we always merge with merge commits.
+last_merge_commit=$(git log --merges -n1 HEAD^ --format=%H)
+if [[ -n "$(git diff $last_merge_commit --name-only config/)" ]]; then
+    echo "Image build configuration has changed!"
+    echo "You must push a new image-v{X}.{Y}.{Z} tag at commit $commit!"
+    echo "See https://github.com/openshift/boilerplate/blob/$commit/README.md#build-images"
+    exit 1
+fi
+
+exit 0

--- a/test/case/convention/openshift/golang-osd-operator/03-image-tags
+++ b/test/case/convention/openshift/golang-osd-operator/03-image-tags
@@ -1,0 +1,49 @@
+#!/bin/bash -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+source $REPO_ROOT/test/lib.sh
+
+echo "Testing image tags"
+repo=$(empty_repo)
+add_cleanup $repo
+test_project="file-generate"
+
+convention=openshift/golang-osd-operator
+bootstrap_project $repo ${test_project} ${convention}
+cd $repo
+
+# NOTE: Change this when publishing a new image tag.
+expected_image_tag=image-v0.1.0
+
+# The convention's `update` replaces the FROM line in the Dockerfile.
+cat -<<EOF >$LOG_DIR/expected-Dockerfile
+FROM quay.io/app-sre/boilerplate:$expected_image_tag AS builder
+
+ENV OPERATOR=/usr/local/bin/file-generate \\
+    USER_UID=1001 \\
+    USER_NAME=file-generate
+
+# install operator binary
+COPY build/_output/bin/file-generate \${OPERATOR}
+
+COPY build/bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER \${USER_UID}
+EOF
+
+diff $LOG_DIR/expected-Dockerfile build/Dockerfile
+
+# The convention's `update` fills in the .ci-operator.yaml.
+# NOTE: Change this when publishing a new image tag.
+cat -<<EOF >$LOG_DIR/expected-.ci-operator.yaml
+build_root_image:
+  namespace: openshift
+  name: boilerplate
+  tag: $expected_image_tag
+EOF
+
+diff $LOG_DIR/expected-.ci-operator.yaml .ci-operator.yaml


### PR DESCRIPTION
The openshift/golang-osd-operator convention now syncs the image used by prow and appsre by editing build/Dockerfile and .ci-operator.yaml. The image tag used in both is the latest `image-v*` tag from the boilerplate repository.