### PR TITLE
CRD fixup for 3.11

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -101,6 +101,10 @@ go-generate:
 .PHONY: op-generate
 op-generate:
 	${CONVENTION_DIR}/operator-sdk-generate.sh
+	# HACK: Due to an OLM bug in 3.11, we need to remove the
+	# spec.validation.openAPIV3Schema.type from CRDs. Remove once
+	# 3.11 is no longer supported.
+	find deploy/ -name '*_crd.yaml' | xargs -n1 -I{} yq d -i {} spec.validation.openAPIV3Schema.type
 	# Don't forget to commit generated files
 
 .PHONY: generate

--- a/test/case/convention/openshift/golang-osd-operator/04-op-generate-crd-fixup
+++ b/test/case/convention/openshift/golang-osd-operator/04-op-generate-crd-fixup
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+source $REPO_ROOT/test/lib.sh
+
+echo "Testing CRD fixup for OLM bug in 3.11"
+
+repo=$(empty_repo)
+add_cleanup $repo
+test_project="file-generate"
+
+bootstrap_project $repo ${test_project} openshift/golang-osd-operator
+cd $repo
+make boilerplate-update
+# Pick a version
+sed s/__operator_sdk_version__/v0.16.0/g go.mod.tmpl > go.mod
+
+make op-generate
+
+diff deploy/crds/mygroup.com_testkinds_crd.yaml expected/mygroup.com_testkinds_crd.yaml || err "CRD fixup didn't work properly."

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -14,6 +14,11 @@ export NEXUS_MK=boilerplate/generated-includes.mk
 
 _BP_TEST_TEMP_DIRS=
 
+err() {
+  echo "==ERROR== $@" >&2
+  exit 1
+}
+
 _cleanup() {
     echo
     echo "Cleaning up"

--- a/test/projects/file-generate/expected/mygroup.com_testkinds_crd.yaml
+++ b/test/projects/file-generate/expected/mygroup.com_testkinds_crd.yaml
@@ -1,0 +1,37 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: testkinds.mygroup.com
+spec:
+  group: mygroup.com
+  names:
+    kind: TestKind
+    listKind: TestKindList
+    plural: testkinds
+    singular: testkind
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: TestKind is the Schema for the testkinds API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: TestKindSpec defines the desired state of TestKind
+          type: object
+        status:
+          description: TestKindStatus defines the observed state of TestKind
+          type: object
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true


### PR DESCRIPTION
Due to an OLM bug in OCP 3.11, we need to remove the spec.validation.openAPIV3Schema.type from generated CRDs.