### PR TITLE
Parses REPO_ROOT to put repo in gopath

### DIFF
--- a/boilerplate/_lib/container-make
+++ b/boilerplate/_lib/container-make
@@ -12,8 +12,15 @@ source ${0%/*}/common.sh
 CONTAINER_ENGINE=$(command -v podman || command -v docker)
 [[ -n "$CONTAINER_ENGINE" ]] || err "Couldn't find a container engine. Are you already in a container?"
 
-CONTAINER_ROOT="/go/src/${REPO_ROOT##*src}"
-[[ -n "$CONTAINER_ROOT" ]] || err "$_lib couldn't parse container root"
+CONTAINER_ROOT="/go/src/${REPO_ROOT##*/src/}"
+ if [[ $CONTAINER_ROOT == "/go/src/${REPO_ROOT}" ]]
+then
+ # If the container root is the same as the repo root without the substring
+ # removal it didn't take because the path might be set up differently
+ # so let's just reset the container root to the repo root
+  echo "$_lib couldn't parse container root"
+  CONTAINER_ROOT=$REPO_ROOT
+fi
 
 # First set up a detached container with the repo mounted.
 banner "Starting the container"

--- a/boilerplate/_lib/container-make
+++ b/boilerplate/_lib/container-make
@@ -12,15 +12,18 @@ source ${0%/*}/common.sh
 CONTAINER_ENGINE=$(command -v podman || command -v docker)
 [[ -n "$CONTAINER_ENGINE" ]] || err "Couldn't find a container engine. Are you already in a container?"
 
+CONTAINER_ROOT="/go/src/${REPO_ROOT##*src}"
+[[ -n "$CONTAINER_ROOT" ]] || err "$_lib couldn't parse container root"
+
 # First set up a detached container with the repo mounted.
 banner "Starting the container"
-container_id=$($CONTAINER_ENGINE run -d -v "$REPO_ROOT":"$REPO_ROOT" $IMAGE_PULL_PATH tail -f /dev/null)
+container_id=$($CONTAINER_ENGINE run -d -v "$REPO_ROOT":"$CONTAINER_ROOT" $IMAGE_PULL_PATH tail -f /dev/null)
 if [[ $? -ne 0 ]] || [[ -z "$container_id" ]]; then
   err "Couldn't start detached container"
 fi
 
 # Now run our `make` command in it with the right UID and working directory
-args="exec -it -u $(id -u):0 -w $REPO_ROOT $container_id"
+args="exec -it -u $(id -u):0 -w $CONTAINER_ROOT $container_id"
 banner "Running: make $@"
 $CONTAINER_ENGINE $args make "$@"
 rc=$?


### PR DESCRIPTION
Using bash substring substitution we parse the current path of the
REPO_ROOT and use that to build a CONTAINER_ROOT which then drops your
operator code into the gopath, allowing things like `make generate` to
work out of the box.