### PR TITLE
Enable container-make in boilerplate itself

### DIFF
--- a/boilerplate/_lib/common.sh
+++ b/boilerplate/_lib/common.sh
@@ -114,11 +114,17 @@ fi
 # The namespace of the ImageStream by which prow will import the image.
 IMAGE_NAMESPACE=openshift
 IMAGE_NAME=boilerplate
-# LATEST_IMAGE_TAG may be set by `update`, in which case that's the
-# value we want to use.
-# Accommodate older consumers who don't have backing-image-tag yet.
-if [[ -z "$LATEST_IMAGE_TAG" ]] && [[ -f ${CONVENTION_ROOT}/_data/backing-image-tag ]]; then
-    LATEST_IMAGE_TAG=$(cat ${CONVENTION_ROOT}/_data/backing-image-tag)
+# LATEST_IMAGE_TAG may be set manually or by `update`, in which case
+# that's the value we want to use.
+if [[ -z "$LATEST_IMAGE_TAG" ]]; then
+    # (Non-ancient) consumers will have the tag in this file.
+    if [[ -f ${CONVENTION_ROOT}/_data/backing-image-tag ]]; then
+        LATEST_IMAGE_TAG=$(cat ${CONVENTION_ROOT}/_data/backing-image-tag)
+
+    # In boilerplate itself, we can discover the latest from git.
+    elif [[ $(repo_name .) == openshift/boilerplate ]]; then
+        LATEST_IMAGE_TAG=$(git describe --tags --abbrev=0 --match image-v*)
+    fi
 fi
 # The public image location
 IMAGE_PULL_PATH=quay.io/app-sre/$IMAGE_NAME:$LATEST_IMAGE_TAG


### PR DESCRIPTION
Previously in order for `container-make` to function in the boilerplate repository itself, you had to set the `LATEST_IMAGE_TAG` environment variable manually. With this commit, if it's unset and we're in boilerplate, we discover it from git.