### PR TITLE
Image v0.3.0

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/ensure.sh
+++ b/boilerplate/openshift/golang-osd-operator/ensure.sh
@@ -65,10 +65,16 @@ operator-sdk)
                 exit 1
                 ;;
         esac
-        echo "Downloading $binary"
-        curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${wantver}/${binary}
-        chmod +x ${binary}
-        osdk=${binary}
+        # The boilerplate backing image sets up binaries with the full
+        # name in /usr/local/bin, so look for the right one of those
+        if which $binary; then
+            osdk=$(realpath $(which $binary))
+        else
+            echo "Downloading $binary"
+            curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${wantver}/${binary}
+            chmod +x ${binary}
+            osdk=${binary}
+        fi
     fi
     # Create (or overwrite) the symlink to the binary we discovered or
     # downloaded above.

--- a/boilerplate/openshift/golang-osd-operator/operator-sdk-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator/operator-sdk-generate.sh
@@ -28,7 +28,7 @@ VER=$(osdk_version $OSDK)
 # This explicitly lists the versions we know about. We don't support
 # anything outside of that.
 case $VER in
-  'v0.15.1'|'v0.16.0'|'v0.17.0'|'v0.17.1')
+  'v0.15.1'|'v0.16.0'|'v0.17.0'|'v0.17.1'|'v0.17.2'|'v0.18.2')
       $OSDK generate crds
       $OSDK generate k8s
       ;;

--- a/config/build.sh
+++ b/config/build.sh
@@ -20,14 +20,27 @@ mv golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint /usr/local/bin
 ##############
 # operator-sdk
 ##############
-OPERATOR_SDK_VERSION="0.16.0"
-OPERATOR_SDK_SHA256SUM="3df782f341749f7962ab0fcfedd2961c18b21ad34ff7acd194b49a152f59abcb"
-OPERATOR_SDK_LOCATION=https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk-v${OPERATOR_SDK_VERSION}-x86_64-linux-gnu
+# Install all the versions we support. ensure.sh is set up to find the
+# one it needs.
+declare -A OSDK_VERSION_HASHES
+OSDK_VERSION_HASHES=(
+    ['v0.15.1']="5c8c06bd8a0c47f359aa56f85fe4e3ee2066d4e51b60b75e131dec601b7b3cd6"
+    ['v0.16.0']="3df782f341749f7962ab0fcfedd2961c18b21ad34ff7acd194b49a152f59abcb"
+    ['v0.17.0']="f801a4a061c175fdb4875fbb021d4f8cae9c57cc1c00829ab2de4edf733e1963"
+    ['v0.17.1']="9f6538beb15272d193e9e0d03678ef0f8aa3afd2f719a491fcc83abbb5cd28cf"
+    ['v0.17.2']="4335d231c0733653ccab4e05623501a93367a459100d577cae1f2ed497b33708"
+    ['v0.18.2']="40d35ea77b7b0cb5d2f88b97bb8c5b0684af4a54b9d7056790ecaa5e4a70a0d4"
+)
 
-curl -L -o operator-sdk $OPERATOR_SDK_LOCATION
-echo ${OPERATOR_SDK_SHA256SUM} operator-sdk | sha256sum -c
-chmod ugo+x operator-sdk
-mv operator-sdk /usr/local/bin
+for OPERATOR_SDK_VERSION in "${!OSDK_VERSION_HASHES[@]}"; do
+    OPERATOR_SDK_SHA256SUM="${OSDK_VERSION_HASHES[$OPERATOR_SDK_VERSION]}"
+    OPERATOR_SDK_BINARY=operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu
+    OPERATOR_SDK_LOCATION=https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/$OPERATOR_SDK_BINARY
+    curl -L -o $OPERATOR_SDK_BINARY $OPERATOR_SDK_LOCATION
+    echo ${OPERATOR_SDK_SHA256SUM} $OPERATOR_SDK_BINARY | sha256sum -c
+    chmod ugo+x $OPERATOR_SDK_BINARY
+    mv $OPERATOR_SDK_BINARY /usr/local/bin
+done
 
 ####
 # yq

--- a/config/build.sh
+++ b/config/build.sh
@@ -13,10 +13,6 @@ OPERATOR_SDK_VERSION="0.16.0"
 OPERATOR_SDK_SHA256SUM="3df782f341749f7962ab0fcfedd2961c18b21ad34ff7acd194b49a152f59abcb"
 OPERATOR_SDK_LOCATION=https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk-v${OPERATOR_SDK_VERSION}-x86_64-linux-gnu
 
-OPM_VERSION="1.13.8"
-OPM_SHASUM="a48aa9d69b0be3439220e818edde4b36b3b9eceb2a058d86b4fdf0ca9dcd21c8"
-OPM_LOCATION=https://github.com/operator-framework/operator-registry/releases/download/v${OPM_VERSION}/linux-amd64-opm
-
 curl -L -o golangci-lint.tar.gz $GOCILINT_LOCATION
 echo ${GOCILINT_SHA256SUM} golangci-lint.tar.gz | sha256sum -c
 tar xzf golangci-lint.tar.gz golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint
@@ -26,11 +22,6 @@ curl -L -o operator-sdk $OPERATOR_SDK_LOCATION
 echo ${OPERATOR_SDK_SHA256SUM} operator-sdk | sha256sum -c
 chmod ugo+x operator-sdk
 mv operator-sdk /usr/local/bin
-
-curl -L -o opm $OPM_LOCATION && \
-echo ${OPM_SHASUM} opm | sha256sum -c
-chmod ugo+x opm
-mv opm /usr/local/bin
 
 python3 -m pip install PyYAML==5.3.1
 

--- a/config/build.sh
+++ b/config/build.sh
@@ -5,35 +5,50 @@ set -euo pipefail
 tmpd=$(mktemp -d)
 pushd $tmpd
 
+###############
+# golangci-lint
+###############
 GOCILINT_VERSION="1.31.0"
 GOCILINT_SHA256SUM="9a5d47b51442d68b718af4c7350f4406cdc087e2236a5b9ae52f37aebede6cb3"
 GOCILINT_LOCATION=https://github.com/golangci/golangci-lint/releases/download/v${GOCILINT_VERSION}/golangci-lint-${GOCILINT_VERSION}-linux-amd64.tar.gz
-
-OPERATOR_SDK_VERSION="0.16.0"
-OPERATOR_SDK_SHA256SUM="3df782f341749f7962ab0fcfedd2961c18b21ad34ff7acd194b49a152f59abcb"
-OPERATOR_SDK_LOCATION=https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk-v${OPERATOR_SDK_VERSION}-x86_64-linux-gnu
-
-YQ_VERSION="3.4.1"
-YQ_SHA256SUM="adbc6dd027607718ac74ceac15f74115ac1f3caef68babfb73246929d4ffb23c"
-YQ_LOCATION=https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64
 
 curl -L -o golangci-lint.tar.gz $GOCILINT_LOCATION
 echo ${GOCILINT_SHA256SUM} golangci-lint.tar.gz | sha256sum -c
 tar xzf golangci-lint.tar.gz golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint
 mv golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint /usr/local/bin
 
+##############
+# operator-sdk
+##############
+OPERATOR_SDK_VERSION="0.16.0"
+OPERATOR_SDK_SHA256SUM="3df782f341749f7962ab0fcfedd2961c18b21ad34ff7acd194b49a152f59abcb"
+OPERATOR_SDK_LOCATION=https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk-v${OPERATOR_SDK_VERSION}-x86_64-linux-gnu
+
 curl -L -o operator-sdk $OPERATOR_SDK_LOCATION
 echo ${OPERATOR_SDK_SHA256SUM} operator-sdk | sha256sum -c
 chmod ugo+x operator-sdk
 mv operator-sdk /usr/local/bin
+
+####
+# yq
+####
+YQ_VERSION="3.4.1"
+YQ_SHA256SUM="adbc6dd027607718ac74ceac15f74115ac1f3caef68babfb73246929d4ffb23c"
+YQ_LOCATION=https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64
 
 curl -L -o yq $YQ_LOCATION
 echo ${YQ_SHA256SUM} yq | sha256sum -c
 chmod ugo+x yq
 mv yq /usr/local/bin
 
+##################
+# python libraries
+##################
 python3 -m pip install PyYAML==5.3.1
 
+#####
+# git
+#####
 # Per https://git-scm.com/download/linux, we have two choices for CentOS
 # (which is what we're running on):
 # - Build from source

--- a/config/build.sh
+++ b/config/build.sh
@@ -13,6 +13,10 @@ OPERATOR_SDK_VERSION="0.16.0"
 OPERATOR_SDK_SHA256SUM="3df782f341749f7962ab0fcfedd2961c18b21ad34ff7acd194b49a152f59abcb"
 OPERATOR_SDK_LOCATION=https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk-v${OPERATOR_SDK_VERSION}-x86_64-linux-gnu
 
+YQ_VERSION="3.4.1"
+YQ_SHA256SUM="adbc6dd027607718ac74ceac15f74115ac1f3caef68babfb73246929d4ffb23c"
+YQ_LOCATION=https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64
+
 curl -L -o golangci-lint.tar.gz $GOCILINT_LOCATION
 echo ${GOCILINT_SHA256SUM} golangci-lint.tar.gz | sha256sum -c
 tar xzf golangci-lint.tar.gz golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint
@@ -22,6 +26,11 @@ curl -L -o operator-sdk $OPERATOR_SDK_LOCATION
 echo ${OPERATOR_SDK_SHA256SUM} operator-sdk | sha256sum -c
 chmod ugo+x operator-sdk
 mv operator-sdk /usr/local/bin
+
+curl -L -o yq $YQ_LOCATION
+echo ${YQ_SHA256SUM} yq | sha256sum -c
+chmod ugo+x yq
+mv yq /usr/local/bin
 
 python3 -m pip install PyYAML==5.3.1
 

--- a/config/build.sh
+++ b/config/build.sh
@@ -59,6 +59,35 @@ mv yq /usr/local/bin
 ##################
 python3 -m pip install PyYAML==5.3.1
 
+##################
+# golang (via gvm)
+##################
+GO_VERSIONS="go1.13.15 go1.14.10"
+
+GVM_VERSION=1.0.22
+GVM_SHA256SUM="72123889c8ef55f7b745038dc8cf556c1aece982408966fa5ff612ce6a97bae7"
+GVM_LOCATION=https://raw.githubusercontent.com/moovweb/gvm/${GVM_VERSION}/binscripts/gvm-installer
+
+curl -L -o gvm-installer $GVM_LOCATION
+echo ${GVM_SHA256SUM} gvm-installer | sha256sum -c
+chmod ugo+x gvm-installer
+./gvm-installer
+rm -f gvm-installer
+source /root/.gvm/scripts/gvm
+
+GVM_DEPS="bison"
+yum -y install ${GVM_DEPS}
+
+for GO_VERSION in $GO_VERSIONS; do
+    gvm install $GO_VERSION --prefer-binary
+done
+
+# Is there a better way to make this usable by the non-root user in the
+# consumer pod?
+chmod -R ugo+w /root/.gvm
+
+yum -y remove ${GVM_DEPS}
+
 #####
 # git
 #####
@@ -81,6 +110,10 @@ make --directory "git-${GIT_VERSION}" configure
 make --directory "git-${GIT_VERSION}" prefix=/usr/local all install
 yum groupremove -y "Development Tools" && \
 yum -y remove ${GIT_DEPENDENCIES}
+
+#########
+# cleanup
+#########
 yum clean all
 yum -y autoremove
 


### PR DESCRIPTION
Updates to the boilerplate backing image:
- Remove OPM
- Add `yq`
- Install all supported operator-sdk versions (and tweak ensure.sh to look for them)
- Install multiple go versions