### PR TITLE
Fix bracing in push.sh

### DIFF
--- a/boilerplate/test/test-base-convention/update
+++ b/boilerplate/test/test-base-convention/update
@@ -20,5 +20,8 @@ echo "Validating variables exported from the main update driver"
 [[ "$CONVENTION_ROOT" == "$REPO_ROOT/boilerplate" ]] || err "Bad CONVENTION_ROOT: '$CONVENTION_ROOT' ; expected $REPO_ROOT/boilerplate"
 # Test framework sets this via the `empty_repo` helper.
 [[ "$REPO_NAME" == "test-repo" ]] || err "Bad REPO_NAME: '$REPO_NAME'"
-# Update this when publishing a new image tag
-[[ "$LATEST_IMAGE_TAG" == "image-v0.1.0" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
+# Granny switch to disable this check for weird tests like reverting to master
+if [[ -z "$SKIP_IMAGE_TAG_CHECK" ]]; then
+    # Update this when publishing a new image tag
+    [[ "$LATEST_IMAGE_TAG" == "image-v0.1.1" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
+fi

--- a/config/push.sh
+++ b/config/push.sh
@@ -15,9 +15,9 @@ git_hash=$(git rev-parse --short=7 HEAD)
 push_for_tag() {
     local tag=$1
     echo "Pushing for tag $tag"
-    skopeo copy --dest-creds "$(QUAY_USER):$(QUAY_TOKEN)" \
-        "docker-daemon:$(name):latest" \
-        "docker://$(quay_image):$tag"
+    skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+        "docker-daemon:${name}:latest" \
+        "docker://${quay_image}:$tag"
 }
 
 push_for_tag latest

--- a/test/case/convention/openshift/golang-osd-operator/03-image-tags
+++ b/test/case/convention/openshift/golang-osd-operator/03-image-tags
@@ -14,7 +14,7 @@ bootstrap_project $repo ${test_project} ${convention}
 cd $repo
 
 # NOTE: Change this when publishing a new image tag.
-expected_image_tag=image-v0.1.0
+expected_image_tag=image-v0.1.1
 
 # The convention's `update` replaces the FROM line in the Dockerfile.
 cat -<<EOF >$LOG_DIR/expected-Dockerfile

--- a/test/case/framework/04-update-from-master-and-revert
+++ b/test/case/framework/04-update-from-master-and-revert
@@ -35,6 +35,10 @@ reset_boilerplate_repo
 make boilerplate-update || exit $?
 check_update $repo 04-check-new-version-update || exit $?
 
+# Hack: test-base-convention's `update` PRE check will fail if master is at an
+# earlier tag.
+export SKIP_IMAGE_TAG_CHECK=1
+
 override_boilerplate_repo $boilerplate_master || exit $?
 
 make boilerplate-update || exit $?


### PR DESCRIPTION
D'oh.

I copied the skopeo commands from [the `make` target](https://github.com/openshift/boilerplate/pull/72/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L30-L35) and I didn't notice that the variable interpolation was using parentheses rather than curly braces.

Fixed.