### PR TITLE
Make go-build only build

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -64,7 +64,7 @@ CONVENTION_DIR := boilerplate/openshift/golang-osd-operator
 # https://www.gnu.org/software/make/manual/make.html#index-_002eDEFAULT_005fGOAL-_0028define-default-goal_0029
 .DEFAULT_GOAL :=
 .PHONY: default
-default: go-build
+default: go-check go-test go-build
 
 .PHONY: clean
 clean:
@@ -111,7 +111,7 @@ op-generate:
 generate: op-generate go-generate
 
 .PHONY: go-build
-go-build: go-check go-test ## Build binary
+go-build: ## Build binary
 	# Force GOOS=linux as we may want to build containers in other *nix-like systems (ie darwin).
 	# This is temporary until a better container build method is developed
 	${GOENV} GOOS=linux go build ${GOBUILDFLAGS} -o ${BINFILE} ${MAINPACKAGE}


### PR DESCRIPTION
Since we're running them in prow, and have made sure the prow environment matches the appsre environment, there's no need for validation steps like linting and `go test` to be run as part of the container build.

This commit makes `make go-build` only do the go build. Since `make go-build` is the crux of `make docker-build`, this makes the container build more efficient.

(Note that, prior to #103, `make docker-build` was the only way to run these validation pieces "locally" in the proper container. Now you can do it with `boilerplate/_lib/container-make {target}`.)