### PR TITLE
Generate operator bundle generically and inclusively

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py
@@ -22,13 +22,13 @@ VERSION_BASE = "0.1"
 parser = argparse.ArgumentParser()
 parser.add_argument("-o", "--operator-name", type=str, help="Name of the operator", required=True)
 parser.add_argument("-d", "--output-dir", type=str, help="Directory for the CSV generation", required=True)
-parser.add_argument("-p", "--previous-version", type=str, help="Directory for the CSV generation", required=True)
+parser.add_argument("-p", "--previous-version", type=str, help="Semver of the version being replaced", required=True)
 parser.add_argument("-n", "--commit-number", type=str, help="Number of commits in the project (used for version generation)", required=True)
 parser.add_argument("-c", "--commit-hash", type=str, help="Current commit hashDirectory for the CSV generation (used for version generation)", required=True)
 parser.add_argument("-i", "--operator-image", type=str, help="Base index image to be used", required=True)
 args = parser.parse_args()
 
-operator_name   = args.operator_name
+OPERATOR_NAME   = args.operator_name
 outdir          = args.output_dir
 prev_version    = args.previous_version
 git_num_commits = args.commit_number
@@ -41,25 +41,167 @@ print("Generating CSV for version: %s" % full_version)
 if not os.path.exists(outdir):
     os.mkdir(outdir)
 
-version_dir = os.path.join(outdir, full_version)
-if not os.path.exists(version_dir):
-    os.mkdir(version_dir)
+VERSION_DIR = os.path.join(outdir, full_version)
+if not os.path.exists(VERSION_DIR):
+    os.mkdir(VERSION_DIR)
 
-with open('config/templates/csv-template.yaml'.format(operator_name), 'r') as stream:
-    csv = yaml.load(stream)
+with open('config/templates/csv-template.yaml', 'r') as stream:
+    csv = yaml.safe_load(stream)
 
-csv['spec']['customresourcedefinitions']['owned'] = []
+# by_kind is a map, keyed by Kind, of all the yaml documents we find
+# under the deploy/ directory. We need to load them all before we start
+# processing because some (e.g. a ClusterRole and the ServiceAccount in
+# its corresponding ClusterRoleBinding) are interdependent.
+by_kind = {}
+# crb_by_cr is a map, keyed by ClusterRole name, of ClusterRoleBinding
+# documents.
+crb_by_cr = {}
+# rb_by_role is a map, keyed by Role name, of RoleBinding documents
+rb_by_role = {}
+for d, _, files in os.walk('deploy'):
+    for fname in files:
+        if not fname.endswith('.yaml'):
+            continue
+        path = os.path.join(d, fname)
+        with open(path, 'r') as stream:
+            for doc in yaml.safe_load_all(stream):
+                print(
+                    f"Loading {doc['kind']} {doc['metadata']['name']} " +
+                    f"from {path}")
+                if doc['kind'] not in by_kind:
+                    by_kind[doc['kind']] = []
+                by_kind[doc['kind']].append(doc)
+                if doc['kind'] == 'ClusterRoleBinding':
+                    crb_by_cr[doc['roleRef']['name']] = doc
+                if doc['kind'] == 'RoleBinding':
+                    rb_by_role[doc['roleRef']['name']] = doc
 
-# Copy all CRD files over to the bundle output dir:
-crd_files = [ f for f in os.listdir('deploy/crds') if f.endswith('_crd.yaml') ]
-for file_name in crd_files:
-    full_path = os.path.join('deploy/crds', file_name)
-    if (os.path.isfile(os.path.join('deploy/crds', file_name))):
-        shutil.copy(full_path, os.path.join(version_dir, file_name))
-    # Load CRD so we can use attributes from it
-    with open("deploy/crds/{}".format(file_name), "r") as stream:
-        crd = yaml.load(stream)
-    # Update CSV template customresourcedefinitions key
+class NoServiceAccountSubjectInBinding(Exception):
+    def __init__(self, binding):
+        super().__init__(
+            f"No ServiceAccount Subject in the following Binding:\n{binding}")
+
+class NoDeploymentFound(Exception):
+    def __init__(self):
+        super().__init__("At least one Deployment is required!")
+
+class MultipleDeploymentsNotSupported(Exception):
+    def __init__(self, deployments):
+        super().__init__(
+            f"Multiple Deployments not supported! Found {len(deployments)}.")
+
+class BindingsNotSupported(Exception):
+    def __init__(self, bindings):
+        super().__init__(
+            "[Cluster]RoleBindings are only supported when they correspond " +
+            "to provided [Cluster]Roles. Found the following orphans:\n" +
+            f"{bindings}")
+
+def log_resource(resource):
+    """Log a message that we're processing the given resource.
+
+    :param resource: A k8s resource definition dict, expected to have at least
+        a kind and metadata.name.
+    """
+    print(f"Processing {resource['kind']} {resource['metadata']['name']}")
+
+def filename_for(resource):
+    """Generate a unique base file name for the given resource.
+
+    :param resource: A k8s resource definition dict, expected to have at least
+        a kind and metadata.name.
+    :return: A base file name (no directory) that should be unique for the
+        given resource (assuming the resource is itself unique).
+    """
+    chunks = [resource['kind']]
+    ns = resource['metadata'].get('namespace')
+    if ns:
+        chunks.append(ns)
+    chunks.append(resource['metadata']['name'])
+    return '_'.join(chunks) + '.yaml'
+
+def bundle(resource):
+    """Create a yaml file for the given resource in the bundle.
+
+    Uses the VERSION_DIR global.
+
+    :param resource: A k8s resource definition dict, expected to have at least
+        a kind and metadata.name.
+    """
+    path = os.path.join(VERSION_DIR, filename_for(resource))
+    print(f"Bundling {path}")
+    with open(path, 'w') as outfile:
+        yaml.dump(resource, outfile, default_flow_style=False)
+
+def discover_service_account(binding):
+    """Discover or default the service account in a [Cluster]RoleBinding.
+
+    If binding is None, default to the operator name.
+    Uses the OPERATOR_NAME global.
+
+    :param binding: A [Cluster]RoleBinding resource dict.
+    :return: A string ServiceAccount name.
+    :raise NoServiceAccountSubjectInBinding: if binding does not contain a
+        ServiceAccount Subject.
+    """
+    if not binding:
+        print(
+            f"  Using default ServiceAccount ({OPERATOR_NAME}).")
+        return OPERATOR_NAME
+    for subject in binding.get('subjects', []):
+        if subject['kind'] == 'ServiceAccount':
+            sa = subject['name']
+            print(f"  Discovered ServiceAccount {sa}.")
+            return sa
+    raise NoServiceAccountSubjectInBinding(binding)
+
+def trim_index(index, kind, item):
+    """Removes one or all items of a given kind from the index.
+
+    :param index: Dict, keyed by kind, of k8s resources.
+    :param kind: String kind name to trim.
+    :param item: The item to trim. May be:
+        - A dict k8s resource. That specific resource is removed. If not found,
+          this function is a no-op.
+        - None. This function is a no-op.
+        - The string 'ALL'. The entire list for the given kind is removed.
+    """
+    if kind not in index:
+        return
+    if not item:
+        return
+    if item == 'ALL':
+        index.pop(kind, None)
+        return
+    name = item['metadata']['name']
+    ns = item['metadata'].get('namespace')
+    # Find the specific resource to remove
+    for i in range(len(index[kind])):
+        meta = index[kind][i]['metadata']
+        if meta['name'] == name and meta.get('namespace') == ns:
+            found = i
+            break
+    else:
+        # not found
+        return
+    # Reconstruct the list without the requested item
+    index[kind] = index[kind][:found] + index[kind][found+1:]
+
+## Up front sanity checks
+if 'Deployment' not in by_kind:
+    raise NoDeploymentFound()
+
+# TODO: Should we support additional Deployments that aren't the operator
+# Deployment?
+if len(by_kind['Deployment']) > 1:
+    raise MultipleDeploymentsNotSupported(by_kind['Deployment'])
+
+## Process CRDs
+if 'CustomResourceDefinition' in by_kind:
+    csv['spec']['customresourcedefinitions'] = {'owned': []}
+for crd in by_kind.get('CustomResourceDefinition', []):
+    log_resource(crd)
+    # And register the CRD as "owned" in the CSV
     csv['spec']['customresourcedefinitions']['owned'].append(
         {
             "name": crd["metadata"]["name"],
@@ -69,43 +211,81 @@ for file_name in crd_files:
             "version": crd["spec"]["version"]
         }
     )
+# These will be written to the bundle at the end along with generic resources
 
-csv['spec']['install']['spec']['clusterPermissions'] = []
+## Process [Cluster]Role[Binding]s (TODO: Match up ServiceAccounts)
+# Role and ClusterRole are processed similarly
+rolekind_csvkey_bindingmap = (
+    ('ClusterRole', 'clusterPermissions', crb_by_cr),
+    # NOTE: The schema supports `permissions` for Roles, but OLM may not. For
+    # backward compatibility, treat Roles and RoleBindings as generic bundle
+    # resources.
+    # ('Role', 'permissions', rb_by_role),
+)
+for kind, csvkey, binding_map in rolekind_csvkey_bindingmap:
+    if kind in by_kind:
+        csv['spec']['install']['spec'][csvkey] = []
+    for role in by_kind.get(kind, []):
+        log_resource(role)
+        # Figure out the ServiceAccount.
+        binding = binding_map.get(role['metadata']['name'], None)
+        sa = discover_service_account(binding)
+        # Get rid of the binding, if found, so it doesn't end up in generic
+        # bundle resources.
+        trim_index(by_kind, f"{kind}Binding", binding)
+        # Inject the rules and ServiceAccount
+        csv['spec']['install']['spec'][csvkey].append(
+            {
+                'rules': role['rules'],
+                'serviceAccountName': sa,
+            })
+    # Get rid of these so we can iterate over what's left at the end
+    trim_index(by_kind, kind, 'ALL')
 
-# Add operator role to the CSV:
-with open('deploy/role.yaml', 'r') as stream:
-    operator_role = yaml.load(stream)
-    csv['spec']['install']['spec']['clusterPermissions'].append(
-        {
-            'rules': operator_role['rules'],
-            'serviceAccountName': operator_name,
-        })
+## Add the Deployment
+# We already made sure there's exactly one Deployment
+deploy = by_kind['Deployment'][0]
+# Use the operator image pull spec we were passed
+deploy['spec']['template']['spec']['containers'][0]['image'] = operator_image
+csv['spec']['install']['spec']['deployments'] = [
+    {
+        'name': deploy['metadata']['name'],
+        'spec': deploy['spec'],
+    }
+]
+# Get rid of these so we can iterate over what's left at the end
+trim_index(by_kind, 'Deployment', 'ALL')
 
-# Add our deployment spec for the operator:
-with open('deploy/operator.yaml', 'r') as stream:
-    operator_components = []
-    operator = yaml.load_all(stream)
-    for doc in operator:
-        operator_components.append(doc)
-    # There is only one yaml document in the operator deployment
-    operator_deployment = operator_components[0]
-    csv['spec']['install']['spec']['deployments'][0]['spec'] = operator_deployment['spec']
+# Get rid of ServiceAccounts
+# TODO: Sanity check these against "generated" ServiceAccounts
+print("Ignoring all explicitly defined ServiceAccounts")
+trim_index(by_kind, 'ServiceAccount', 'ALL')
 
-# Update the deployment to use the defined image:
-csv['spec']['install']['spec']['deployments'][0]['spec']['template']['spec']['containers'][0]['image'] = operator_image
+# If there are any bindings left, it's an error
+leftover_bindings = []
+for kind, _, _ in rolekind_csvkey_bindingmap:
+    leftover_bindings.extend(by_kind.get(kind, []))
+if leftover_bindings:
+    raise BindingsNotSupported(leftover_bindings)
+
+## Process any additional resources
+# These don't go in the CSV; they just get copied into the bundle as is.
+for kind, docs in by_kind.items():
+    for doc in docs:
+        bundle(doc)
 
 # Update the versions to include git hash:
-csv['metadata']['name'] = "{}.v{}".format(operator_name, full_version)
+csv['metadata']['name'] = f"{OPERATOR_NAME}.v{full_version}"
 csv['spec']['version'] = full_version
-csv['spec']['replaces'] = "{}.v{}".format(operator_name, prev_version)
+csv['spec']['replaces'] = f"{OPERATOR_NAME}.v{prev_version}"
 
 # Set the CSV createdAt annotation:
 now = datetime.datetime.now()
 csv['metadata']['annotations']['createdAt'] = now.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 # Write the CSV to disk:
-csv_filename = "{}.v{}.clusterserviceversion.yaml".format(operator_name, full_version)
-csv_file = os.path.join(version_dir, csv_filename)
+csv_filename = f"{OPERATOR_NAME}.v{full_version}.clusterserviceversion.yaml"
+csv_file = os.path.join(VERSION_DIR, csv_filename)
 with open(csv_file, 'w') as outfile:
     yaml.dump(csv, outfile, default_flow_style=False)
 print("Wrote ClusterServiceVersion: %s" % csv_file)

--- a/test/case/convention/openshift/golang-osd-operator/06-csv-generate
+++ b/test/case/convention/openshift/golang-osd-operator/06-csv-generate
@@ -23,7 +23,7 @@ source $REPO_ROOT/test/lib.sh
 # csv-generate.sh uses skopeo, but that's not in the backing image.
 # Create a dummy skopeo until it is.
 # FIXME
-mkdir /tmp/bin
+mkdir -p /tmp/bin
 cat <<EOF >/tmp/bin/skopeo
 #!/bin/bash
 echo '{"Digest": "sha256:abc123"}'

--- a/test/projects/file-generate/deploy/cluster_role.yaml
+++ b/test/projects/file-generate/deploy/cluster_role.yaml
@@ -1,0 +1,80 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: file-generate
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - file-generate
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - get
+- apiGroups:
+  - mygroup.com
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/test/projects/file-generate/deploy/cluster_role_binding.yaml
+++ b/test/projects/file-generate/deploy/cluster_role_binding.yaml
@@ -1,0 +1,11 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: file-generate
+subjects:
+- kind: ServiceAccount
+  name: file-generate
+roleRef:
+  kind: ClusterRole
+  name: file-generate
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This is an almost-total rewrite of the common operator bundle generator script to accommodate variations in boilerplate consumers.

Before: The script looked for specific files by name. This wasn't a big deal as long as consumers had the right corresponding file they could simply rename. However, it would blow up if those files weren't present or didn't contain exactly what was expected; or (importantly) if more than one file of that kind was needed.

After: The script processes all yaml documents under the deploy/ subdirectory, regardless of filename, including cases where multiple yaml documents exist in a single file, and processes them based on their Kind. The following are treated specially:

- CustomResourceDefinitions: These are registered as "owned" in the CSV. Otherwise they are copied into the bundle directory as usual.
- ClusterRoles: These are folded into the CSV's `clusterPermissions` and *not* copied into the bundle directory.
- ClusterRoleBindings: These are only used to discover the appropriate `serviceAccountName` for their corresponding ClusterRoles. They are not copied into the bundle directory. If any ClusterRoleBindings are "left over" at the end (not used to find a ServiceAccount), an error is raised.
- Deployment: We explicitly validate that there is exactly one of these. We fold the contents into the CSV's `deployments`. The Deployment is *not* copied to the bundle directory.
- ServiceAccounts: These are *ignored*, as we assume they correspond exactly to those listed in ClusterRoleBindings or the Deployment's Pod spec.

TODO:s
- The CSV [schema](https://docs.openshift.com/container-platform/4.5/rest_api/operatorhub_apis/clusterserviceversion-operators-coreos-com-v1alpha1.html) appears to support Role[Binding]s in a manner similar to ClusterRole[Binding]s. Assuming OLM supports that, we should use it. For now, this commit treats Role[Binding]s as generic resources and simply copies them into the bundle, as consumers appeared to be doing.
- We should validate ServiceAccounts to make sure they correspond to [Cluster]RoleBindings or Pod specs in the Deployment, and error if any are "left over".