### PR TITLE
Increase golangci-lint timeout to 10m

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/golangci.yml
+++ b/boilerplate/openshift/golang-osd-operator/golangci.yml
@@ -3,7 +3,9 @@ run:
   # default concurrency is a available CPU number
   concurrency: 10
   # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 2m
+  # We're using a somewhat resource-constrained container in the CI
+  # environment, so make this longish.
+  timeout: 10m
 
 issues:
   # We want to make sure we get a full report every time. Setting these


### PR DESCRIPTION
golangci-lint has been timing out frequently in CI runs.

We could also/instead bump up the resources of the test container. But let's see how this goes.