### PR TITLE
Support building multiple images

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/app-sre-build-deploy.sh
+++ b/boilerplate/openshift/golang-osd-operator/app-sre-build-deploy.sh
@@ -3,7 +3,23 @@
 set -ev
 
 usage() {
-    echo "$0 OPERATOR_IMAGE_URI REGISTRY_IMAGE CURRENT_COMMIT"
+    cat <<EOF
+    Usage: $0 REGISTRY_IMAGE CURRENT_COMMIT "IMAGE_SPECS"
+    IMAGE_SPECS is a multiline string where each line has the format:
+
+dockerfile_path image_uri
+
+    For example:
+
+# This is the main operator image
+./build/Dockerfile quay.io/app-sre/my-wizbang-operator:v0.1.123-abcd123
+
+# A supplemental image to also build and push
+./build/Dockerfile.other quay.io/app-sre/supplemental-image:v5.6.0
+
+    The parameter is mandatory; if only building the catalog image,
+    specify the empty string.
+EOF
     exit -1
 }
 
@@ -12,17 +28,37 @@ source $REPO_ROOT/boilerplate/_lib/common.sh
 
 [[ $# -eq 3 ]] || usage
 
-OPERATOR_IMAGE_URI=$1
-REGISTRY_IMAGE=$2
-CURRENT_COMMIT=$3
+REGISTRY_IMAGE=$1
+CURRENT_COMMIT=$2
+IMAGE_SPECS="$3"
 
-# Don't rebuild the image if it already exists in the repository
-if image_exists_in_repo "${OPERATOR_IMAGE_URI}"; then
-    echo "Skipping operator image build/push"
-else
-    # build and push the operator image
-    make docker-push
-fi
+while read dockerfile_path image_uri junk; do
+    # Support comment lines
+    if [[ "$dockerfile_path" == '#'* ]]; then
+        continue
+    fi
+    # Support blank lines
+    if [[ "$dockerfile_path" == "" ]]; then
+        continue
+    fi
+    if [[ "$junk" != "" ]] && [[ "$junk" != '#'* ]]; then
+        echo "Invalid image spec: found extra garbage: '$junk'"
+        exit 1
+    fi
+    if ! [[ -f "$dockerfile_path" ]]; then
+        echo "Invalid image spec: no such dockerfile: '$dockerfile_path'"
+        exit 1
+    fi
+    # TODO: Validate ${image_uri} format?
+
+    # Don't rebuild the image if it already exists in the repository
+    if image_exists_in_repo "${image_uri}"; then
+        echo "Skipping build/push for ${image_uri}"
+    else
+        # build and push the operator image
+        make IMAGE_URI="${image_uri}" DOCKERFILE_PATH="${dockerfile_path}" docker-build-push-one
+    fi
+done <<< "$3"
 
 for channel in staging production; do
     # If the catalog image already exists, short out

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -31,6 +31,18 @@ OPERATOR_IMAGE_URI_LATEST=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME):la
 OPERATOR_DOCKERFILE ?=build/Dockerfile
 REGISTRY_IMAGE=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME)-registry
 
+# Consumer can optionally define ADDITIONAL_IMAGE_SPECS like:
+#     define ADDITIONAL_IMAGE_SPECS
+#     ./path/to/a/Dockerfile $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/a-image:v1.2.3
+#     ./path/to/b/Dockerfile $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/b-image:v4.5.6
+#     endef
+# Each will be conditionally built and pushed along with the operator image.
+define IMAGES_TO_BUILD
+$(OPERATOR_DOCKERFILE) $(OPERATOR_IMAGE_URI)
+$(ADDITIONAL_IMAGE_SPECS)
+endef
+export IMAGES_TO_BUILD
+
 OLM_BUNDLE_IMAGE = $(OPERATOR_IMAGE)-bundle
 OLM_CATALOG_IMAGE = $(OPERATOR_IMAGE)-catalog
 OLM_CHANNEL ?= alpha
@@ -85,16 +97,27 @@ clean:
 isclean:
 	@(test "$(ALLOW_DIRTY_CHECKOUT)" != "false" || test 0 -eq $$(git status --porcelain | wc -l)) || (echo "Local git checkout is not clean, commit changes and try again." >&2 && git --no-pager diff && exit 1)
 
+# TODO: figure out how to docker-login only once across multiple `make` calls
+.PHONY: docker-build-push-one
+docker-build-push-one: isclean docker-login
+	@(if [[ -z "${IMAGE_URI}" ]]; then echo "Must specify IMAGE_URI"; exit 1; fi)
+	@(if [[ -z "${DOCKERFILE_PATH}" ]]; then echo "Must specify DOCKERFILE_PATH"; exit 1; fi)
+	${CONTAINER_ENGINE} build . -f $(DOCKERFILE_PATH) -t $(IMAGE_URI)
+	${CONTAINER_ENGINE} --config=${CONTAINER_ENGINE_CONFIG_DIR} push ${IMAGE_URI}
+
+# TODO: Get rid of docker-build. It's only used by opm-build-push
 .PHONY: docker-build
 docker-build: isclean
 	${CONTAINER_ENGINE} build . -f $(OPERATOR_DOCKERFILE) -t $(OPERATOR_IMAGE_URI)
 	${CONTAINER_ENGINE} tag $(OPERATOR_IMAGE_URI) $(OPERATOR_IMAGE_URI_LATEST)
 
+# TODO: Get rid of docker-push. It's only used by opm-build-push
 .PHONY: docker-push
 docker-push: docker-login docker-build
 	${CONTAINER_ENGINE} --config=${CONTAINER_ENGINE_CONFIG_DIR} push ${OPERATOR_IMAGE_URI}
 	${CONTAINER_ENGINE} --config=${CONTAINER_ENGINE_CONFIG_DIR} push ${OPERATOR_IMAGE_URI_LATEST}
 
+# TODO: Get rid of push. It's not used.
 .PHONY: push
 push: docker-push
 
@@ -208,7 +231,7 @@ coverage:
 # TODO: Boilerplate this script.
 .PHONY: build-push
 build-push:
-	${CONVENTION_DIR}/app-sre-build-deploy.sh ${OPERATOR_IMAGE_URI} ${REGISTRY_IMAGE} ${CURRENT_COMMIT}
+	${CONVENTION_DIR}/app-sre-build-deploy.sh ${REGISTRY_IMAGE} ${CURRENT_COMMIT} "$$IMAGES_TO_BUILD"
 
 .PHONY: opm-build-push
 opm-build-push: docker-push


### PR DESCRIPTION
Previously the app-sre pipeline scripts were designed to build/push (if not already extant) exactly two things: the operator image and the OLM catalog.

With this commit we allow the consumer to build arbitrary images in addition to the operator image by setting a multiline `make` variable as follows:

```make
define ADDITIONAL_IMAGE_SPECS
./path/to/a/Dockerfile $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/a-image:v1.2.3
./path/to/b/Dockerfile $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/b-image:v4.5.6
endef
```

NOTE: As an ancillary side effect (benefit) of this commit, we stop tagging `latest` operator images. They were unused at best, misused at worst.