### PR TITLE
image-v0.4.0

### DIFF
--- a/boilerplate/test/test-base-convention/update
+++ b/boilerplate/test/test-base-convention/update
@@ -27,5 +27,5 @@ echo "Validating variables exported from the main update driver"
 # Granny switch to disable this check for weird tests like reverting to master
 if [[ -z "$SKIP_IMAGE_TAG_CHECK" ]]; then
     # Update this when publishing a new image tag
-    [[ "$LATEST_IMAGE_TAG" == "image-v0.3.0" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
+    [[ "$LATEST_IMAGE_TAG" == "image-v0.4.0" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
 fi

--- a/config/build.sh
+++ b/config/build.sh
@@ -59,35 +59,6 @@ mv yq /usr/local/bin
 ##################
 python3 -m pip install PyYAML==5.3.1
 
-##################
-# golang (via gvm)
-##################
-GO_VERSIONS="go1.13.15 go1.14.10"
-
-GVM_VERSION=1.0.22
-GVM_SHA256SUM="72123889c8ef55f7b745038dc8cf556c1aece982408966fa5ff612ce6a97bae7"
-GVM_LOCATION=https://raw.githubusercontent.com/moovweb/gvm/${GVM_VERSION}/binscripts/gvm-installer
-
-curl -L -o gvm-installer $GVM_LOCATION
-echo ${GVM_SHA256SUM} gvm-installer | sha256sum -c
-chmod ugo+x gvm-installer
-./gvm-installer
-rm -f gvm-installer
-source /root/.gvm/scripts/gvm
-
-GVM_DEPS="bison"
-yum -y install ${GVM_DEPS}
-
-for GO_VERSION in $GO_VERSIONS; do
-    gvm install $GO_VERSION --prefer-binary
-done
-
-# Is there a better way to make this usable by the non-root user in the
-# consumer pod?
-chmod -R ugo+w /root/.gvm
-
-yum -y remove ${GVM_DEPS}
-
 #####
 # git
 #####

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -3,7 +3,7 @@ if [ "$BOILERPLATE_SET_X" ]; then
 fi
 
 # NOTE: Change this when publishing a new image tag.
-LATEST_IMAGE_TAG=image-v0.3.0
+LATEST_IMAGE_TAG=image-v0.4.0
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 # Make all tests use this local clone by default.


### PR DESCRIPTION
This PR puts together `image-v0.4.0` with the following changes:
- Don't set up gvm anymore. We don't need it.
- Include mockgen and openapi-gen.

See individual commit messages for details.