### PR TITLE
Enable selecting test cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ tag-check:
 
 .PHONY: test
 test: isclean tag-check
-	test/driver
+	test/driver $(CASE_GLOB)
 
 .PHONY: pr-check
 pr-check: test


### PR DESCRIPTION
With this commit, you can use a `CASE_GLOB` variable to restrict which tests are run by `make test` (aka `make pr-check`). The value of `CASE_GLOB` is passed to `find ... -name`, so may be anything that will accept. For example, to run just the test case named `06-csv-generate`, you can run:

```
make CASE_GLOB=06-csv-generate test
```

This also works via `container-make`, which can be convenient for debugging CI failures:

```
./boilerplate/_lib/container-make CASE_GLOB=06-csv-generate pr-check
```