### PR TITLE
Do not evaluate main with a conditional or

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
+++ b/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
@@ -379,5 +379,5 @@ function main() {
 
 # Main
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  main || exit 1
+  main
 fi


### PR DESCRIPTION
Not only it is not needed, it can deactivate the effect of `set -e`

Tested in DVO repo: https://github.com/app-sre/deployment-validation-operator/pull/86 (see the build [logs](https://ci.int.devshift.net/view/deployment-validation-operator/job/app-sre-deployment-validation-operator-gh-build-master/52/console))

Bug found while debugging why [this build](https://ci.int.devshift.net/view/mas-sso/job/service-saas-mas-sso-gl-build-master/26/console) hadn't failed (look for the `fatal: could not read Username`) message

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>