### PR TITLE
golang-osd-operator: Enable app-sre build and deploy

### DIFF
--- a/boilerplate/_lib/common.sh
+++ b/boilerplate/_lib/common.sh
@@ -74,6 +74,56 @@ current_branch() {
     )
 }
 
+## image_exits_in_repo IMAGE_URI
+#
+# Checks whether IMAGE_URI -- e.g. quay.io/app-sre/osd-metrics-exporter:abcd123
+# -- exists in the remote repository.
+# If so, returns success.
+# If the image does not exist, but the query was otherwise successful, returns
+# failure.
+# If the query fails for any reason, prints an error and *exits* nonzero.
+image_exists_in_repo() {
+    local image_uri=$1
+    local output
+
+    output=$(skopeo inspect docker://${image_uri} 2>&1)
+    if [[ $? -eq 0 ]]; then
+        # The image exists. Sanity check the output.
+        local digest=$(echo $output | jq -r .Digest)
+        if [[ -z "$digest" ]]; then
+            echo "Unexpected error: skopeo inspect succeeded, but output contained no .Digest"
+            echo "Here's the output:"
+            echo "$output"
+            exit 1
+        fi
+        echo "Image ${image_uri} exists with digest $digest."
+        return 0
+    elif [[ "$output" == *"manifest unknown"* ]]; then
+        # We were able to talk to the repository, but the tag doesn't exist.
+        # This is the normal "green field" case.
+        echo "Image ${image_uri} does not exist in the repository."
+        return 1
+    elif [[ "$output" == *"was deleted or has expired"* ]]; then
+        # This should be rare, but accounts for cases where we had to
+        # manually delete an image.
+        echo "Image ${image_uri} was deleted from the repository."
+        echo "Proceeding as if it never existed."
+        return 1
+    else
+        # Any other error. For example:
+        #   - "unauthorized: access to the requested resource is not
+        #     authorized". This happens not just on auth errors, but if we
+        #     reference a repository that doesn't exist.
+        #   - "no such host".
+        #   - Network or other infrastructure failures.
+        # In all these cases, we want to bail, because we don't know whether
+        # the image exists (and we'd likely fail to push it anyway).
+        echo "Error querying the repository for ${image_uri}:"
+        echo "$output"
+        exit 1
+    fi
+}
+
 if [ "$BOILERPLATE_SET_X" ]; then
   set -x
 fi

--- a/boilerplate/openshift/golang-osd-operator/README.md
+++ b/boilerplate/openshift/golang-osd-operator/README.md
@@ -1,5 +1,14 @@
 # Conventions for OSD operators written in Go
 
+- [Conventions for OSD operators written in Go](#conventions-for-osd-operators-written-in-go)
+  - [`make` targets and functions.](#make-targets-and-functions)
+    - [Prow](#prow)
+      - [Local Testing](#local-testing)
+    - [app-sre](#app-sre)
+  - [Code coverage](#code-coverage)
+  - [Linting and other static analysis with `golangci-lint`](#linting-and-other-static-analysis-with-golangci-lint)
+  - [Checks on generated code](#checks-on-generated-code)
+
 This convention is suitable for both cluster- and hive-deployed operators.
 
 The following components are included:
@@ -59,6 +68,8 @@ $ ./boilerplate/_lib/container-make {target}
 
 The `build-push` target builds and pushes the operator and OLM registry images,
 ready to be SaaS-deployed.
+By default it is configured to be run from the app-sre jenkins pipelines.
+Consult [this doc](app-sre.md) for information on local execution/testing.
 
 ## Code coverage
 - A `codecov.sh` script, referenced by the `coverage` `make` target, to
@@ -106,5 +117,3 @@ Checks consist of:
 * `openapi-gen`. This is a no-op if your operator has no APIs.
 * `go generate`. This is a no-op if you have no `//go:generate`
   directives in your code.
-
-## More coming soon

--- a/boilerplate/openshift/golang-osd-operator/app-sre-build-deploy.sh
+++ b/boilerplate/openshift/golang-osd-operator/app-sre-build-deploy.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -ev
+
+usage() {
+    echo "$0 OPERATOR_IMAGE_URI REGISTRY_IMAGE CURRENT_COMMIT"
+    exit -1
+}
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+source $REPO_ROOT/boilerplate/_lib/common.sh
+
+[[ $# -eq 3 ]] || usage
+
+OPERATOR_IMAGE_URI=$1
+REGISTRY_IMAGE=$2
+CURRENT_COMMIT=$3
+
+# Don't rebuild the image if it already exists in the repository
+if image_exists_in_repo "${OPERATOR_IMAGE_URI}"; then
+    echo "Skipping operator image build/push"
+else
+    # build and push the operator image
+    make docker-push
+fi
+
+for channel in staging production; do
+    # If the catalog image already exists, short out
+    if image_exists_in_repo "${REGISTRY_IMAGE}:${channel}-${CURRENT_COMMIT}"; then
+        echo "Catalog image ${REGISTRY_IMAGE}:${channel}-${CURRENT_COMMIT} already "
+        echo "exists. Assuming this means the saas bundle work has also been done "
+        echo "properly. Nothing to do!"
+    else
+        # build the CSV and create & push image catalog for the appropriate channel
+        make ${channel}-common-csv-build ${channel}-catalog-build ${channel}-catalog-publish
+    fi
+done

--- a/boilerplate/openshift/golang-osd-operator/app-sre.md
+++ b/boilerplate/openshift/golang-osd-operator/app-sre.md
@@ -1,0 +1,71 @@
+# Testing APP-SRE Scripts Locally
+
+- [Testing APP-SRE Scripts Locally](#testing-app-sre-scripts-locally)
+  - [Create image repositories](#create-image-repositories)
+  - [Fork the SaaS bundle repository](#fork-the-saas-bundle-repository)
+  - [Set environment variables](#set-environment-variables)
+  - [Execute](#execute)
+
+Local testing of APP-SRE pipelines requires the following setup:
+
+## Create image repositories
+In your image registry*, create two repositories in your personal namespace.
+Make sure they are **public**.
+1. For the operator image, name the repository the same as the operator, e.g. `deadmanssnitch-operator`.
+2. For the catalog image, append `-registry` to the operator name, e.g. `deadamnssnitch-operator-registry`.
+
+*We assume you are using quay.io.
+If not, you will need to set the `IMAGE_REGISTRY` environment variable (see [below](#set-environment-variables)).
+
+## Fork the SaaS bundle repository
+The SaaS bundle repository for `$OPERATOR_NAME` should be located at `https://gitlab.cee.redhat.com/service/saas-{operator}-bundle`, e.g. https://gitlab.cee.redhat.com/service/saas-deadmanssnitch-operator-bundle.
+Fork it to your personal namespace.
+
+## Set environment variables
+```bash
+# The process creates artifacts in your git clone. Some of the make targets
+# will bounce when the repository is not clean. Override this behavior:
+export ALLOW_DIRTY_CHECKOUT=true
+
+# If you are using an image registry other than quay.io, configure it thus:
+# export IMAGE_REGISTRY=docker.io
+
+# Your personal repository space in the image registry.
+export IMAGE_REPOSITORY=2uasimojo
+
+# These are used to authenticate to your personal image registry.
+# E.g. for quay.io, generate these values via
+#    Account Settings => Generate Encrypted Password.
+export REGISTRY_USER=<your registry username>
+export REGISTRY_TOKEN=<token obtained from the registry>
+# FIXME: we shouldn't need both REGISTRY_* and QUAY_*
+export QUAY_USER=$REGISTRY_USER
+export QUAY_TOKEN=$REGISTRY_TOKEN
+
+# Tell the scripts where to find your fork of the SaaS bundle repository.
+# Except for the authentication part, this should correspond to what you see in the
+# https "clone" button in your fork.
+# Generate an access token via Settings => Access Tokens. Enable `write_repository`.
+# - {gitlab-user} is your username in gitlab
+# - {gitlab-token} is the authentication token you generated above
+# - {operator} is the name of the consumer repository, e.g. `deadmanssnitch-operator`
+export GIT_PATH=https://{gitlab-user}:{gitlab-token}@gitlab.cee.redhat.com/{gitlab-user}/saas-{operator}-bundle.git
+```
+
+## Execute
+At this point you should be able to run
+```
+make build-push
+```
+
+This will create the following artifacts if it succeeds
+(`{hash}` is the 7-digit SHA of the current git commit in the repository under test):
+- Operator image in your personal operator repository, tagged `v{major}.{minor}.{commit-count}-{hash}` (e.g. `v0.1.228-e0b6129`) and `latest`
+- Two catalog images in your personal registry repository:
+  - One image tagged `staging-{hash}` and `staging-latest`
+  - The other tagged `production-{hash}` and `production-latest`
+- Two commits in your fork of the SaaS bundle repository:
+  - One in the `staging` branch
+  - The other in the `production` branch
+  These are also present locally in a `saas-{operator-name}-bundle` subdirectory of your operator repository clone.
+  You can inspect the artifacts therein to make sure e.g. the CSV was generated correctly.

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
@@ -2,15 +2,19 @@
 
 source `dirname $0`/common.sh
 
-usage() { echo "Usage: $0 -o operator_name -c saas-repository-channel" 1>&2; exit 1; }
+usage() { echo "Usage: $0 -o operator-name -c saas-repository-channel -r registry-image" 1>&2; exit 1; }
 
-while getopts "o:c:" option; do
+while getopts "o:c:r:" option; do
     case "${option}" in
         o)
             operator_name=${OPTARG}
             ;;
         c)
             operator_channel=${OPTARG}
+            ;;
+        r)
+            # NOTE: This is the URL without the tag/digest
+            registry_image=${OPTARG}
             ;;
         *)
             usage
@@ -22,7 +26,6 @@ check_mandatory_params operator_channel operator_name
 
 # Parameters for the Dockerfile
 SAAS_OPERATOR_DIR="saas-${operator_name}-bundle"
-REGISTRY_IMG="quay.io/app-sre/${operator_name}-registry"
 DOCKERFILE_REGISTRY="Dockerfile.olm-registry"
 
 # Checking SAAS_OPERATOR_DIR exist
@@ -32,13 +35,13 @@ if [ ! -d "${SAAS_OPERATOR_DIR}/.git" ] ; then
 fi
 
 cat <<EOF > $DOCKERFILE_REGISTRY
-FROM quay.io/openshift/origin-operator-registry:latest
+FROM quay.io/openshift/origin-operator-registry:4.7.0
 COPY $SAAS_OPERATOR_DIR manifests
 RUN initializer --permissive
 CMD ["registry-server", "-t", "/tmp/terminate.log"]
 EOF
 
-docker build -f $DOCKERFILE_REGISTRY --tag "${REGISTRY_IMG}:${operator_channel}-latest" .
+docker build -f $DOCKERFILE_REGISTRY --tag "${registry_image}:${operator_channel}-latest" .
 
 if [ $? -ne 0 ] ; then 
     echo "docker build failed, exiting..."

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/common.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/common.sh
@@ -1,5 +1,8 @@
 #!/bin/bash 
 
+REPO_ROOT=$(git rev-parse --show-toplevel)
+source $REPO_ROOT/boilerplate/_lib/common.sh
+
 function check_mandatory_params() {
     local csv_missing_param_error
     local param_name

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.mk
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.mk
@@ -17,15 +17,15 @@ staging-common-csv-build-and-diff:
 
 .PHONY: staging-catalog-build
 staging-catalog-build: 
-	@${CONVENTION_DIR}/csv-generate/catalog-build.sh -o $(OPERATOR_NAME) -c staging
+	@${CONVENTION_DIR}/csv-generate/catalog-build.sh -o $(OPERATOR_NAME) -c staging -r ${REGISTRY_IMAGE}
 	
 .PHONY: staging-saas-bundle-push
 staging-saas-bundle-push: 
-	@${CONVENTION_DIR}/csv-generate/catalog-publish.sh -o $(OPERATOR_NAME) -c staging -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER)
+	@${CONVENTION_DIR}/csv-generate/catalog-publish.sh -o $(OPERATOR_NAME) -c staging -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -r ${REGISTRY_IMAGE}
 	
 .PHONY: staging-catalog-publish
 staging-catalog-publish: 
-	@${CONVENTION_DIR}/csv-generate/catalog-publish.sh -o $(OPERATOR_NAME) -c staging -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -p
+	@${CONVENTION_DIR}/csv-generate/catalog-publish.sh -o $(OPERATOR_NAME) -c staging -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -p -r ${REGISTRY_IMAGE}
 	
 .PHONY: staging-catalog-build-and-publish
 staging-catalog-build-and-publish: 
@@ -50,15 +50,15 @@ production-common-csv-build-and-diff:
 
 .PHONY: production-catalog-build
 production-catalog-build: 
-	@${CONVENTION_DIR}/csv-generate/catalog-build.sh -o $(OPERATOR_NAME) -c production
+	@${CONVENTION_DIR}/csv-generate/catalog-build.sh -o $(OPERATOR_NAME) -c production -r ${REGISTRY_IMAGE}
 	
 .PHONY: production-saas-bundle-push
 production-saas-bundle-push: 
-	@${CONVENTION_DIR}/csv-generate/catalog-publish.sh -o $(OPERATOR_NAME) -c production -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER)
+	@${CONVENTION_DIR}/csv-generate/catalog-publish.sh -o $(OPERATOR_NAME) -c production -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -r ${REGISTRY_IMAGE}
 	
 .PHONY: production-catalog-publish
 production-catalog-publish: 
-	@${CONVENTION_DIR}/csv-generate/catalog-publish.sh -o $(OPERATOR_NAME) -c production -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -p
+	@${CONVENTION_DIR}/csv-generate/catalog-publish.sh -o $(OPERATOR_NAME) -c production -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -p -r ${REGISTRY_IMAGE}
 	
 .PHONY: production-catalog-build-and-publish
 production-catalog-build-and-publish: 

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.mk
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.mk
@@ -2,18 +2,18 @@
 	
 .PHONY: staging-hack-csv-build
 staging-hack-csv-build: 
-	@${CONVENTION_DIR}/csv-generate/csv-generate.sh -o $(OPERATOR_NAME) -i $(OPERATOR_IMAGE_URI) -c staging -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -g hack
+	@${CONVENTION_DIR}/csv-generate/csv-generate.sh -o $(OPERATOR_NAME) -i $(OPERATOR_IMAGE) -V $(OPERATOR_VERSION) -c staging -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -g hack
 	
 .PHONY: staging-common-csv-build
 staging-common-csv-build: 
-	@${CONVENTION_DIR}/csv-generate/csv-generate.sh -o $(OPERATOR_NAME) -i $(OPERATOR_IMAGE_URI) -c staging -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -g common
+	@${CONVENTION_DIR}/csv-generate/csv-generate.sh -o $(OPERATOR_NAME) -i $(OPERATOR_IMAGE) -V $(OPERATOR_VERSION) -c staging -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -g common
 	
 .PHONY: staging-csv-build
 staging-csv-build: staging-hack-csv-build
 
 .PHONY: staging-common-csv-build-and-diff
 staging-common-csv-build-and-diff: 
-	@${CONVENTION_DIR}/csv-generate/csv-generate.sh -o $(OPERATOR_NAME) -i $(OPERATOR_IMAGE_URI) -c staging -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -g common -d
+	@${CONVENTION_DIR}/csv-generate/csv-generate.sh -o $(OPERATOR_NAME) -i $(OPERATOR_IMAGE) -V $(OPERATOR_VERSION) -c staging -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -g common -d
 
 .PHONY: staging-catalog-build
 staging-catalog-build: 
@@ -35,18 +35,18 @@ staging-catalog-build-and-publish:
 	
 .PHONY: production-hack-csv-build
 production-hack-csv-build: 
-	@${CONVENTION_DIR}/csv-generate/csv-generate.sh -o $(OPERATOR_NAME) -i $(OPERATOR_IMAGE_URI) -c production -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -g hack
+	@${CONVENTION_DIR}/csv-generate/csv-generate.sh -o $(OPERATOR_NAME) -i $(OPERATOR_IMAGE) -V $(OPERATOR_VERSION) -c production -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -g hack
 	
 .PHONY: production-common-csv-build
 production-common-csv-build: 
-	@${CONVENTION_DIR}/csv-generate/csv-generate.sh -o $(OPERATOR_NAME) -i $(OPERATOR_IMAGE_URI) -c production -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -g common
+	@${CONVENTION_DIR}/csv-generate/csv-generate.sh -o $(OPERATOR_NAME) -i $(OPERATOR_IMAGE) -V $(OPERATOR_VERSION) -c production -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -g common
 	
 .PHONY: production-csv-build
 production-csv-build: production-hack-csv-build
 
 .PHONY: production-common-csv-build-and-diff
 production-common-csv-build-and-diff: 
-	@${CONVENTION_DIR}/csv-generate/csv-generate.sh -o $(OPERATOR_NAME) -i $(OPERATOR_IMAGE_URI) -c production -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -g common -d
+	@${CONVENTION_DIR}/csv-generate/csv-generate.sh -o $(OPERATOR_NAME) -i $(OPERATOR_IMAGE) -V $(OPERATOR_VERSION) -c production -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -g common -d
 
 .PHONY: production-catalog-build
 production-catalog-build: 

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
@@ -68,8 +68,8 @@ else
     if [[ "$operator_channel" == "production" ]]; then
         if [ -z "$DEPLOYED_HASH" ] ; then
             DEPLOYED_HASH=$(
-                curl -s "https://gitlab.cee.redhat.com/service/app-interface/raw/master/data/services/osd-operators/cicd/saas/saas-${_OPERATOR_NAME}.yaml" | \
-                    docker run --rm -i quay.io/app-sre/yq:3.4.1 yq r - "resourceTemplates[*].targets(namespace.\$ref==/services/osd-operators/namespaces/hivep01ue1/${_OPERATOR_NAME}.yml).ref"
+                curl -s "https://gitlab.cee.redhat.com/service/app-interface/raw/master/data/services/osd-operators/cicd/saas/saas-${operator_name}.yaml" | \
+                    docker run --rm -i quay.io/app-sre/yq:3.4.1 yq r - "resourceTemplates[*].targets(namespace.\$ref==/services/osd-operators/namespaces/hivep01ue1/${operator_name}.yml).ref"
             )
         fi
     

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
@@ -2,10 +2,10 @@
 
 source `dirname $0`/common.sh
 
-usage() { echo "Usage: $0 -o operator_name -c saas-repository-channel -H operator_commit_hash -n operator_commit_number -i operator_image -g [hack|common][-d]" 1>&2; exit 1; }
+usage() { echo "Usage: $0 -o operator-name -c saas-repository-channel -H operator-commit-hash -n operator-commit-number -i operator-image -V operator-version -g [hack|common][-d]" 1>&2; exit 1; }
 
 # TODO : Add support of long-options 
-while getopts "c:dg:H:i:n:o:" option; do
+while getopts "c:dg:H:i:n:o:V:" option; do
     case "${option}" in
         c)
             operator_channel=${OPTARG}
@@ -25,6 +25,8 @@ while getopts "c:dg:H:i:n:o:" option; do
             operator_commit_hash=${OPTARG}
             ;;
         i)
+            # This should be $OPERATOR_IMAGE from standard.mk
+            # I.e. the URL to the image repository with *no* tag.
             operator_image=${OPTARG}
             ;;
         n)
@@ -33,13 +35,27 @@ while getopts "c:dg:H:i:n:o:" option; do
         o)
             operator_name=${OPTARG}
             ;;
+        V)
+            # This should be $OPERATOR_VERSION from standard.mk:
+            # `{major}.{minor}.{commit-number}.{hash}`
+            # Notably, it does *not* start with `v`.
+            operator_version=${OPTARG}
+            ;;
         *)
             usage
     esac
 done
 
 # Checking parameters
-check_mandatory_params operator_channel operator_image operator_name operator_commit_hash operator_commit_number generate_script
+check_mandatory_params operator_channel operator_image operator_version operator_name operator_commit_hash operator_commit_number generate_script
+
+# Get the image URI as repo URL + image digest
+IMAGE_DIGEST=$(skopeo inspect docker://${operator_image}:v${operator_version} | jq -r .Digest)
+if [[ -z "$IMAGE_DIGEST" ]]; then
+    echo "Couldn't discover IMAGE_DIGEST for docker://${operator_image}:v${operator_version}!"
+    exit 1
+fi
+REPO_DIGEST=${operator_image}@${IMAGE_DIGEST}
 
 # If no override, using the gitlab repo
 if [ -z "$GIT_PATH" ] ; then 
@@ -90,21 +106,20 @@ else
             fi
         done
     fi
-    # TODO : Clean handling of major version (should be variable from consumer repo and default to 0.1 is undefined)
     OPERATOR_PREV_VERSION=$(ls "$BUNDLE_DIR" | sort -t . -k 3 -g | tail -n 1)
-    OPERATOR_NEW_VERSION="0.1.${operator_commit_number}-${operator_commit_hash}"
+    OPERATOR_NEW_VERSION="${operator_version}"
     OUTPUT_DIR=${BUNDLE_DIR}
 fi
 
 if [[ "$generate_script" = "common" ]] ; then
-    ./boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py -o ${operator_name} -d ${OUTPUT_DIR} -p ${OPERATOR_PREV_VERSION} -n ${operator_commit_number} -c ${operator_commit_hash} -i ${operator_image}
+    ./boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py -o ${operator_name} -d ${OUTPUT_DIR} -p ${OPERATOR_PREV_VERSION} -n ${operator_commit_number} -c ${operator_commit_hash} -i ${REPO_DIGEST}
 elif [[ "$generate_script" = "hack" ]] ; then
     if [ -z "$OPERATOR_PREV_VERSION" ] ; then 
         OPERATOR_PREV_VERSION="no-version"
         DELETE_REPLACE=true
     fi
     
-    ./hack/generate-operator-bundle.py ${OUTPUT_DIR} ${OPERATOR_PREV_VERSION} ${operator_commit_number} ${operator_commit_hash} ${operator_image}
+    ./hack/generate-operator-bundle.py ${OUTPUT_DIR} ${OPERATOR_PREV_VERSION} ${operator_commit_number} ${operator_commit_hash} ${REPO_DIGEST}
     
     if [ ! -z "${DELETE_REPLACE}" ] ; then
         yq d -i output-comparison/${OPERATOR_NEW_VERSION}/*.clusterserviceversion.yaml 'spec.replaces'

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -29,6 +29,7 @@ IMG?=$(OPERATOR_IMAGE):$(OPERATOR_IMAGE_TAG)
 OPERATOR_IMAGE_URI=${IMG}
 OPERATOR_IMAGE_URI_LATEST=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME):latest
 OPERATOR_DOCKERFILE ?=build/Dockerfile
+REGISTRY_IMAGE=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME)-registry
 
 OLM_BUNDLE_IMAGE = $(OPERATOR_IMAGE)-bundle
 OLM_CATALOG_IMAGE = $(OPERATOR_IMAGE)-catalog
@@ -207,7 +208,7 @@ coverage:
 # TODO: Boilerplate this script.
 .PHONY: build-push
 build-push:
-	hack/app_sre_build_deploy.sh
+	${CONVENTION_DIR}/app-sre-build-deploy.sh ${OPERATOR_IMAGE_URI} ${REGISTRY_IMAGE} ${CURRENT_COMMIT}
 
 .PHONY: opm-build-push
 opm-build-push: docker-push

--- a/test/case/convention/openshift/golang-osd-operator/06-csv-generate
+++ b/test/case/convention/openshift/golang-osd-operator/06-csv-generate
@@ -19,6 +19,19 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 
 source $REPO_ROOT/test/lib.sh
 
+# >>HACK!>>
+# csv-generate.sh uses skopeo, but that's not in the backing image.
+# Create a dummy skopeo until it is.
+# FIXME
+mkdir /tmp/bin
+cat <<EOF >/tmp/bin/skopeo
+#!/bin/bash
+echo '{"Digest": "sha256:abc123"}'
+EOF
+chmod +x /tmp/bin/skopeo
+export PATH=$PATH:/tmp/bin
+# <<HACK!<<
+
 repo=$(empty_repo)
 saas_repo=$(empty_repo)
 


### PR DESCRIPTION
This PR comprises two commits:

- Add the top-level script to perform the end-to-end app-sre build and deploy sequence, and enable it by default for consumers via the `build-push` make target. Enable (and document) local testing of this sequence without changing code.
- Switch to pulling the operator image by digest rather than by tag.