### PR TITLE
removes debug flag from container-make

### DIFF
--- a/boilerplate/_lib/container-make
+++ b/boilerplate/_lib/container-make
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 if [[ "$1" == "-h"* ]] || [[ "$1" == "--h"* ]]; then
   echo "Usage: $0 {arguments to the real 'make'}"


### PR DESCRIPTION
Removes the debug flag on container-make.  If still needed by end-users, they can always set it in their session.

[efried] ...via `BOILERPLATE_SET_X=1`