### PR TITLE
Make sed prompt to use compatible sed

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -13,13 +13,13 @@ cp ${HERE}/.codecov.yml $REPO_ROOT
 
 # TODO: boilerplate more of Dockerfile
 echo "Overwriting build/Dockerfile's initial FROM with $IMAGE_PULL_PATH"
-sed -i "1s,.*,FROM $IMAGE_PULL_PATH AS builder," build/Dockerfile
+${SED?} -i "1s,.*,FROM $IMAGE_PULL_PATH AS builder," build/Dockerfile
 
 echo "Writing .ci-operator.yaml in your repository root with:"
 echo "    namespace: $IMAGE_NAMESPACE"
 echo "    name: $IMAGE_NAME"
 echo "    tag: $LATEST_IMAGE_TAG"
-sed "s/__NAMESPACE__/$IMAGE_NAMESPACE/; s/__NAME__/$IMAGE_NAME/; s/__TAG__/$LATEST_IMAGE_TAG/" ${HERE}/.ci-operator.yaml > $REPO_ROOT/.ci-operator.yaml
+${SED?} "s/__NAMESPACE__/$IMAGE_NAMESPACE/; s/__NAME__/$IMAGE_NAME/; s/__TAG__/$LATEST_IMAGE_TAG/" ${HERE}/.ci-operator.yaml > $REPO_ROOT/.ci-operator.yaml
 
 cat <<EOF
 

--- a/boilerplate/update
+++ b/boilerplate/update
@@ -19,6 +19,16 @@ fi
 export CONVENTION_ROOT="$(realpath $(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd ))"
 CONFIG_FILE="${CONVENTION_ROOT}/update.cfg"
 
+# Set SED variable
+if LANG=C sed --help 2>&1 | grep -q GNU; then
+  SED="sed"
+elif command -v gsed &>/dev/null; then
+  SED="gsed"
+else
+  echo "Failed to find GNU sed as sed or gsed. If you are on Mac: brew install gnu-sed." >&2
+  exit 1
+fi
+
 # scrubbed_conventions
 # Parses the $CONFIG_FILE and outputs a space-delimited list of conventions.
 scrubbed_conventions() {
@@ -122,7 +132,7 @@ trap "rm -fr $BP_CLONE" EXIT
 # repo doesn't have an `origin` remote.
 if [ -z "$REPO_NAME" ]; then
   # This is a tad ambitious, but it should usually work.
-  export REPO_NAME=$(git config --get remote.origin.url | sed 's,.*/,,; s/\.git$//')
+  export REPO_NAME=$(git config --get remote.origin.url | ${SED?} 's,.*/,,; s/\.git$//')
   # If that still didn't work, warn (but proceed)
   if [ -z "$REPO_NAME" ]; then
     echo 'Failed to discover repository name! $REPO_NAME not set!'

--- a/test/case/convention/openshift/golang-osd-operator/01-generated-files-checker
+++ b/test/case/convention/openshift/golang-osd-operator/01-generated-files-checker
@@ -13,7 +13,7 @@ for version in v0.15.1 v0.16.0 v0.17.0 v0.17.1 ; do
     bootstrap_project $repo ${test_project} openshift/golang-osd-operator
     cd $repo
     make boilerplate-update
-    sed s/__operator_sdk_version__/${version}/g go.mod.tmpl > go.mod
+    ${SED?} s/__operator_sdk_version__/${version}/g go.mod.tmpl > go.mod
     export GOPATH=$GOPATH:`pwd`
 
     # Check failure when project is not committed

--- a/test/case/convention/openshift/golang-osd-operator/04-op-generate-crd-fixup
+++ b/test/case/convention/openshift/golang-osd-operator/04-op-generate-crd-fixup
@@ -14,7 +14,7 @@ bootstrap_project $repo ${test_project} openshift/golang-osd-operator
 cd $repo
 make boilerplate-update
 # Pick a version
-sed s/__operator_sdk_version__/v0.16.0/g go.mod.tmpl > go.mod
+${SED?} s/__operator_sdk_version__/v0.16.0/g go.mod.tmpl > go.mod
 
 make op-generate
 

--- a/test/driver
+++ b/test/driver
@@ -26,7 +26,7 @@ main() {
     fi
 
     echo "Will run test cases:"
-    echo "$cases" | sed 's,^./,  ,'
+    echo "$cases" | ${SED?} 's,^./,  ,'
 
     for test_case_executable in $cases; do
         test_case_name=${test_case_executable#./}
@@ -51,10 +51,10 @@ main() {
     hr
     colorprint ${GREEN} "PASS: ${#_PASS[@]}"
     /bin/echo -n "  "
-    colorprint ${GREEN} ${_PASS[@]} | sed 's/ /\n  /g'
+    colorprint ${GREEN} ${_PASS[@]} | ${SED?} 's/ /\n  /g'
     colorprint ${RED} "FAIL: ${#_FAIL[@]}"
     /bin/echo -n "  "
-    colorprint ${RED} ${_FAIL[@]} | sed 's/ /\n  /g'
+    colorprint ${RED} ${_FAIL[@]} | ${SED?} 's/ /\n  /g'
     hr
     if [[ ${#_FAIL[@]} -ne 0 ]]; then
         exit 1

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -23,6 +23,17 @@ ORANGE='\033[0;33m'
 GREEN='\033[0;32m'
 RESET='\033[0m'
 
+# Set SED variable
+if LANG=C sed --help 2>&1 | grep -q GNU; then
+  SED="sed"
+elif command -v gsed &>/dev/null; then
+  SED="gsed"
+else
+  echo "Failed to find GNU sed as sed or gsed. If you are on Mac: brew install gnu-sed." >&2
+  exit 1
+fi
+
+
 colorprint() {
   color=$1
   shift
@@ -107,7 +118,7 @@ bootstrap_project() {
             add_convention . $convention
         done
         make boilerplate-update
-        sed -i '1s,^,include boilerplate/generated-includes.mk\n\n,' Makefile
+        ${SED?} -i '1s,^,include boilerplate/generated-includes.mk\n\n,' Makefile
         make boilerplate-commit
     )
 }
@@ -264,7 +275,7 @@ ensure_nexus_makefile_include() {
 
     if ! _is_line_in_file $line $file; then
         # Put the line at the top.
-        sed -i "1s,^,$line\n\n," $file
+        ${SED?} -i "1s,^,$line\n\n," $file
     fi
 }
 


### PR DESCRIPTION
BSD and GNU sed have different syntaxes. The BSD sed ships by default on mac.

Needed to duplicate this in a couple places as `boilerplate/update` needs to be standalone, as well as the test harness.