### PR TITLE
Skip operator-sdk generate if no APIs

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/operator-sdk-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator/operator-sdk-generate.sh
@@ -10,6 +10,14 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 
 source $REPO_ROOT/boilerplate/_lib/common.sh
 
+# There's nothing to generate if pkg/apis is empty (other than apis.go).
+# And instead of succeeding gracefully, `operator-sdk generate` will
+# fail if you try. So do our own check.
+if ! /bin/ls -1 pkg/apis | grep -Fqv apis.go; then
+    echo "No APIs! Skipping operator-sdk generate."
+    exit 0
+fi
+
 $HERE/ensure.sh operator-sdk
 
 # Symlink to operator-sdk binary set up by `ensure.sh operator-sdk`:


### PR DESCRIPTION
If your operator has no APIs (which is a legitimate thing), `operator-sdk generate` will fail with a message like:

`error generating CRDs from APIs in pkg/apis: error generating CRD manifests: error reading CRD cache dir deploy/crds: open deploy/crds: file does not exist`

Add a check to operator-sdk-generate.sh to skip if no APIs are found.