### PR TITLE
Allow flags to `operator-sdk generate crds`

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/operator-sdk-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator/operator-sdk-generate.sh
@@ -29,7 +29,7 @@ VER=$(osdk_version $OSDK)
 # anything outside of that.
 case $VER in
   'v0.15.1'|'v0.16.0'|'v0.17.0'|'v0.17.1'|'v0.17.2'|'v0.18.2')
-      $OSDK generate crds
+      $OSDK generate crds $OSDK_GENERATE_CRDS_FLAGS
       $OSDK generate k8s
       ;;
   *) err "Unsupported operator-sdk version $VER" ;;

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -100,7 +100,7 @@ go-generate:
 
 .PHONY: op-generate
 op-generate:
-	${CONVENTION_DIR}/operator-sdk-generate.sh
+	OSDK_GENERATE_CRDS_FLAGS="${OSDK_GENERATE_CRDS_FLAGS}" ${CONVENTION_DIR}/operator-sdk-generate.sh
 	# HACK: Due to an OLM bug in 3.11, we need to remove the
 	# spec.validation.openAPIV3Schema.type from CRDs. Remove once
 	# 3.11 is no longer supported.


### PR DESCRIPTION
operator-sdk started supporting CRD v1 at 0.17; and that became the default for `operator-sdk generate crds` at 0.18.

This commit adds support for a Makefile variable `OSDK_GENERATE_CRDS_FLAGS` to accommodate boilerplate consumers who either:
- moved to v1 at 0.17 (`OSDK_GENERATE_CRDS_FLAGS := --crd-version v1`); or
- moved to 0.18 without moving to v1 (`OSDK_GENERATE_CRDS_FLAGS := --crd-version v1beta1`).