### PR TITLE
Golangci-lint configuration can be overriden

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -47,6 +47,8 @@ GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPAT
 # Relevant issue - https://github.com/golangci/golangci-lint/issues/734
 GOLANGCI_LINT_CACHE ?= /tmp/golangci-cache
 
+GOLANGCI_LINT_CONFIG ?= ${CONVENTION_DIR}/golangci.yml
+
 TESTTARGETS := $(shell ${GOENV} go list -e ./... | egrep -v "/(vendor)/")
 # ex, -v
 TESTOPTS :=
@@ -88,7 +90,7 @@ push: docker-push
 .PHONY: go-check
 go-check: ## Golang linting and other static analysis
 	${CONVENTION_DIR}/ensure.sh golangci-lint
-	GOLANGCI_LINT_CACHE=${GOLANGCI_LINT_CACHE} golangci-lint run -c ${CONVENTION_DIR}/golangci.yml ./...
+	GOLANGCI_LINT_CACHE=${GOLANGCI_LINT_CACHE} golangci-lint run -c ${GOLANGCI_LINT_CONFIG} ./...
 
 .PHONY: go-generate
 go-generate:


### PR DESCRIPTION
I expect different consumers of boilerplate to have different ideas of
what kind of linters / static code analyzers should be run via golangci.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>