### PR TITLE
Add opm-build-push target

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
+++ b/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
@@ -1,0 +1,380 @@
+#!/bin/bash
+
+set -euo pipefail
+
+## Global vars to modify behaviour of the script
+SET_X=${SET_X:-false}
+[[ "$SET_X" != "false" ]] && set -x
+
+DRY_RUN=${DRY_RUN:-false}
+DELETE_TEMP_DIR=${DELETE_TEMP_DIR:-true}
+NO_LOG=${NO_LOG:-false}
+OLM_BUNDLE_VERSIONS_REPO=${OLM_BUNDLE_VERSIONS_REPO:-gitlab.cee.redhat.com/service/saas-operator-versions.git}
+OLM_BUNDLE_VERSIONS_REPO_BRANCH=${OLM_BUNDLE_VERSIONS_REPO_BRANCH:-master}
+
+# Global vars
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+function log() {
+    local to_log=${1}
+    [[ "$NO_LOG" != "false" ]] && return 0
+    local msg
+    msg="$(date "+%Y-%m-%d %H:%M:%S")"
+    [[ "$DRY_RUN" != "false" ]] && msg="$msg -- DRY-RUN"
+    echo "$msg -- $to_log" 1>&2
+}
+
+function check_required_environment() {
+    local count=0
+    for var in OLM_BUNDLE_IMAGE \
+               OLM_CATALOG_IMAGE \
+               OPERATOR_IMAGE \
+               OPERATOR_IMAGE_TAG \
+               OPERATOR_VERSION \
+               OPERATOR_NAME \
+               CONTAINER_ENGINE \
+               CONTAINER_ENGINE_CONFIG_DIR \
+               CURRENT_COMMIT \
+               OLM_CHANNEL
+    do
+        if [ ! "${!var:-}" ]; then
+          log "$var is not set"
+          count=$((count + 1))
+        fi
+    done
+
+    [[ $count -eq 0 ]] && return 0 || return 1
+}
+
+function setup_temp_dir() {
+    local temp_dir
+    temp_dir=$(mktemp -d --suffix "-$(basename "$0")")
+    [[ "$DELETE_TEMP_DIR" == "true" ]] && trap 'rm -rf $temp_dir' EXIT
+
+    echo "$temp_dir"
+}
+
+function setup_local_executable() {
+    local executable=${1}
+    "$REPO_ROOT"/boilerplate/openshift/golang-osd-operator/ensure.sh "$executable" >&2
+    echo "$REPO_ROOT/.$executable/bin/$executable"
+}
+
+function check_bundle_contents_cmd() {
+    bundle_contents_cmd="$REPO_ROOT/hack/generate-operator-bundle-contents.py"
+    if [[ ! -x "$bundle_contents_cmd" ]]; then
+        log "$bundle_contents_cmd is either missing or non-executable"
+        return 1
+    fi
+}
+
+# Check we are running an opm supported container engine
+function check_opm_supported_container_engine() {
+    local image_builder=${1}
+    if [[ "$image_builder" != "docker" && "$image_builder" != "podman" ]]; then
+        # opm error messages are obscure. Let's make this clear
+        log "image_builder $image_builder is not one of docker or podman"
+        return 1
+    fi
+
+    return 0
+}
+
+# Check we will be able to properly authenticate ourselves against the registry
+function check_authenticated_registry_command() {
+    if [[ ! -f "$CONTAINER_ENGINE_CONFIG_DIR/config.json" ]]; then
+        log "$CONTAINER_ENGINE_CONFIG_DIR/config.json missing"
+        return 1
+    fi
+
+    return 0
+}
+
+function setup_authenticated_registry_command() {
+    echo "$CONTAINER_ENGINE --config=$CONTAINER_ENGINE_CONFIG_DIR"
+}
+
+function clone_olm_bundle_versions_repo() {
+    local saas_root_dir=${1}
+
+    local bundle_versions_repo_url
+    if [[ -n "${APP_SRE_BOT_PUSH_TOKEN:-}" ]]; then
+        log "Using APP_SRE_BOT_PUSH_TOKEN credentials to authenticate"
+        bundle_versions_repo_url="https://app:${APP_SRE_BOT_PUSH_TOKEN}@$OLM_BUNDLE_VERSIONS_REPO"
+    else
+        bundle_versions_repo_url="https://$OLM_BUNDLE_VERSIONS_REPO"
+    fi
+
+    log "Cloning $OLM_BUNDLE_VERSIONS_REPO into $saas_root_dir"
+    git clone --branch "$OLM_BUNDLE_VERSIONS_REPO_BRANCH" "$bundle_versions_repo_url" "$saas_root_dir"
+}
+
+function get_prev_operator_version() {
+    local bundle_versions_file=${1}
+
+    local return_message=""
+
+    # if the line contains SKIP it will not be included
+    local prev_operator_version=""
+    local prev_good_operator_version=""
+    local skip_versions=()
+    if [[ -s "$bundle_versions_file" ]]; then
+        log "$bundle_versions_file exists. We'll use to determine current version"
+
+        prev_operator_version=$(tail -n 1 "$bundle_versions_file" | awk '{print $1}')
+
+        # we traverse the bundle versions file backwards
+        # we cannot use pipes here or we would lose the inner variables changes
+        local version
+        while read -r line; do
+            if [[ "$line" == *SKIP* ]]; then
+                version=$(echo "$line" | awk '{print $1}')
+                skip_versions+=("$version")
+            else
+                prev_good_operator_version="$line"
+                break
+            fi
+        done < <(sort -r -t . -k 3 -g "$bundle_versions_file")
+
+        if [[ -z "$prev_good_operator_version" ]]; then
+            # This means that we have skipped all the available versions. In this case we're going to use the last
+            # SKIP version as the prev_good_operator_version to have something to feed replaces in the CSV
+            log "No unskipped version in $bundle_versions_file. We'll use the last skipped one: ${skip_versions[0]}"
+            prev_good_operator_version="${skip_versions[0]}"
+        fi
+
+        log "Previous operator version is $prev_operator_version"
+        log "Previous good operator version is $prev_good_operator_version"
+        return_message="$prev_operator_version $prev_good_operator_version"
+
+        if [[ ${#skip_versions[@]} -gt 0 ]]; then
+            log "We will be skipping: ${skip_versions[*]}"
+            return_message="$return_message ${skip_versions[*]}"
+        fi
+    else
+        log "No $bundle_versions_file exist or it is empty. This is the first time the operator is built"
+        if [[ ! -d "$(dirname "$bundle_versions_file")" ]]; then
+            log "Operator directory doesn't exist in versions repository. Exiting"
+            exit 1
+        fi
+    fi
+
+    echo "$return_message"
+
+}
+
+function build_opm_bundle() {
+    local bundle_contents_cmd=${1}
+    local opm_local_executable=${2}
+    local image_builder=${3}
+    local prev_good_operator_version=${4}
+    # shellcheck disable=SC2206
+    local skip_versions=(${@:5})
+
+    local bundle_temp_dir
+    bundle_temp_dir=$(mktemp -d -p "$temp_dir" bundle.XXXX)
+    local generate_csv_template_args=""
+    [[ -n "$prev_good_operator_version" ]] && generate_csv_template_args="--replaces $prev_good_operator_version"
+    if [[ ${#skip_versions[@]} -gt 0 ]]; then
+        for version in "${skip_versions[@]}"; do
+            generate_csv_template_args="$generate_csv_template_args --skip $version"
+        done
+    fi
+
+    local manifests_temp_dir
+    manifests_temp_dir=$(mktemp -d -p "$bundle_temp_dir" manifests.XXXX)
+    # shellcheck disable=SC2086
+    $bundle_contents_cmd --name "$OPERATOR_NAME" \
+                         --current-version "$OPERATOR_VERSION" \
+                         --image "$OPERATOR_IMAGE" \
+                         --image-tag "$OPERATOR_IMAGE_TAG" \
+                         --output-dir "$manifests_temp_dir" \
+                         $generate_csv_template_args
+
+    # opm won't get anything locally, so we need to push the bundle even in dry run mode
+    # we will use a different tag to make sure those leftovers are clearly recognized
+    # TODO: remove this tag if we're in dry-run mode in the cleanup trap script
+    [[ "$DRY_RUN" == "false" ]] || bundle_image_current_commit="${bundle_image_current_commit}-dryrun"
+
+    log "Creating bundle image $bundle_image_current_commit"
+    local current_dir="$PWD"
+    cd "$bundle_temp_dir"
+    $opm_local_executable alpha bundle build --directory "$manifests_temp_dir" \
+                                             --channels "$OLM_CHANNEL" \
+                                             --default "$OLM_CHANNEL" \
+                                             --package "$OPERATOR_NAME" \
+                                             --tag "$bundle_image_current_commit" \
+                                             --image-builder "$image_builder" \
+                                             --overwrite \
+                                             1>&2
+    cd "$current_dir"
+
+    echo "$bundle_image_current_commit"
+}
+
+function build_opm_catalog() {
+    local opm_local_executable=${1}
+    local image_builder=${2}
+    local bundle_image_current_commit=${3}
+    local catalog_image_current_commit=${4}
+    local prev_operator_version=${5}
+
+    local from_arg=""
+    if [[ "$prev_operator_version" ]]; then
+        local prev_commit=${prev_operator_version#*-}
+        from_arg="--from-index $OLM_CATALOG_IMAGE:$prev_commit"
+    fi
+
+    log "Creating catalog image $catalog_image_current_commit using opm"
+    # shellcheck disable=SC2086
+    $opm_local_executable index add --bundles "$bundle_image_current_commit" \
+                                    --tag "$catalog_image_current_commit" \
+                                    --build-tool "$image_builder" \
+                                    $from_arg
+}
+
+function check_opm_catalog() {
+    local catalog_image_current_commit=${1}
+    local engine_cmd=${2}
+    local grpcurl_local_executable=${3}
+
+    # Check that catalog works fine
+    log "Checking that catalog we have built returns the correct version $OPERATOR_VERSION"
+
+    local free_port
+    free_port=$(python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
+
+    log "Running $catalog_image_current_commit and exposing $free_port"
+    local catalog_container_id
+    catalog_container_id=$($engine_cmd run -d -p "$free_port:50051" "$catalog_image_current_commit")
+
+    log "Getting current version from running catalog"
+    current_version_from_catalog=$(
+        $grpcurl_local_executable -plaintext -d '{"name": "'"$OPERATOR_NAME"'"}' \
+            "localhost:$free_port" api.Registry/GetPackage | \
+                jq -r '.channels[] | select(.name=="'"$OLM_CHANNEL"'") | .csvName' | \
+                sed "s/$OPERATOR_NAME\.//"
+    )
+
+    log "Removing docker container $catalog_container_id"
+    $engine_cmd rm -f "$catalog_container_id"
+
+    if [[ "$current_version_from_catalog" != "v$OPERATOR_VERSION" ]]; then
+        log "Version from catalog $current_version_from_catalog != v$OPERATOR_VERSION"
+        return 1
+    fi
+
+    return 0
+}
+
+function add_current_version_to_bundle_versions_file() {
+    local bundle_versions_file=${1}
+    local saas_root_dir=${2}
+    local prev_operator_version=${3}
+
+    log "Adding the current version $OPERATOR_VERSION to the bundle versions file in $OLM_BUNDLE_VERSIONS_REPO"
+    echo "$OPERATOR_VERSION" >> "$bundle_versions_file"
+
+    local current_directory="$PWD"
+
+    cd "$saas_root_dir/$OPERATOR_NAME"
+    git add .
+    message="add version $OPERATOR_VERSION"
+    [[ "$prev_operator_version" ]] && message="$message
+
+    replaces $prev_operator_version"
+
+    git commit -m "$message"
+
+    cd "$current_directory"
+}
+
+function main() {
+    log "Building $OPERATOR_NAME version $OPERATOR_VERSION"
+
+    check_required_environment || return 1
+    check_bundle_contents_cmd || return 1
+    check_authenticated_registry_command || return 1
+
+    local temp_dir
+    local opm_local_executable
+    local grpcurl_local_executable
+    local engine_cmd
+    local image_builder
+    temp_dir=$(setup_temp_dir)
+    opm_local_executable=$(setup_local_executable opm)
+    grpcurl_local_executable=$(setup_local_executable grpcurl)
+    engine_cmd=$(setup_authenticated_registry_command)
+    image_builder=$(basename "$CONTAINER_ENGINE")
+
+    check_opm_supported_container_engine "$image_builder" || return 1
+
+    local saas_root_dir="$temp_dir/saas-operator-versions"
+    clone_olm_bundle_versions_repo "$saas_root_dir"
+
+    local bundle_versions_file="$saas_root_dir/$OPERATOR_NAME/${OPERATOR_NAME}-versions.txt"
+    local versions
+    # shellcheck disable=SC2207
+    versions=($(get_prev_operator_version "$bundle_versions_file"))
+    local prev_operator_version="${versions[0]}"
+    local prev_good_operator_version="${versions[1]}"
+    local skip_versions=("${versions[@]:2}")
+
+    if [[ "$OPERATOR_VERSION" == "$prev_operator_version" ]]; then
+        log "stopping script as $OPERATOR_VERSION version was already built, so no need to rebuild it"
+        return 0
+    fi
+
+    local bundle_image_current_commit="$OLM_BUNDLE_IMAGE:$CURRENT_COMMIT"
+    local bundle_image_latest="$OLM_BUNDLE_IMAGE:latest"
+    local catalog_image_current_commit="$OLM_CATALOG_IMAGE:$CURRENT_COMMIT"
+    local catalog_image_latest="$OLM_CATALOG_IMAGE:latest"
+
+    bundle_image_current_commit=$(build_opm_bundle "$bundle_contents_cmd" \
+                                                   "$opm_local_executable" \
+                                                   "$image_builder" \
+                                                   "$prev_good_operator_version" \
+                                                   "${skip_versions[*]}")
+
+    log "Pushing bundle image $bundle_image_current_commit"
+    $engine_cmd push "$bundle_image_current_commit"
+
+    # Make sure this is run after pushing the image
+    log "Validating bundle $bundle_image_current_commit"
+    $opm_local_executable alpha bundle validate --tag "$bundle_image_current_commit" \
+                                                --image-builder "$image_builder"
+
+    log "Tagging bundle image $bundle_image_current_commit as $bundle_image_latest"
+    $engine_cmd tag "$bundle_image_current_commit" "$bundle_image_latest"
+
+    build_opm_catalog "$opm_local_executable" \
+                      "$image_builder" \
+                      "$bundle_image_current_commit" \
+                      "$catalog_image_current_commit" \
+                      "$prev_operator_version"
+
+    check_opm_catalog "$catalog_image_current_commit" "$engine_cmd" "$grpcurl_local_executable" || return 1
+
+    log "Tagging catalog image $catalog_image_current_commit as $catalog_image_latest"
+    $engine_cmd tag "$catalog_image_current_commit" "$catalog_image_latest"
+
+    add_current_version_to_bundle_versions_file "$bundle_versions_file" \
+                                                "$saas_root_dir" \
+                                                "$prev_operator_version"
+
+    log "Pushing catalog image $catalog_image_current_commit"
+    [[ "$DRY_RUN" == "false" ]] && $engine_cmd push "$catalog_image_current_commit"
+
+    log "Pushing bundle image $catalog_image_latest"
+    [[ "$DRY_RUN" == "false" ]] && $engine_cmd push "$catalog_image_latest"
+
+    log "Pushing bundle image $bundle_image_latest"
+    [[ "$DRY_RUN" == "false" ]] && $engine_cmd push "$bundle_image_latest"
+
+    return 0
+}
+
+# Main
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main || exit 1
+fi

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -30,6 +30,14 @@ OPERATOR_IMAGE_URI=${IMG}
 OPERATOR_IMAGE_URI_LATEST=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME):latest
 OPERATOR_DOCKERFILE ?=build/Dockerfile
 
+OLM_BUNDLE_IMAGE = $(OPERATOR_IMAGE)-bundle
+OLM_CATALOG_IMAGE = $(OPERATOR_IMAGE)-catalog
+OLM_CHANNEL ?= alpha
+
+REGISTRY_USER ?=
+REGISTRY_TOKEN ?=
+CONTAINER_ENGINE_CONFIG_DIR = .docker
+
 BINFILE=build/_output/bin/$(OPERATOR_NAME)
 MAINPACKAGE=./cmd/manager
 
@@ -80,12 +88,18 @@ docker-build: isclean
 	${CONTAINER_ENGINE} tag $(OPERATOR_IMAGE_URI) $(OPERATOR_IMAGE_URI_LATEST)
 
 .PHONY: docker-push
-docker-push:
-	${CONTAINER_ENGINE} push $(OPERATOR_IMAGE_URI)
-	${CONTAINER_ENGINE} push $(OPERATOR_IMAGE_URI_LATEST)
+docker-push: docker-login docker-build
+	${CONTAINER_ENGINE} --config=${CONTAINER_ENGINE_CONFIG_DIR} push ${OPERATOR_IMAGE_URI}
+	${CONTAINER_ENGINE} --config=${CONTAINER_ENGINE_CONFIG_DIR} push ${OPERATOR_IMAGE_URI_LATEST}
 
 .PHONY: push
 push: docker-push
+
+.PHONY: docker-login
+docker-login:
+	@test "${REGISTRY_USER}" != "" && test "${REGISTRY_TOKEN}" != "" || (echo "REGISTRY_USER and REGISTRY_TOKEN must be defined" && exit 1)
+	mkdir -p ${CONTAINER_ENGINE_CONFIG_DIR}
+	@${CONTAINER_ENGINE} --config=${CONTAINER_ENGINE_CONFIG_DIR} login -u="${REGISTRY_USER}" -p="${REGISTRY_TOKEN}" quay.io
 
 .PHONY: go-check
 go-check: ## Golang linting and other static analysis
@@ -180,3 +194,17 @@ coverage:
 .PHONY: build-push
 build-push:
 	hack/app_sre_build_deploy.sh
+
+.PHONY: opm-build-push
+opm-build-push: docker-login-and-push
+	OLM_BUNDLE_IMAGE="${OLM_BUNDLE_IMAGE}" \
+	OLM_CATALOG_IMAGE="${OLM_CATALOG_IMAGE}" \
+	CONTAINER_ENGINE="${CONTAINER_ENGINE}" \
+	CONTAINER_ENGINE_CONFIG_DIR="${CONTAINER_ENGINE_CONFIG_DIR}" \
+	CURRENT_COMMIT="${CURRENT_COMMIT}" \
+	OPERATOR_VERSION="${OPERATOR_VERSION}" \
+	OPERATOR_NAME="${OPERATOR_NAME}" \
+	OPERATOR_IMAGE="${OPERATOR_IMAGE}" \
+	OPERATOR_IMAGE_TAG="${OPERATOR_IMAGE_TAG}" \
+	OLM_CHANNEL="${OLM_CHANNEL}" \
+	${CONVENTION_DIR}/build-opm-catalog.sh

--- a/test/case/convention/openshift/golang-osd-operator/05-build-olm-catalog
+++ b/test/case/convention/openshift/golang-osd-operator/05-build-olm-catalog
@@ -1,0 +1,209 @@
+#!/bin/bash
+
+# shellcheck disable=SC2207,SC2155
+
+set -euo pipefail
+
+export OLM_BUNDLE_IMAGE=quay.io/rporresm/deployment-validation-operator-bundle
+export OLM_CATALOG_IMAGE=quay.io/rporresm/deployment-validation-operator-catalog
+export CONTAINER_ENGINE=/usr/local/bin/docker
+export CONTAINER_ENGINE_CONFIG_DIR=.docker
+export CURRENT_COMMIT=860gta5q
+export COMMIT_NUMBER=5
+export OPERATOR_VERSION=0.1.5-860gta5q
+export OPERATOR_NAME=deployment-validation-operator
+export OPERATOR_IMAGE=quay.io/rporresm/deployment-validation-operator
+export OPERATOR_IMAGE_TAG=not-important-at-the-moment
+export OLM_CHANNEL=alpha
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+# shellcheck disable=SC1090
+source "$REPO_ROOT/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh"
+
+function gen_commit() {
+    # shellcheck disable=SC2002
+    cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 8 | head -n 1
+}
+
+function gen_operator_version() {
+    local commit=${1}
+    local commit_number=${2}
+    echo "0.1.$commit_number-$commit"
+}
+
+# build_version_file commit commit_number1 commit_number2 commit_number3 ...
+# commit_number can be a single digit or a digit followed by the S letter
+# in the latter case, the resulting line will have the SKIP word appended
+function build_versions_file() {
+    local commit=${1}
+    shift
+    local commit_numbers=("$@")
+
+    local versions_file=$(mktemp -p "$TEMP_DIR" versions-file.XXXXXXXX)
+
+    for commit_number in "${commit_numbers[@]}"; do
+        if [[ "$commit_number" == *S ]]; then
+            echo "$(gen_operator_version "$commit" "${commit_number%S}") SKIP" >> "$versions_file"
+        else
+            gen_operator_version "$commit" "$commit_number" >> "$versions_file"
+        fi
+    done
+
+    echo "$versions_file"
+}
+
+function initialize_local_saas_repo() {
+    local saas_root_repo=$(mktemp -p "$TEMP_DIR" -d -t saas-operator-versions-XXXXXXXX)
+    local current_dir=$PWD
+    cd "$saas_root_repo"
+    git init > /dev/null 2>&1
+    git config user.name "Test Boilerplate" > /dev/null 2>&1
+    git config user.email "test@example.com" > /dev/null 2>&1
+    mkdir "$OPERATOR_NAME"
+    touch "$OPERATOR_NAME/$OPERATOR_NAME-versions.txt"
+    git add  "$OPERATOR_NAME/$OPERATOR_NAME-versions.txt" > /dev/null 2>&1
+    git commit -m "Adding empty versions file for $OPERATOR_NAME" > /dev/null 2>&1
+    cd "$current_dir"
+
+    echo "$saas_root_repo"
+}
+
+function test_get_prev_operator_version_no_versions_file() {
+    local versions_file=$(mktemp -p "$TEMP_DIR" versions-file.XXXXXXXX)
+    rm "$versions_file"
+    [[ "$(get_prev_operator_version "$versions_file")" == "" ]] && return 0 || return 1
+}
+
+# This is the same as if the file does not exist
+function test_get_prev_operator_version_empty_versions_file() {
+    local versions_file=$(mktemp -p "$TEMP_DIR" versions-file.XXXXXXXX)
+    [[ "$(get_prev_operator_version "$versions_file")" == "" ]] && return 0 || return 1
+}
+
+function test_get_prev_operator_version_one_version() {
+    local commit=$(gen_commit)
+    local versions_file=$(build_versions_file "$commit" 1)
+    local expected_prev_operator_version=$(gen_operator_version "$commit" 1)
+    local expected_prev_good_operator_version="$expected_prev_operator_version"
+    local expected_skip_versions=""
+    local versions=($(get_prev_operator_version "$versions_file"))
+
+    [[ "${versions[0]}" == "$expected_prev_operator_version" ]] || return 1
+    [[ "${versions[1]}" == "$expected_prev_good_operator_version" ]] || return 1
+    [[ "${versions[2]:-}" == "" ]] || return 1
+
+    return 0
+}
+
+function test_get_prev_operator_version_multiple_versions() {
+    local commit=$(gen_commit)
+    local versions_file=$(build_versions_file "$commit" 1 2 3 4)
+    local expected_prev_operator_version=$(gen_operator_version "$commit" 4)
+    local expected_prev_good_operator_version="$expected_prev_operator_version"
+    local expected_skip_versions=""
+    local versions=($(get_prev_operator_version "$versions_file"))
+
+    [[ "${versions[0]}" == "$expected_prev_operator_version" ]] || return 1
+    [[ "${versions[1]}" == "$expected_prev_good_operator_version" ]] || return 1
+    [[ "${versions[2]:-}" == "$expected_skip_versions" ]] || return 1
+
+    return 0
+}
+
+function test_get_prev_operator_version_multiple_versions_old_skips() {
+    local commit=$(gen_commit)
+    local versions_file=$(build_versions_file "$commit" 1 2S 3S 4 5S 6)
+    local expected_prev_operator_version=$(gen_operator_version "$commit" 6)
+    local expected_prev_good_operator_version="$expected_prev_operator_version"
+    local expected_skip_versions=""
+    local versions=($(get_prev_operator_version "$versions_file"))
+
+    [[ "${versions[0]}" == "$expected_prev_operator_version" ]] || return 1
+    [[ "${versions[1]}" == "$expected_prev_good_operator_version" ]] || return 1
+    [[ "${versions[2]:-}" == "$expected_skip_versions" ]] || return 1
+
+    return 0
+}
+
+function test_get_prev_operator_version_one_skip() {
+    local commit=$(gen_commit)
+    local versions_file=$(build_versions_file "$commit" 1 2 3 4S)
+    local expected_prev_operator_version=$(gen_operator_version "$commit" 4)
+    local expected_prev_good_operator_version=$(gen_operator_version "$commit" 3)
+    local expected_skip_versions="$expected_prev_operator_version"
+    local versions=($(get_prev_operator_version "$versions_file"))
+
+    [[ "${versions[0]}" == "$expected_prev_operator_version" ]] || return 1
+    [[ "${versions[1]}" == "$expected_prev_good_operator_version" ]] || return 1
+    [[ "${versions[2]:-}" == "$expected_skip_versions" ]] || return 1
+
+    return 0
+}
+
+function test_get_prev_operator_version_multiple_skips() {
+    local commit=$(gen_commit)
+    local versions_file=$(build_versions_file "$commit" 1 2 3S 4S)
+    local expected_prev_operator_version=$(gen_operator_version "$commit" 4)
+    local expected_prev_good_operator_version=$(gen_operator_version "$commit" 2)
+    local expected_skip_versions="$expected_prev_operator_version $(gen_operator_version "$commit" 3)"
+    local versions=($(get_prev_operator_version "$versions_file"))
+
+    [[ "${versions[0]}" == "$expected_prev_operator_version" ]] || return 1
+    [[ "${versions[1]}" == "$expected_prev_good_operator_version" ]] || return 1
+    [[ "${versions[2]:-} ${versions[3]:-}" == "$expected_skip_versions" ]] || return 1
+
+    return 0
+}
+
+function test_get_prev_operator_version_all_skips() {
+    local commit=$(gen_commit)
+    local versions_file=$(build_versions_file "$commit" 1S 2S 3S)
+    local expected_prev_operator_version=$(gen_operator_version "$commit" 3)
+    local expected_prev_good_operator_version=$(gen_operator_version "$commit" 3)
+    local expected_skip_versions="$expected_prev_operator_version $(gen_operator_version "$commit" 2) $(gen_operator_version "$commit" 1)"
+    local versions=($(get_prev_operator_version "$versions_file"))
+
+    [[ "${versions[0]}" == "$expected_prev_operator_version" ]] || return 1
+    [[ "${versions[1]}" == "$expected_prev_good_operator_version" ]] || return 1
+    [[ "${versions[2]:-} ${versions[3]:-} ${versions[4]}" == "$expected_skip_versions" ]] || return 1
+
+    return 0
+}
+
+function test_add_current_version_to_bundle_versions_file() {
+    local saas_root_repo=$(initialize_local_saas_repo)
+    local bundle_versions_file="$saas_root_repo/$OPERATOR_NAME/$OPERATOR_NAME-versions.txt"
+    local prev_operator_version=""
+    add_current_version_to_bundle_versions_file "$bundle_versions_file" "$saas_root_repo" "$prev_operator_version"
+    local versions=($(get_prev_operator_version "$bundle_versions_file"))
+
+    [[ "${versions[0]}" == "$OPERATOR_VERSION" ]] || return 1
+    [[ "${versions[1]}" == "$OPERATOR_VERSION" ]] || return 1
+    [[ "${versions[2]:-}" == "" ]] || return 1
+
+    return 0
+}
+
+function main() {
+    TEMP_DIR=$(mktemp -d --suffix "-$(basename "$0")")
+    [[ -z "${PRESERVE_TEMP_DIRS:-}" ]] && trap 'rm -rf $TEMP_DIR' EXIT
+
+    local failed=0
+    for test_name in test_get_prev_operator_version_no_versions_file \
+                     test_get_prev_operator_version_empty_versions_file \
+                     test_get_prev_operator_version_one_version \
+                     test_get_prev_operator_version_multiple_versions \
+                     test_get_prev_operator_version_multiple_versions_old_skips \
+                     test_get_prev_operator_version_one_skip \
+                     test_get_prev_operator_version_multiple_skips \
+                     test_get_prev_operator_version_all_skips \
+                     test_add_current_version_to_bundle_versions_file
+    do
+        $test_name || { echo "$test_name failed"; failed=$((failed+1)); }
+    done
+
+    return $failed
+}
+
+main


### PR DESCRIPTION
* Opt-in target, we are not ready to force anyone to use this
* Adds a script to build catalog using opm
* Adds authentication to docker-push (breaking change)
* Depends on a local `hack/generate-bundle-contents.py` script

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>