### PR TITLE
container-make: Fix access denied to mounted filesystem on start

### DIFF
--- a/boilerplate/_lib/container-make
+++ b/boilerplate/_lib/container-make
@@ -19,7 +19,7 @@ CONTAINER_MOUNT=/go/src/$(repo_import $REPO_ROOT)
 
 # First set up a detached container with the repo mounted.
 banner "Starting the container"
-container_id=$($CONTAINER_ENGINE run -d -v "$REPO_ROOT":"$CONTAINER_MOUNT" $IMAGE_PULL_PATH tail -f /dev/null)
+container_id=$($CONTAINER_ENGINE run --userns keep-id -d -v "$REPO_ROOT":"$CONTAINER_MOUNT":Z $IMAGE_PULL_PATH tail -f /dev/null)
 if [[ $? -ne 0 ]] || [[ -z "$container_id" ]]; then
   err "Couldn't start detached container"
 fi


### PR DESCRIPTION
Fixes required to grain filesystem permissions on mount.