### PR TITLE
Remove DPTP-1640 workaround for consumers

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/prow-config
+++ b/boilerplate/openshift/golang-osd-operator/prow-config
@@ -28,14 +28,6 @@ release_process_args "$@"
 
 release_validate_invocation
 
-# Due to the DPTP-1640 workaround, we need to be even stricter, since we have
-# to copy in the ImageStreamTag config.
-# TODO: Get rid of this check, and $ci_config, and its usage in the config
-# dump, once DPTP-1640 is resolved.
-ci_config=$REPO_ROOT/.ci-operator.yaml
-[[ -s $ci_config ]] || err "
-.ci-operator.yaml not found! Do you need to 'make boilerplate-update'?"
-
 release_prep_clone
 
 cd $RELEASE_CLONE
@@ -57,14 +49,10 @@ $0 $RELEASE_CLONE"
 # TODO: Edit it instead, replacing only the relevant sections. This would allow
 # the consumer to preserve any additional checks they want in prow.
 cat <<EOF > $config_dir/$config
-base_images:
-  temporarily_needed_to_make_this_image_appear_in_all_build_clusters_see_jira_dptp_1640:
-$(sed -n '2,5s/^/  /p' $ci_config)
 build_root:
   from_repository: true
 images:
 - dockerfile_path: build/Dockerfile
-  from: src
   to: unused
 resources:
   '*':


### PR DESCRIPTION
It turns out we don't need to do the workaround for [DPTP-1640](https://issues.redhat.com/browse/DPTP-1640) for every consumer -- we only need to do it once in the whole environment. That's now being taken care of in [boilerplate's config](https://github.com/openshift/release/pull/13288), so this commit removes it from what consumers generate via `make prow-config`.

[DPTP-1640](https://issues.redhat.com/browse/DPTP-1640)