### PR TITLE
Alphabetize .ci-operator.yaml

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/.ci-operator.yaml
+++ b/boilerplate/openshift/golang-osd-operator/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
-  namespace: __NAMESPACE__
   name: __NAME__
+  namespace: __NAMESPACE__
   tag: __TAG__

--- a/test/case/convention/openshift/golang-osd-operator/03-image-tags
+++ b/test/case/convention/openshift/golang-osd-operator/03-image-tags
@@ -41,8 +41,8 @@ diff $LOG_DIR/expected-Dockerfile build/Dockerfile
 # NOTE: Change this when publishing a new image tag.
 cat -<<EOF >$LOG_DIR/expected-.ci-operator.yaml
 build_root_image:
-  namespace: openshift
   name: boilerplate
+  namespace: openshift
   tag: $expected_image_tag
 EOF
 


### PR DESCRIPTION
When `make prow-config` parlays .ci-operator.yaml into (the temporary section in) the prow configuration, apparently prow's CI cares that the fields are ordered alphabetically.

Consumers not updated with this commit can work around this by manually reordering in their release PR.

And this will become n/a anyway once [DPTP-1640](https://issues.redhat.com/browse/DPTP-1640) is gone.