### PR TITLE
Persist codecov script used as a test artifact

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/codecov.sh
+++ b/boilerplate/openshift/golang-osd-operator/codecov.sh
@@ -33,7 +33,7 @@ elif [[ "${JOB_TYPE}" == "local" ]]; then
        echo "coverage report available at ${COVER_PROFILE}"
        exit 0
 else
-       echo "${JOB_TYPE} jobs not supported"
+       echo "${JOB_TYPE} jobs not supported" >&2
        exit 1
 fi
 
@@ -42,4 +42,13 @@ export CI_BUILD_URL="${JOB_LINK}"
 export CI_BUILD_ID="${JOB_NAME}"
 export CI_JOB_ID="${BUILD_ID}"
 
-bash <(curl -s https://codecov.io/bash) -Z -K -f "${COVER_PROFILE}" -r "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}
+if [[ "${JOB_TYPE}" != "local" ]]; then
+       if [[ -z "${ARTIFACT_DIR:-}" ]] || [[ ! -d "${ARTIFACT_DIR}" ]] || [[ ! -w "${ARTIFACT_DIR}" ]]; then
+              echo '${ARTIFACT_DIR} must be set for non-local jobs, and must point to a writable directory' >&2
+              exit 1
+       fi
+       curl -s https://codecov.io/bash -o " ${ARTIFACT_DIR}/codecov.sh"
+       bash <(cat "${ARTIFACT_DIR}/codecov.sh") -Z -K -f "${COVER_PROFILE}" -r "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}
+else
+       bash <(curl -s https://codecov.io/bash) -Z -K -f "${COVER_PROFILE}" -r "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}
+fi


### PR DESCRIPTION
This will persist the codecov script used as an artifact of the coverage job

ARTIFACT_DIR is defined here: https://docs.ci.openshift.org/docs/architecture/step-registry/#available-environment-variables