### PR TITLE
Improvements to container-make

### DIFF
--- a/boilerplate/_lib/container-make
+++ b/boilerplate/_lib/container-make
@@ -1,10 +1,36 @@
 #!/bin/bash
 
+if [[ "$1" == "-h"* ]] || [[ "$1" == "--h"* ]]; then
+  echo "Usage: $0 {arguments to the real 'make'}"
+  echo "Runs 'make' in the boilerplate backing container."
+  echo "If the command fails, starts a shell in the container so you can debug."
+  exit -1
+fi
+
 source ${0%/*}/common.sh
 
 CONTAINER_ENGINE=$(command -v podman || command -v docker)
 [[ -n "$CONTAINER_ENGINE" ]] || err "Couldn't find a container engine. Are you already in a container?"
 
-# echo this regardless of BOILERPLATE_SET_X
-set -x
-$CONTAINER_ENGINE run --rm -v "$REPO_ROOT":"$REPO_ROOT" $IMAGE_PULL_PATH /bin/sh -c "cd $REPO_ROOT; make $@"
+# First set up a detached container with the repo mounted.
+banner "Starting the container"
+container_id=$($CONTAINER_ENGINE run -d -v "$REPO_ROOT":"$REPO_ROOT" $IMAGE_PULL_PATH tail -f /dev/null)
+if [[ $? -ne 0 ]] || [[ -z "$container_id" ]]; then
+  err "Couldn't start detached container"
+fi
+
+# Now run our `make` command in it with the right UID and working directory
+args="exec -it -u $(id -u):0 -w $REPO_ROOT $container_id"
+banner "Running: make $@"
+$CONTAINER_ENGINE $args make "$@"
+rc=$?
+
+# If it failed, drop into the container in a shell
+if [[ $rc -ne 0 ]]; then
+  banner "The 'make' command failed! Starting a shell in the container for debugging. Just 'exit' when done."
+  $CONTAINER_ENGINE $args /bin/bash
+fi
+
+# Finally, remove the container
+banner "Cleaning up the container"
+$CONTAINER_ENGINE rm -f $container_id >/dev/null

--- a/boilerplate/openshift/golang-osd-operator/README.md
+++ b/boilerplate/openshift/golang-osd-operator/README.md
@@ -44,6 +44,17 @@ This will generate a delta configuring prow to:
 - Run the `coverage` target in a postsubmit. This is the step that
   updates your coverage report in codecov.io.
 
+#### Local Testing
+You can run these `make` targets locally during development to test your
+code changes. However, differences in platforms and environments may
+lead to unpredictable results. Therefore boilerplate provides a utility
+to run targets in a container environment that is designed to be as
+similar as possible to CI:
+
+```shell
+$ ./boilerplate/_lib/container-make {target}
+```
+
 ### app-sre
 
 The `build-push` target builds and pushes the operator and OLM registry images,


### PR DESCRIPTION
- Run the container as self. Previously it was running as root, which had some unintended consequences, including leaving root-owned files in your repo.
- If the target fails, stay in the container so you can debug.
- Prints a usage statement if invoked with -h/--help.