### PR TITLE
Remove docker specific configuration

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/app-sre.md
+++ b/boilerplate/openshift/golang-osd-operator/app-sre.md
@@ -38,9 +38,6 @@ export IMAGE_REPOSITORY=2uasimojo
 #    Account Settings => Generate Encrypted Password.
 export REGISTRY_USER=<your registry username>
 export REGISTRY_TOKEN=<token obtained from the registry>
-# FIXME: we shouldn't need both REGISTRY_* and QUAY_*
-export QUAY_USER=$REGISTRY_USER
-export QUAY_TOKEN=$REGISTRY_TOKEN
 
 # Tell the scripts where to find your fork of the SaaS bundle repository.
 # Except for the authentication part, this should correspond to what you see in the

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-publish.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-publish.sh
@@ -39,6 +39,14 @@ BUNDLE_DIR="${SAAS_OPERATOR_DIR}/${operator_name}"
 OPERATOR_NEW_VERSION=$(ls "${BUNDLE_DIR}" | sort -t . -k 3 -g | tail -n 1)
 OPERATOR_PREV_VERSION=$(ls "${BUNDLE_DIR}" | sort -t . -k 3 -g | tail -n 2 | head -n 1)
 
+# Use REGISTRY_USER and REGISTRY_TOKEN if available as container registry credentials
+# TODO: Update Jenkins jobs expose credentials in matching REGISTRY_USER and REGISTRY_TOKEN vars
+if [ ! -z "${REGISTRY_USER}" ] && [ ! -x "${REGISTRY_TOKEN}" ] ; then
+    echo "Using REGISTRY_USER and REGISTRY_TOKEN vars for container registry login"
+    QUAY_USER="$REGISTRY_USER"
+    QUAY_TOKEN="$REGISTRY_TOKEN"
+fi
+
 # Checking SAAS_OPERATOR_DIR exist
 if [ ! -d "${SAAS_OPERATOR_DIR}/.git" ] ; then
     echo "${SAAS_OPERATOR_DIR} should exist and be a git repository"


### PR DESCRIPTION
Unable to perform docker login using `podman` as podman doesn't support the `--config` arg. I believe we could further improve this by passing the REGSITRY_TOKEN to `${CONTAINER_LOGIN} login` via stdin, it should get rid of the warnings. 

```
Image quay.io/jharrington22/cloud-ingress-operator:v0.1.338-5da0f82 does not exist in the repository.
make[1]: Entering directory '/home/jamesh/.gvm/pkgsets/go1.13.6/global/src/github.com/openshift/cloud-ingress-operator'
mkdir -p .docker                                           
Error: unknown flag: --config                                                                                         
make[1]: *** [boilerplate/openshift/golang-osd-operator/standard.mk:105: docker-login] Error 125                      
make[1]: Leaving directory '/home/jamesh/.gvm/pkgsets/go1.13.6/global/src/github.com/openshift/cloud-ingress-operator'
make: *** [boilerplate/openshift/golang-osd-operator/standard.mk:211: build-push] Error 2    
```

Podman version

```
podman -v
podman version 2.2.1
```

The .docker file isn't need to login an push.

Fixed is also the `CONTAINER_ENGINE` var to respect environment variables so that it can be set. `podman` is selected by default if its installed by you may choose to use docker by setting `export CONTAINER_ENGINE=docker` 

Last change was to check for the the ENV's `REGISTRY_USER and REGISTRY_TOKEN` and set `QUAY_USER and QUAY_TOKEN` to be those values. APPSRE pipelines should be unaffected by this change.