### PR TITLE
Make default golangci-lint config rules explicit

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/golangci.yml
+++ b/boilerplate/openshift/golang-osd-operator/golangci.yml
@@ -11,3 +11,16 @@ issues:
   max-issues-per-linter: 0
   max-same-issues: 0
 
+linters:
+  disable-all: true
+  enable:
+  - deadcode
+  - errcheck
+  - gosimple
+  - govet
+  - ineffassign
+  - staticcheck
+  - structcheck
+  - typecheck
+  - unused
+  - varcheck


### PR DESCRIPTION
We will know better which checks are in use and they won't change if
defaults are changed between golangci-lint versions

Addresses [OSD-5557](https://issues.redhat.com/browse/OSD-5557)

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>