### PR TITLE
Unbound error fix for the new operators

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
+++ b/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
@@ -319,6 +319,14 @@ function main() {
     local versions
     # shellcheck disable=SC2207
     versions=($(get_prev_operator_version "$bundle_versions_file"))
+    # This condition is triggered when an operator is built for the first time. In such case the
+    # get_prev_operator_version returns an empty string and causes undefined variables failures
+    # in a few lines below.
+    if [ -z ${versions+x} ]
+    then
+        versions[0]=""
+        versions[1]=""
+    fi
     local prev_operator_version="${versions[0]}"
     local prev_good_operator_version="${versions[1]}"
     local skip_versions=("${versions[@]:2}")


### PR DESCRIPTION
This Pull Request fixes an error that appears when introducing a new Operator. 

In this case, there are no previous versions and the `get_prev_operator_version` function emits an empty string.  This string fails later on when trying to extract the first or the second item for the `versions` array.