### PR TITLE
Optional second golangci-lint config

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/README.md
+++ b/boilerplate/openshift/golang-osd-operator/README.md
@@ -77,6 +77,7 @@ $ make RELEASE_CLONE=/home/me/github/openshift/release codecov-secret-mapping
 - ensures the proper version of `golangci-lint` is installed, and
 - runs it against
 - a `golangci.yml` config.
+- a `GOLANGCI_OPTIONAL_CONFIG` config if it is defined and file exists
 
 ## Checks on generated code
 

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -47,6 +47,8 @@ GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPAT
 # Relevant issue - https://github.com/golangci/golangci-lint/issues/734
 GOLANGCI_LINT_CACHE ?= /tmp/golangci-cache
 
+GOLANGCI_OPTIONAL_CONFIG ?=
+
 TESTTARGETS := $(shell ${GOENV} go list -e ./... | egrep -v "/(vendor)/")
 # ex, -v
 TESTOPTS :=
@@ -89,6 +91,7 @@ push: docker-push
 go-check: ## Golang linting and other static analysis
 	${CONVENTION_DIR}/ensure.sh golangci-lint
 	GOLANGCI_LINT_CACHE=${GOLANGCI_LINT_CACHE} golangci-lint run -c ${CONVENTION_DIR}/golangci.yml ./...
+	test "${GOLANGCI_OPTIONAL_CONFIG}" = "" || test ! -e "${GOLANGCI_OPTIONAL_CONFIG}" || GOLANGCI_LINT_CACHE="${GOLANGCI_LINT_CACHE}" golangci-lint run -c "${GOLANGCI_OPTIONAL_CONFIG}" ./...
 
 .PHONY: go-generate
 go-generate:


### PR DESCRIPTION
This will be controlled by `GOLANGCI_OPTIONAL_CONFIG` and it will allow
boilerplate consumers to run additional checks not covered by the
default config

Addresses [OSD-5558](https://issues.redhat.com/browse/OSD-5558)

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>