### PR TITLE
openshift/golang-osd-operator: openapi-gen

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/README.md
+++ b/boilerplate/openshift/golang-osd-operator/README.md
@@ -86,7 +86,14 @@ To trigger the check, you can use `make generate-check` provided your Makefile p
 
 Checks consist of:
 * Checking all files are committed to ensure a safe point to revert to in case of error
-* Running the `make generate` command to regenerate the needed code
+* Running the `make generate` command (see below) to regenerate the needed code
 * Checking if this results in any new uncommitted files in the git project or if all is clean.
+
+`make generate` does the following:
+* `operator-sdk generate crds` and `k8s`. This is a no-op if your
+  operator has no APIs.
+* `openapi-gen`. This is a no-op if your operator has no APIs.
+* `go generate`. This is a no-op if you have no `//go:generate`
+  directives in your code.
 
 ## More coming soon

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -121,8 +121,19 @@ op-generate:
 	find deploy/ -name '*_crd.yaml' | xargs -n1 -I{} yq d -i {} spec.validation.openAPIV3Schema.type
 	# Don't forget to commit generated files
 
+.PHONY: openapi-generate
+openapi-generate:
+	find ./pkg/apis/ -maxdepth 2 -mindepth 2 -type d | xargs -t -n1 -I% \
+		openapi-gen --logtostderr=true \
+			-i % \
+			-o "" \
+			-O zz_generated.openapi \
+			-p % \
+			-h /dev/null \
+			-r "-"
+
 .PHONY: generate
-generate: op-generate go-generate
+generate: op-generate go-generate openapi-generate
 
 .PHONY: go-build
 go-build: ## Build binary

--- a/test/case/convention/openshift/golang-osd-operator/01-generated-files-checker
+++ b/test/case/convention/openshift/golang-osd-operator/01-generated-files-checker
@@ -37,6 +37,9 @@ for version in v0.15.1 v0.16.0 v0.17.0 v0.17.1 ; do
 	if [ ! -f pkg/apis/mygroup/v1alpha1/zz_generated.deepcopy.go ] ; then
 		err "crd generate didn't work properly"
 	fi
+	if [ ! -f pkg/apis/mygroup/v1alpha1/zz_generated.openapi.go ] ; then
+		err "openapi generate didn't work properly"
+	fi
 
     git add -A
     git commit -m "commit generated files"


### PR DESCRIPTION
Make consumers produce openapi by adding a target called `openapi-generate` which runs `openapi-gen` if necessary. Put it in the chain for `generate`.