### PR TITLE
Small improvements to make it easier to run csv-generate test locally

### DIFF
--- a/test/case/convention/openshift/golang-osd-operator/06-csv-generate
+++ b/test/case/convention/openshift/golang-osd-operator/06-csv-generate
@@ -29,7 +29,7 @@ cat <<EOF >/tmp/bin/skopeo
 echo '{"Digest": "sha256:abc123"}'
 EOF
 chmod +x /tmp/bin/skopeo
-export PATH=$PATH:/tmp/bin
+export PATH=/tmp/bin:$PATH
 # <<HACK!<<
 
 repo=$(empty_repo)
@@ -47,7 +47,7 @@ saas_root_repo=$(mktemp -d -t boilerplate-saas-XXXXXXXX)
 cp -R $REPO_ROOT/test/projects/saas-file-generate-bundle $saas_root_repo/.
 saas_repo=${saas_root_repo}/saas-file-generate-bundle
 pushd $saas_repo 
-git init 
+git init -b master
 git config user.name "Test Boilerplate" 
 git config user.email "test@example.com" 
 git add .


### PR DESCRIPTION
- When the dummy `skopeo` is not the first in the path the actual `skopeo` executable will be used causing the test to fail.
- When a git repo is initialized the name of the default branch is taken from the users local configuration which could be something other than `master`. So set it explicitly.