### PR TITLE
Fix container-make for openapi-gen

### DIFF
--- a/boilerplate/_lib/common.sh
+++ b/boilerplate/_lib/common.sh
@@ -42,11 +42,26 @@ grpcurl_version() {
     $grpcurl -version 2>&1 | cut -d " " -f 2
 }
 
+## repo_import REPODIR
+#
+# Print the qualified org/name of the current repository, e.g.
+# "openshift/wizbang-foo-operator". This relies on git remotes being set
+# reasonably.
 repo_name() {
+    # Just strip off the first component of the import-ish path
+    repo_import $1 | sed 's,^[^/]*/,,'
+}
+
+## repo_import REPODIR
+#
+# Print the go import-ish path to the current repository, e.g.
+# "github.com/openshift/wizbang-foo-operator". This relies on git
+# remotes being set reasonably.
+repo_import() {
     # Account for remotes which are
     # - upstream or origin
     # - ssh ("git@host.com:org/name.git") or https ("https://host.com/org/name.git")
-    (git -C $1 config --get remote.upstream.url || git -C $1 config --get remote.origin.url) | sed 's,git@[^:]*:,,; s,https://[^/]*/,,; s/\.git$//'
+    (git -C $1 config --get remote.upstream.url || git -C $1 config --get remote.origin.url) | sed 's,git@\([^:]*\):,\1/,; s,https://,,; s/\.git$//'
 }
 
 ## current_branch REPO

--- a/boilerplate/_lib/container-make
+++ b/boilerplate/_lib/container-make
@@ -12,15 +12,20 @@ source ${0%/*}/common.sh
 CONTAINER_ENGINE=$(command -v podman || command -v docker)
 [[ -n "$CONTAINER_ENGINE" ]] || err "Couldn't find a container engine. Are you already in a container?"
 
+# Make sure the mount inside the container is named in such a way that
+# - openapi-gen (which relies on GOPATH) produces absolute paths; and
+# - other go-ish paths are writeable, e.g. for `go mod download`.
+CONTAINER_MOUNT=/go/src/$(repo_import $REPO_ROOT)
+
 # First set up a detached container with the repo mounted.
 banner "Starting the container"
-container_id=$($CONTAINER_ENGINE run -d -v "$REPO_ROOT":"$REPO_ROOT" $IMAGE_PULL_PATH tail -f /dev/null)
+container_id=$($CONTAINER_ENGINE run -d -v "$REPO_ROOT":"$CONTAINER_MOUNT" $IMAGE_PULL_PATH tail -f /dev/null)
 if [[ $? -ne 0 ]] || [[ -z "$container_id" ]]; then
   err "Couldn't start detached container"
 fi
 
 # Now run our `make` command in it with the right UID and working directory
-args="exec -it -u $(id -u):0 -w $REPO_ROOT $container_id"
+args="exec -it -u $(id -u):0 -w $CONTAINER_MOUNT $container_id"
 banner "Running: make $@"
 $CONTAINER_ENGINE $args make "$@"
 rc=$?


### PR DESCRIPTION
`openapi-gen` is really picky about how `GOPATH` is set with respect to the path to the repo clone it's working on. And CI is really picky about where things like `go mod download` are allowed to write. With this change, we make sure the path inside `container-make`'s container gels with `GOPATH` so `openapi-gen` works as expected.

Parts of this were stolen from #121 -- thanks @iamkirkbater.

Co-Authored-By: Kirk Bater <kbater@redhat.com>