### PR TITLE
WIP: Default Dockerfile in openshift/golang-osd-operator

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/Dockerfile
+++ b/boilerplate/openshift/golang-osd-operator/Dockerfile
@@ -1,0 +1,34 @@
+FROM quay.io/app-sre/boilerplate:image-v0.3.0 AS builder
+
+ARG OPERATOR_NAME
+ENV OPERATOR_NAME=$OPERATOR_NAME
+ARG OPERATOR_DESCRIPTION
+ENV OPERATOR_DESCRIPTION=$OPERATOR_DESCRIPTION
+
+RUN mkdir -p /workdir
+WORKDIR /workdir
+
+# TODO: Can we get rid of this? Shouldn't it be part of `make go-build`?
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN make go-build
+
+####
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+ENV USER_UID=1001 \
+    USER_NAME=${OPERATOR_NAME}
+
+COPY --from=builder /workdir/build/_output/bin/* /usr/local/bin/
+
+COPY build/bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}
+
+LABEL io.openshift.managed.name="${OPERATOR_NAME}" \
+      io.openshift.managed.description="${OPERATOR_DESCRIPTION}"


### PR DESCRIPTION
Add a standard Dockerfile to the openshift/golang-osd-operator
convention. Consumers updating to this level should either
- Delete `build/Dockerfile` and define `OPERATOR_DESCRIPTION` in the
local `Makefile` (preferred); or
- Override `OPERATOR_DOCKERFILE` in the local `Makefile`. But only if
you _really_ can't use the standard one.

WIP:
- How are we going to keep the initial `FROM` up to date? We can keep
overriding it from the convention's `update`; or we can hardcode it and
add a check to `03-image-tags` to make sure we don't forget to update it
when publishing a new image.
- Are we going to bother continuing with the `FROM` hack in the
convention's `update` if they're using a bespoke Dockerfile? Probably
not (at the least, we would need to do some refactoring to be able to
discover what path they've overridden with). But maybe a warning if we
discover they're not using the (latest) boilerplate backing image.
- Update convention's `README.md` and `update` output.
- Tests?