### PR TITLE
Set debug for ensure.sh

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/ensure.sh
+++ b/boilerplate/openshift/golang-osd-operator/ensure.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 set -eo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
This will help debug CI failures (we've seen what may be flakes `curl`ing golangci-lint) and shouldn't be _too_ noisy under other
circumstances.