### PR TITLE
Set the operator bundle generator python script to use python

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Common script to generate OSD operator bundles for publishing to OLM. Copies appropriate files
 # into a directory, and composes the ClusterServiceVersion which needs bits and


### PR DESCRIPTION
`python3` may not be defined in some environments

[efried] To be clear, the script still relies on the python version being 3; we’re just no longer being explicit about it because apparently build environments are defaulting “python” to 3 *and* starting to not provide the “python3” alias/symlink. 