### PR TITLE
Support containerized local builds

### DIFF
--- a/boilerplate/_lib/common.sh
+++ b/boilerplate/_lib/common.sh
@@ -99,5 +99,10 @@ fi
 # The namespace of the ImageStream by which prow will import the image.
 IMAGE_NAMESPACE=openshift
 IMAGE_NAME=boilerplate
+# LATEST_IMAGE_TAG may be set by `update`, in which case that's the
+# value we want to use.
+if [[ -z "$LATEST_IMAGE_TAG" ]]; then
+    LATEST_IMAGE_TAG=$(cat ${CONVENTION_ROOT}/_data/backing-image-tag)
+fi
 # The public image location
 IMAGE_PULL_PATH=quay.io/app-sre/$IMAGE_NAME:$LATEST_IMAGE_TAG

--- a/boilerplate/_lib/container-make
+++ b/boilerplate/_lib/container-make
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source ${0%/*}/common.sh
+
+CONTAINER_ENGINE=$(command -v podman || command -v docker)
+[[ -n "$CONTAINER_ENGINE" ]] || err "Couldn't find a container engine. Are you already in a container?"
+
+# echo this regardless of BOILERPLATE_SET_X
+set -x
+$CONTAINER_ENGINE run --rm -v "$REPO_ROOT":"$REPO_ROOT" $IMAGE_PULL_PATH /bin/sh -c "cd $REPO_ROOT; make $@"

--- a/boilerplate/update
+++ b/boilerplate/update
@@ -186,10 +186,16 @@ for convention in $(scrubbed_conventions $CONFIG_FILE); do
   echo ""
 done
 
-# If all that went well, lay down the last-boilerplate-commit file,
-# which allows freeze-check to work.
-echo "Registering commit hash..."
+# If all that went well, record some metadata.
 mkdir -p ${CONVENTION_ROOT}/_data
+# - The last-boilerplate-commit file, which allows freeze-check to work.
+echo "Registering commit hash..."
 bp_commit=$(cd ${BP_CLONE} && git rev-parse HEAD)
 echo ${bp_commit} > ${CONVENTION_ROOT}/_data/last-boilerplate-commit
+
+# - The boilerplate backing image tag. This is used to run containerized
+#   local builds/tests.
+echo "Registering image tag..."
+echo $LATEST_IMAGE_TAG > ${CONVENTION_ROOT}/_data/backing-image-tag
+
 echo "Done"

--- a/test/case/convention/openshift/golang-osd-operator/03-image-tags
+++ b/test/case/convention/openshift/golang-osd-operator/03-image-tags
@@ -13,12 +13,9 @@ convention=openshift/golang-osd-operator
 bootstrap_project $repo ${test_project} ${convention}
 cd $repo
 
-# NOTE: Change this when publishing a new image tag.
-expected_image_tag=image-v0.3.0
-
 # The convention's `update` replaces the FROM line in the Dockerfile.
 cat -<<EOF >$LOG_DIR/expected-Dockerfile
-FROM quay.io/app-sre/boilerplate:$expected_image_tag AS builder
+FROM quay.io/app-sre/boilerplate:$LATEST_IMAGE_TAG AS builder
 
 ENV OPERATOR=/usr/local/bin/file-generate \\
     USER_UID=1001 \\
@@ -43,7 +40,7 @@ cat -<<EOF >$LOG_DIR/expected-.ci-operator.yaml
 build_root_image:
   name: boilerplate
   namespace: openshift
-  tag: $expected_image_tag
+  tag: $LATEST_IMAGE_TAG
 EOF
 
 diff $LOG_DIR/expected-.ci-operator.yaml .ci-operator.yaml

--- a/test/case/framework/04-update-from-master-and-revert
+++ b/test/case/framework/04-update-from-master-and-revert
@@ -15,8 +15,8 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 
 source $REPO_ROOT/test/lib.sh
 
-# Hack: test-base-convention's `update` PRE check will fail if master is at an
-# earlier tag. Other tests validate the proper setting of this variable.
+# Hack: some checks will fail if master is at an earlier tag. Other
+# tests validate the proper setting of this variable.
 export SKIP_IMAGE_TAG_CHECK=1
 
 repo=$(empty_repo)


### PR DESCRIPTION
Add a utility, boilerplate/_lib/container-make, which can be used as a drop-in replacement for the real `make` to invoke the target(s) in the boilerplate container appropriate to the current level of boilerplate.

[OSD-5096](https://issues.redhat.com/browse/OSD-5096)