### PR TITLE
image-v0.5.1: registry.svc.ci.openshift.org is dead

### DIFF
--- a/boilerplate/test/test-base-convention/update
+++ b/boilerplate/test/test-base-convention/update
@@ -27,5 +27,5 @@ echo "Validating variables exported from the main update driver"
 # Granny switch to disable this check for weird tests like reverting to master
 if [[ -z "$SKIP_IMAGE_TAG_CHECK" ]]; then
     # Update this when publishing a new image tag
-    [[ "$LATEST_IMAGE_TAG" == "image-v0.5.0" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
+    [[ "$LATEST_IMAGE_TAG" == "image-v0.5.1" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
 fi

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,5 +1,5 @@
 # NOTE: Keep this in sync with .ci-operator.yaml
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13
+FROM registry.ci.openshift.org/openshift/release:golang-1.13
 
 COPY build.sh /build.sh
 RUN /build.sh && rm -f /build.sh

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -3,7 +3,7 @@ if [ "$BOILERPLATE_SET_X" ]; then
 fi
 
 # NOTE: Change this when publishing a new image tag.
-LATEST_IMAGE_TAG=image-v0.5.0
+LATEST_IMAGE_TAG=image-v0.5.1
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 # Make all tests use this local clone by default.


### PR DESCRIPTION
We need to build our image `FROM registry.ci.openshift.org` now, since `registry.svc.ci.openshift.org` has been decommissioned.

image-v0.5.0 will never build and is therefore unusable.