### PR TITLE
Add support for grpcurl and opm in ensure.sh

### DIFF
--- a/boilerplate/_lib/common.sh
+++ b/boilerplate/_lib/common.sh
@@ -16,6 +16,16 @@ osdk_version() {
     $osdk version | sed 's/operator-sdk version: "*\([^,"]*\)"*,.*/\1/'
 }
 
+## opm_version BINARY
+#
+# Print the version of the specified opm BINARY
+opm_version() {
+    local opm=$1
+    # `opm version` output looks like:
+    #    Version: version.Version{OpmVersion:"v1.15.2", GitCommit:"fded0bf", BuildDate:"2020-11-18T14:21:24Z", GoOs:"darwin", GoArch:"amd64"}
+    $opm version | sed 's/.*OpmVersion:"//;s/".*//'
+}
+
 repo_name() {
     # Account for remotes which are
     # - upstream or origin

--- a/boilerplate/_lib/common.sh
+++ b/boilerplate/_lib/common.sh
@@ -26,6 +26,15 @@ opm_version() {
     $opm version | sed 's/.*OpmVersion:"//;s/".*//'
 }
 
+## grpcurl_version BINARY
+#
+# Print the version of the specified grpcurl BINARY
+grpcurl_version() {
+    local grpcurl=$1
+    # `grpcurl -version` output looks like:  grpcurl 1.7.0
+    $grpcurl -version 2>&1 | cut -d " " -f 2
+}
+
 repo_name() {
     # Account for remotes which are
     # - upstream or origin

--- a/boilerplate/openshift/golang-osd-operator/ensure.sh
+++ b/boilerplate/openshift/golang-osd-operator/ensure.sh
@@ -6,6 +6,7 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh
 
 GOLANGCI_LINT_VERSION="1.30.0"
+OPM_VERSION="v1.15.2"
 DEPENDENCY=${1:-}
 GOOS=$(go env GOOS)
 
@@ -79,6 +80,26 @@ operator-sdk)
     # Create (or overwrite) the symlink to the binary we discovered or
     # downloaded above.
     ln -sf $osdk operator-sdk
+    ;;
+
+opm)
+    mkdir -p .opm/bin
+    cd .opm/bin
+
+    if [[ -x ./opm  && "$(opm_version ./opm)" == "$OPM_VERSION" ]]; then
+        exit 0
+    fi
+
+    if which opm && [[ "$(opm_version $(which opm))" == "$OPM_VERSION" ]]; then
+        opm=$(realpath $(which opm))
+    else
+        opm="opm-$OPM_VERSION-$GOOS-amd64"
+        opm_download_url="https://github.com/operator-framework/operator-registry/releases/download/$OPM_VERSION/$GOOS-amd64-opm"
+        curl -sfL "${opm_download_url}" -o "$opm"
+        chmod +x "$opm"
+    fi
+
+    ln -fs "$opm" opm
     ;;
 
 venv)

--- a/boilerplate/openshift/golang-osd-operator/ensure.sh
+++ b/boilerplate/openshift/golang-osd-operator/ensure.sh
@@ -7,6 +7,7 @@ source $REPO_ROOT/boilerplate/_lib/common.sh
 
 GOLANGCI_LINT_VERSION="1.30.0"
 OPM_VERSION="v1.15.2"
+GRPCURL_VERSION="1.7.0"
 DEPENDENCY=${1:-}
 GOOS=$(go env GOOS)
 
@@ -100,6 +101,28 @@ opm)
     fi
 
     ln -fs "$opm" opm
+    ;;
+
+grpcurl)
+    mkdir -p .grpcurl/bin
+    cd .grpcurl/bin
+
+    if [[ -x ./grpcurl  && "$(grpcurl_version ./grpcurl)" == "$GRPCURL_VERSION" ]]; then
+        exit 0
+    fi
+
+    if which grpcurl && [[ "$(grpcurl_version $(which grpcurl))" == "$GRPCURL_VERSION" ]]; then
+        grpcurl=$(realpath $(which grpcurl))
+    else
+        # mapping from https://github.com/fullstorydev/grpcurl/blob/master/.goreleaser.yml
+        [[ "$GOOS" == "darwin" ]] && os=osx || os="$GOOS"
+        grpcurl="grpcurl-$GRPCURL_VERSION-$os-x86_64"
+        grpcurl_download_url="https://github.com/fullstorydev/grpcurl/releases/download/v$GRPCURL_VERSION/grpcurl_${GRPCURL_VERSION}_${os}_x86_64.tar.gz"
+        curl -sfL "$grpcurl_download_url" | tar -xzf - -O grpcurl > "$grpcurl"
+        chmod +x "$grpcurl"
+    fi
+
+    ln -fs "$grpcurl" grpcurl
     ;;
 
 venv)


### PR DESCRIPTION
This is in preparation of the catalog creation script using `opm` that will be added to boilerplate.