### PR TITLE
golang-osd-operator: make codecov-secret-mapping

### DIFF
--- a/boilerplate/_lib/common.sh
+++ b/boilerplate/_lib/common.sh
@@ -16,6 +16,10 @@ osdk_version() {
     $osdk version | sed 's/operator-sdk version: "*\([^,"]*\)"*,.*/\1/'
 }
 
+repo_name() {
+    (git -C $1 config --get remote.upstream.url || git -C $1 config --get remote.origin.url) | sed 's,.*:,,; s/\.git$//'
+}
+
 if [ "$BOILERPLATE_SET_X" ]; then
   set -x
 fi
@@ -52,6 +56,30 @@ fi
 if [ -z "$BOILERPLATE_GIT_CLONE" ]; then
   export BOILERPLATE_GIT_CLONE="git clone $BOILERPLATE_GIT_REPO"
 fi
+
+## Information about the boilerplate consumer
+# E.g. "openshift/my-wizbang-operator"
+CONSUMER=$(repo_name .)
+[[ -z "$CONSUMER" ]] && err "
+Failed to determine current repository name"
+#
+# E.g. "openshift"
+CONSUMER_ORG=${CONSUMER%/*}
+[[ -z "$CONSUMER_ORG" ]] && err "
+Failed to determine consumer org"
+#
+# E.g. "my-wizbang-operator"
+CONSUMER_NAME=${CONSUMER#*/}
+[[ -z "$CONSUMER_NAME" ]] && err "
+Failed to determine consumer name"
+#
+# E.g. "master"
+# This will produce something like refs/remotes/origin/master
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/upstream/HEAD || git symbolic-ref refs/remotes/origin/HEAD || echo defaulting/to/master)
+# Strip off refs/remotes/{upstream|origin}/
+DEFAULT_BRANCH=${DEFAULT_BRANCH##*/}
+[[ -z "$DEFAULT_BRANCH" ]] && err "
+Failed to determine default branch name"
 
 # The namespace of the ImageStream by which prow will import the image.
 IMAGE_NAMESPACE=openshift

--- a/boilerplate/_lib/release.sh
+++ b/boilerplate/_lib/release.sh
@@ -1,0 +1,101 @@
+# Helpers and variables for dealing with openshift/release
+
+RELEASE_REPO=openshift/release
+
+## release_process_args "$@"
+#
+# This is for use by commands expecting one optional argument which is
+# the file system path to a clone of the $RELEASE_REPO.
+#
+# Will invoke `usage` -- which must be defined by the caller -- if
+# the wrong number of arguments are received, or if the single argument
+# is `help` or a flag.
+#
+# If exactly one argument is specified and it is valid, it is assigned
+# to the global RELEASE_CLONE variable.
+release_process_args() {
+    if [[ $# -eq 1 ]]; then
+        # Special cases for usage queries
+        if [[ "$1" == '-'* ]] || [[ "$1" == help ]]; then
+            usage
+        fi
+
+        [[ -d $1 ]] || err "
+    $1: Not a directory."
+
+        [[ $(repo_name $1) == "$RELEASE_REPO" ]] || err "
+    $1 is not a clone of $RELEASE_REPO; or its 'origin' remote is not set properly."
+
+        # Got a usable clone of openshift/release
+        RELEASE_CLONE="$1"
+
+    elif [[ $# -ne 0 ]]; then
+        usage
+    fi
+}
+
+## release_validate_invocation
+#
+# Make sure we were called from a reasonable place, that being:
+# - A boilerplate consumer
+# - ...that's actually subscribed to a convention
+# - ...containing the script being invoked
+release_validate_invocation() {
+    # Make sure we were invoked from a boilerplate consumer.
+    [[ -z "$CONVENTION_NAME" ]] && err "
+    $cmd must be invoked from a consumer of an appropriate convention. Where did you get this script from?"
+    # Or at least not from boilerplate itself
+    [[ "$CONSUMER" == "openshift/boilerplate" ]] && err "
+    $cmd must be invoked from a boilerplate consumer, not from boilerplate itself."
+
+    [[ -s $CONVENTION_ROOT/_data/last-boilerplate-commit ]] || err "
+    $cmd must be invoked from a boilerplate consumer!"
+
+    grep -E -q "^$CONVENTION_NAME(\s.*)?$" $CONVENTION_ROOT/update.cfg || err "
+    $CONSUMER is not subscribed to $CONVENTION_NAME!"
+}
+
+## release_prep_clone
+#
+# If $RELEASE_CLONE is already set:
+# - It should represent a directory containing a clean checkout of the
+#   release repository; otherwise we error.
+# - We checkout and pull master.
+# Otherwise:
+# - We clone the release repo to a temporary directory.
+# - We set the $RELEASE_CLONE global variable to point to that
+#   directory.
+release_prep_clone() {
+    # If a release repo clone wasn't specified, create one
+    if [[ -z "$RELEASE_CLONE" ]]; then
+        RELEASE_CLONE=$(mktemp -dt openshift_release_XXXXXXX)
+        git clone git@github.com:${RELEASE_REPO}.git $RELEASE_CLONE
+    else
+        [[ -z "$(git -C $RELEASE_CLONE status --porcelain)" ]] || err "
+Your release clone must start clean."
+        # These will blow up if it's misconfigured
+        git -C $RELEASE_CLONE checkout master
+        git -C $RELEASE_CLONE pull
+    fi
+}
+
+## release_done_msg BRANCH
+#
+# Print exit instructions for submitting the release PR.
+# BRANCH is a suggested branch name.
+release_done_msg() {
+    echo
+    git status
+
+    cat <<EOF
+
+Ready to commit, push, and create a PR in $RELEASE_CLONE
+You may wish to:
+
+cd $RELEASE_CLONE
+git checkout -b $release_branch
+git add -A
+git commit
+git push origin $release_branch
+EOF
+}

--- a/boilerplate/openshift/golang-osd-operator/README.md
+++ b/boilerplate/openshift/golang-osd-operator/README.md
@@ -52,6 +52,19 @@ run code coverage analysis per [this SOP](https://github.com/openshift/ops-sop/b
   this is copied into the repository root, because that's
   [where codecov.io expects it](https://docs.codecov.io/docs/codecov-yaml#can-i-name-the-file-codecovyml).
 
+- A `make` target to [request the secret mapping in openshift/release](https://github.com/openshift/ops-sop/blob/be43125239deb1f2bbc1ef54f010410e97ff6146/services/codecov.md#openshiftrelease-pr-1---secret-mapping):
+
+```shell
+$ make codecov-secret-mapping
+```
+
+If you already have the openshift/release repository cloned locally, you
+may specify its path via `$RELEASE_CLONE`:
+
+```shell
+$ make RELEASE_CLONE=/home/me/github/openshift/release codecov-secret-mapping
+```
+
 ## Linting and other static analysis with `golangci-lint`
 
 - A `go-check` `make` target, which

--- a/boilerplate/openshift/golang-osd-operator/codecov-secret-mapping
+++ b/boilerplate/openshift/golang-osd-operator/codecov-secret-mapping
@@ -1,0 +1,60 @@
+#!/bin/bash -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+source $REPO_ROOT/boilerplate/_lib/common.sh
+source $REPO_ROOT/boilerplate/_lib/release.sh
+
+cmd=${0##*/}
+
+usage() {
+    cat <<EOF
+Usage: $cmd [PATH_TO_RELEASE_CLONE]
+
+Creates a delta in $RELEASE_REPO requesting a codecov secret mapping for a
+boilerplate consumer. Must be invoked from within a local clone of a repository
+already subscribed to the $CONVENTION_NAME convention.
+
+Parameters:
+    PATH_TO_RELEASE_CLONE   File system path to a local clone of
+                            https://github.com/$RELEASE_REPO. If not
+                            specified, the repository will be cloned in a
+                            temporary directory.
+EOF
+    exit -1
+}
+
+# Was a release repo clone specified?
+release_process_args "$@"
+
+release_validate_invocation
+
+release_prep_clone
+
+cd $RELEASE_CLONE
+
+mapping_file=core-services/secret-mirroring/_mapping.yaml
+secret_name=$CONSUMER_NAME-codecov-token
+
+# TODO: Do some proper yaml validation and editing here.
+
+# See if the mapping already exists. This ain't great: it assumes the
+# lines are in a particular order, and doesn't check the namespaces. See
+# TODO above :)
+grep -B2 $secret_name $mapping_file && err "
+Found existing mapping in $mapping_file
+Nothing to do."
+
+# Append it. This ain't great: it assumes the `secrets` top-level key is
+# still in play, that we're matching whitespace, etc. See TODO above :)
+cat <<EOF >> $mapping_file
+- from:
+    namespace: sd-sre-secrets
+    name: $secret_name
+  to:
+    namespace: ci
+    name: $secret_name
+EOF
+
+release_branch=$CONSUMER_ORG-$CONSUMER_NAME-$DEFAULT_BRANCH-boilerplate-$cmd
+
+release_done_msg $release_branch

--- a/boilerplate/openshift/golang-osd-operator/prow-config
+++ b/boilerplate/openshift/golang-osd-operator/prow-config
@@ -2,86 +2,31 @@
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh
+source $REPO_ROOT/boilerplate/_lib/release.sh
 
 cmd=${0##*/}
-
-release_repo=openshift/release
 
 usage() {
     cat <<EOF
 Usage: $cmd [PATH_TO_RELEASE_CLONE]
 
-Creates a delta in $release_repo standardizing prow configuration for a
+Creates a delta in $RELEASE_REPO standardizing prow configuration for a
 boilerplate consumer. Must be invoked from within a local clone of a repository
 already subscribed to the $CONVENTION_NAME convention.
 
 Parameters:
     PATH_TO_RELEASE_CLONE   File system path to a local clone of
-                            https://github.com/$release_repo. If not
+                            https://github.com/$RELEASE_REPO. If not
                             specified, the repository will be cloned in a
                             temporary directory.
 EOF
     exit -1
 }
 
-repo_name() {
-    (git -C $1 config --get remote.upstream.url || git -C $1 config --get remote.origin.url) | sed 's,.*:,,; s/\.git$//'
-}
-
 # Was a release repo clone specified?
-release_clone=
-if [[ $# -eq 1 ]]; then
-    # Special cases for usage queries
-    if [[ "$1" == '-'* ]] || [[ "$1" == help ]]; then
-        usage
-    fi
+release_process_args "$@"
 
-    [[ -d $1 ]] || err "
-$1: Not a directory."
-
-    [[ $(repo_name $1) == "$release_repo" ]] || err "
-$1 is not a clone of $release_repo; or its 'origin' remote is not set properly."
-
-    # Got a usable clone of openshift/release
-    release_clone=$1
-
-elif [[ $# -ne 0 ]]; then
-    usage
-fi
-
-consumer=$(repo_name .)
-[[ -z "$consumer" ]] && err "
-Failed to determine current repository name"
-
-consumer_org=${consumer%/*}
-[[ -z "$consumer_org" ]] && err "
-Failed to determine consumer org"
-
-consumer_name=${consumer#*/}
-[[ -z "$consumer_name" ]] && err "
-Failed to determine consumer name"
-
-# This will be something like refs/remotes/origin/master
-default_branch=$(git symbolic-ref refs/remotes/origin/HEAD)
-[[ -z "$default_branch" ]] && err "
-Failed to determine default branch name"
-# Strip off refs/remotes/origin/
-default_branch=${default_branch##*/}
-[[ -z "$default_branch" ]] && err "
-Failed to determine default branch name"
-
-# Make sure we were invoked from a boilerplate consumer.
-[[ -z "$CONVENTION_NAME" ]] && err "
-$cmd must be invoked from a consumer of an appropriate convention. Where did you get this script from?"
-# Or at least not from boilerplate itself
-[[ "$consumer" == "openshift/boilerplate" ]] && err "
-$cmd must be invoked from a boilerplate consumer, not from boilerplate itself."
-
-[[ -s $CONVENTION_ROOT/_data/last-boilerplate-commit ]] || err "
-$cmd must be invoked from a boilerplate consumer!"
-
-grep -E -q "^$CONVENTION_NAME(\s.*)?$" $CONVENTION_ROOT/update.cfg || err "
-$consumer is not subscribed to $CONVENTION_NAME!"
+release_validate_invocation
 
 # Due to the DPTP-1640 workaround, we need to be even stricter, since we have
 # to copy in the ImageStreamTag config.
@@ -91,32 +36,22 @@ ci_config=$REPO_ROOT/.ci-operator.yaml
 [[ -s $ci_config ]] || err "
 .ci-operator.yaml not found! Do you need to 'make boilerplate-update'?"
 
-# If a release repo clone wasn't specified, create one
-if [[ -z "$release_clone" ]]; then
-    release_clone=$(mktemp -dt openshift_release_XXXXXXX)
-    git clone git@github.com:${release_repo}.git $release_clone
-else
-    [[ -z "$(git -C $release_clone status --porcelain)" ]] || err "
-Your release clone must start clean."
-    # These will blow up if it's misconfigured
-    git -C $release_clone checkout master
-    git -C $release_clone pull
-fi
+release_prep_clone
 
-cd $release_clone
-release_branch=$consumer_org-$consumer_name-$default_branch-boilerplate-prow-config
-config_dir=ci-operator/config/${consumer_org}/${consumer_name}
-config=${consumer_org}-${consumer_name}-${default_branch}.yaml
+cd $RELEASE_CLONE
+release_branch=$CONSUMER_ORG-$CONSUMER_NAME-$DEFAULT_BRANCH-boilerplate-$cmd
+config_dir=ci-operator/config/${CONSUMER_ORG}/${CONSUMER_NAME}
+config=${CONSUMER_ORG}-${CONSUMER_NAME}-${DEFAULT_BRANCH}.yaml
 [[ -f $config_dir/$config ]] || err "
-$release_repo bootstrapping is not fully supported! Recommend running 'make new-repo' first!
+$RELEASE_REPO bootstrapping is not fully supported! Recommend running 'make new-repo' first!
 To circumvent this warning (not recommended), run:
 
-git -C $release_clone checkout -b $release_branch
-mkdir -p $release_clone/$config_dir
-touch $release_clone/$config_dir/$config
-git -C $release_clone add $config_dir/$config
-git -C $release_clone commit
-$0 $release_clone"
+git -C $RELEASE_CLONE checkout -b $release_branch
+mkdir -p $RELEASE_CLONE/$config_dir
+touch $RELEASE_CLONE/$config_dir/$config
+git -C $RELEASE_CLONE add $config_dir/$config
+git -C $RELEASE_CLONE commit
+$0 $RELEASE_CLONE"
 
 # If we get here, the config file exists. Replace it.
 # TODO: Edit it instead, replacing only the relevant sections. This would allow
@@ -143,7 +78,7 @@ tests:
     from: src
   secret:
     mount_path: /tmp/secret
-    name: ${consumer_name}-codecov-token
+    name: ${CONSUMER_NAME}-codecov-token
 - as: publish-coverage
   commands: |
     export CODECOV_TOKEN=\$(cat /tmp/secret/CODECOV_TOKEN)
@@ -153,7 +88,7 @@ tests:
   postsubmit: true
   secret:
     mount_path: /tmp/secret
-    name: ${consumer_name}-codecov-token
+    name: ${CONSUMER_NAME}-codecov-token
 - as: lint
   commands: make lint
   container:
@@ -167,24 +102,11 @@ tests:
   container:
     from: src
 zz_generated_metadata:
-  branch: ${default_branch}
-  org: ${consumer_org}
-  repo: ${consumer_name}
+  branch: ${DEFAULT_BRANCH}
+  org: ${CONSUMER_ORG}
+  repo: ${CONSUMER_NAME}
 EOF
 
 make jobs
 
-echo
-git status
-
-cat <<EOF
-
-Ready to commit, push, and create a PR in $release_clone
-You may wish to:
-
-cd $release_clone
-git checkout -b $release_branch
-git add -A
-git commit
-git push origin $release_branch
-EOF
+release_done_msg $release_branch

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -137,6 +137,10 @@ olm-deploy-yaml-validate: python-venv
 prow-config:
 	${CONVENTION_DIR}/prow-config ${RELEASE_CLONE}
 
+.PHONY: codecov-secret-mapping
+codecov-secret-mapping:
+	${CONVENTION_DIR}/codecov-secret-mapping ${RELEASE_CLONE}
+
 ######################
 # Targets used by prow
 ######################


### PR DESCRIPTION
Add a `make` target, which can accept an optional `RELEASE_CLONE` environment variable, creating a delta in openshift/release to request the codecov secret mapping per the [SOP](https://github.com/openshift/ops-sop/blob/be43125239deb1f2bbc1ef54f010410e97ff6146/services/codecov.md#openshiftrelease-pr-1---secret-mapping)

This script shares a lot of logic with `prow-config`, so that's factored out into libraries.

Jira: [OSD-5420](https://issues.redhat.com/browse/OSD-5420)