### PR TITLE
Ensure we fetch a valid deployed production hash

### DIFF
--- a/test/case/convention/openshift/golang-osd-operator/06-csv-generate
+++ b/test/case/convention/openshift/golang-osd-operator/06-csv-generate
@@ -32,6 +32,16 @@ chmod +x /tmp/bin/skopeo
 export PATH=/tmp/bin:$PATH
 # <<HACK!<<
 
+# >>HACK!>>
+# csv-generate.sh queries the project's SaaS file in app-interface. Our
+# dummy project doesn't have one. Even if it did, the CI image doesn't
+# have the right certs to query gitlab over https. Use the granny switch
+# to disable those pieces of the script.
+# FIXME -- This should go away when we're querying app-interface via
+# graphql.
+export SKIP_SAAS_FILE_CHECKS=1
+# <<HACK!<<
+
 repo=$(empty_repo)
 saas_repo=$(empty_repo)
 


### PR DESCRIPTION
This PR does two things to discover and ensure we fetch a valid HASH.

1. We determine if the SAAS file is applying a resource type of `SelectorSyncSet` if it is we'll assume the saas file is for a customer cluster and not Hive. (Resources cannot be sync'd to a customer cluster without a SelectorSyncSet (I should validate that and SyncSet).
2. Once we know the resource type we can make an assumption on the namespace path reference in resourceTemplates.

Before adding validation (Non hive cluster):

```
Image quay.io/jharrington22/cloud-ingress-operator-registry:production-1a3ab03 was deleted from the repository.
Proceeding as if it never existed.
make[1]: Entering directory '/home/jamesh/.gvm/pkgsets/go1.13.6/global/src/github.com/openshift/cloud-ingress-operator'
Cloning into 'saas-cloud-ingress-operator-bundle'...
remote: Enumerating objects: 155, done.
remote: Counting objects: 100% (155/155), done.
remote: Compressing objects: 100% (50/50), done.
remote: Total 1348 (delta 97), reused 138 (delta 81), pack-reused 1193
Receiving objects: 100% (1348/1348), 130.62 KiB | 228.00 KiB/s, done.
Resolving deltas: 100% (891/891), done.
SAAS file is NOT applied to Hive, MANAGED_RESOURCE_TYPE=SelectorSyncSet
Current deployed production HASH: 
Error discovering current production deployed HASH
make[1]: *** [boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.mk:42: production-common-csv-build] Error 1
make[1]: Leaving directory '/home/jamesh/.gvm/pkgsets/go1.13.6/global/src/github.com/openshift/cloud-ingress-operator'
make: *** [boilerplate/openshift/golang-osd-operator/standard.mk:211: build-push] Error 2

```

After (Non hive cluster)

```
Image quay.io/jharrington22/cloud-ingress-operator-registry:staging-1a3ab03 exists with digest sha256:64b5c9d1090c21f67419a282ea99971d62ab23ea3e53c05e2c4bae622d09e0ec.                                                                                       
Catalog image quay.io/jharrington22/cloud-ingress-operator-registry:staging-1a3ab03 already                                                                                                                                                                   
exists. Assuming this means the saas bundle work has also been done                                                                                                                                                                                           
properly. Nothing to do!                                                                                                                                                                                                                                      
Image quay.io/jharrington22/cloud-ingress-operator-registry:production-1a3ab03 was deleted from the repository.                                                                                                                                               
Proceeding as if it never existed.                                                                                                                                                                                                                            
make[1]: Entering directory '/home/jamesh/.gvm/pkgsets/go1.13.6/global/src/github.com/openshift/cloud-ingress-operator'                                                                                                                                       
Cloning into 'saas-cloud-ingress-operator-bundle'...                                                                                                                                                                                                          
remote: Enumerating objects: 155, done.                                                                                                                                                                                                                       
remote: Counting objects: 100% (155/155), done.                                                                                                                                                                                                               
remote: Compressing objects: 100% (50/50), done.                                                                                                                                                                                                              
remote: Total 1348 (delta 97), reused 138 (delta 81), pack-reused 1193                                                                                                                                                                                        
Receiving objects: 100% (1348/1348), 130.62 KiB | 165.00 KiB/s, done.                                                                                                                                                                                         
Resolving deltas: 100% (891/891), done.                                                                                                                                                                                                                       
SAAS file is NOT applied to Hive, MANAGED_RESOURCE_TYPE=SelectorSyncSet                                                                                                                                                                                       
Current deployed production HASH: 10af8dab0515ed5762aa283c83eb4080b0238fcd                                                                                                                                                                                    
Generating CSV for version: 0.1.344-1a3ab03    
```

We can go further to validate this by running the built catalog images and comparing the versions returned by the registry API and what we expect according to the `saas-${operator_name}-bundle` repo. This is how I realized the issue in the first place.