### PR TITLE
Run image build in a temp directory

### DIFF
--- a/boilerplate/test/test-base-convention/update
+++ b/boilerplate/test/test-base-convention/update
@@ -1,5 +1,9 @@
 #!/bin/bash -e
 
+if [[ -z "$BOILERPLATE_SET_X" ]]; then
+    set -x
+fi
+
 # This script validates the vars we expect from the main `update` driver, and
 # many of those are set by common.sh, so don't source it.
 err() {
@@ -23,5 +27,5 @@ echo "Validating variables exported from the main update driver"
 # Granny switch to disable this check for weird tests like reverting to master
 if [[ -z "$SKIP_IMAGE_TAG_CHECK" ]]; then
     # Update this when publishing a new image tag
-    [[ "$LATEST_IMAGE_TAG" == "image-v0.1.1" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
+    [[ "$LATEST_IMAGE_TAG" == "image-v0.1.2" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
 fi

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,3 +1,4 @@
+# NOTE: Keep this in sync with .ci-operator.yaml
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13
 
 COPY build.sh /build.sh

--- a/config/build.sh
+++ b/config/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+tmpd=$(mktemp -d)
+pushd $tmpd
+
 GOCILINT_VERSION="1.31.0"
 GOCILINT_SHA256SUM="9a5d47b51442d68b718af4c7350f4406cdc087e2236a5b9ae52f37aebede6cb3"
 GOCILINT_LOCATION=https://github.com/golangci/golangci-lint/releases/download/v${GOCILINT_VERSION}/golangci-lint-${GOCILINT_VERSION}-linux-amd64.tar.gz
@@ -17,8 +20,6 @@ curl -L -o golangci-lint.tar.gz $GOCILINT_LOCATION
 echo ${GOCILINT_SHA256SUM} golangci-lint.tar.gz | sha256sum -c
 tar xzf golangci-lint.tar.gz golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint
 mv golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint /usr/local/bin
-rm -rf golangci-lint-${GOCILINT_VERSION}-linux-amd64
-rm -f golangci-lint.tar.gz
 
 curl -L -o operator-sdk $OPERATOR_SDK_LOCATION
 echo ${OPERATOR_SDK_SHA256SUM} operator-sdk | sha256sum -c
@@ -42,9 +43,11 @@ tar xzf git.tar.gz
 make --directory "git-${GIT_VERSION}" configure
 ./git-${GIT_VERSION}/configure --prefix=/usr
 make --directory "git-${GIT_VERSION}" prefix=/usr/local all install
-rm -rf "git-${GIT_VERSION}"
 yum groupremove -y "Development Tools" && \
 yum -y remove ${GIT_DEPENDENCIES}
 yum clean all
 yum -y autoremove
 rm -rf /var/cache/yum
+
+popd
+rm -fr $tmpd

--- a/test/case/convention/openshift/golang-osd-operator/03-image-tags
+++ b/test/case/convention/openshift/golang-osd-operator/03-image-tags
@@ -14,7 +14,7 @@ bootstrap_project $repo ${test_project} ${convention}
 cd $repo
 
 # NOTE: Change this when publishing a new image tag.
-expected_image_tag=image-v0.1.1
+expected_image_tag=image-v0.1.2
 
 # The convention's `update` replaces the FROM line in the Dockerfile.
 cat -<<EOF >$LOG_DIR/expected-Dockerfile

--- a/test/case/framework/04-update-from-master-and-revert
+++ b/test/case/framework/04-update-from-master-and-revert
@@ -15,6 +15,10 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 
 source $REPO_ROOT/test/lib.sh
 
+# Hack: test-base-convention's `update` PRE check will fail if master is at an
+# earlier tag. Other tests validate the proper setting of this variable.
+export SKIP_IMAGE_TAG_CHECK=1
+
 repo=$(empty_repo)
 add_cleanup $repo
 
@@ -34,10 +38,6 @@ reset_boilerplate_repo
 
 make boilerplate-update || exit $?
 check_update $repo 04-check-new-version-update || exit $?
-
-# Hack: test-base-convention's `update` PRE check will fail if master is at an
-# earlier tag.
-export SKIP_IMAGE_TAG_CHECK=1
 
 override_boilerplate_repo $boilerplate_master || exit $?
 


### PR DESCRIPTION
The build script was valiantly trying to clean up after itself, but was leaving a few things behind:

```
sh-4.2$ git status
On branch master
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	config.log
	config.mak.autogen
	config.status
	git.tar.gz
```

...which were causing CI failures when they ended up in the image used for pr-check.

This refactor moves all the processing to a temp directory which it blows away when done.