### PR TITLE
Add docker image build to prow config

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/README.md
+++ b/boilerplate/openshift/golang-osd-operator/README.md
@@ -38,6 +38,12 @@ may specify its path via `$RELEASE_CLONE`:
 $ make RELEASE_CLONE=/home/me/github/openshift/release prow-config
 ```
 
+This will generate a delta configuring prow to:
+- Build your `build/Dockerfile`.
+- Run the above targets in presubmit tests.
+- Run the `coverage` target in a postsubmit. This is the step that
+  updates your coverage report in codecov.io.
+
 ### app-sre
 
 The `build-push` target builds and pushes the operator and OLM registry images,

--- a/boilerplate/openshift/golang-osd-operator/prow-config
+++ b/boilerplate/openshift/golang-osd-operator/prow-config
@@ -62,6 +62,10 @@ base_images:
 $(sed -n '2,5s/^/  /p' $ci_config)
 build_root:
   from_repository: true
+images:
+- dockerfile_path: build/Dockerfile
+  from: src
+  to: unused
 resources:
   '*':
     limits:

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -163,13 +163,6 @@ test: go-test
 coverage:
 	${CONVENTION_DIR}/codecov.sh
 
-# build: Code compilation and bundle generation. This should do as much
-# of what app-sre does as possible, so that there are no surprises after
-# a PR is merged.
-# TODO: Include generating (but not pushing) the bundle
-.PHONY: build
-build: docker-build
-
 #########################
 # Targets used by app-sre
 #########################


### PR DESCRIPTION
Tweak `make prow-config` to generate a section testing the build of the main Dockerfile.