### PR TITLE
Secure freeze-check, enable hiding boilerplate deltas

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ This work was inspired by, and partially cribbed from,
   - [Quick Start](#quick-start)
   - [Overview](#overview)
     - [A Pretty Picture](#a-pretty-picture)
+    - [Consumer Philosophy](#consumer-philosophy)
+      - [Trust](#trust)
+      - [Ignore](#ignore)
   - [Mechanism](#mechanism)
   - [Consuming](#consuming)
     - [Bootstrap](#bootstrap)
@@ -104,6 +107,30 @@ The lifecycle from the consuming repository's perspective:
                  |push|
                  +----+
 ```
+
+### Consumer Philosophy
+Consuming repositories should think about boilerplate deltas the same way you would think about the `vendor/` directory for go dependencies: **trust** and **ignore**.
+
+#### Trust
+When reviewing a PR that includes a boilerplate changes, you can trust:
+- That they have already been **peer reviewed** in the boilerplate repository itself.
+  You may of course wish to review them at a high level to understand how they relate to your specific repository.
+- That they are **unchanged from their original form** in the boilerplate repository itself.
+  Assuming you are using standardized prow jobs, [freeze-check](boilerplate/_lib/freeze-check) is wired in to make sure of this.
+
+#### Ignore
+As with deltas under `vendor/`, changes under `boilerplate/` can be ignored the vast majority of the time.
+To facilitate this, you may wish to take advantage of [linguist](https://github.com/github/linguist), which is used by GitHub, to hide deltas under `boilerplate/` by default.
+This will make them appear the same as generated mocks, `go.sum`, etc.: unrendered by default, but with a link to render them on demand.
+To enable this behavior, add the following to the top of the `.gitattributes` file in the root of your repository:
+
+```
+# Hide most boilerplate deltas by default
+boilerplate/** linguist-generated=true
+```
+
+Note that, for security reasons, boilerplate will generate a block of overrides to force by-default rendering of certain files under `boilerplate/`, as well as the `.gitattributes` file itself.
+This is so that malicious changes attempting to subvert the tooling behind the [trust](#trust) model will always be rendered.
 
 ## Mechanism
 

--- a/boilerplate/_lib/freeze-check
+++ b/boilerplate/_lib/freeze-check
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 
+# NOTE: For security reasons, everything imported or invoked (even
+# indirectly) by this script should be audited for vulnerabilities and
+# explicitly excluded from `linguist-generated` in the consuming
+# repository's .gitattributes. In other words, we want PRs to show
+# deltas to this script and all its dependencies by default so that
+# attempts to inject or circumvent code are visible.
+
 set -e
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-source $REPO_ROOT/boilerplate/_lib/common.sh
+# Hardcoded rather than sourced to reduce attack surface.
+BOILERPLATE_GIT_REPO=https://github.com/openshift/boilerplate.git
 
 # Validate that no subscribed boilerplate artifacts have been changed.
 # PR checks may wish to gate on this.
@@ -28,7 +36,8 @@ source $REPO_ROOT/boilerplate/_lib/common.sh
 # seriously ticked off if something went wrong and lost my in-flight
 # changes.
 if ! [ -z "$(git status --porcelain)" ]; then
-  err "Can't validate boilerplate in a dirty repository. Please commit your changes and try again."
+  echo "Can't validate boilerplate in a dirty repository. Please commit your changes and try again." >&2
+  exit 1
 fi
 
 # We glean the last boilerplate commit from the
@@ -52,19 +61,19 @@ git remote add origin $BOILERPLATE_GIT_REPO
 git fetch origin $(cat $LBCF) --tags
 git reset --hard FETCH_HEAD
 
-# Now invoke the update script, bypassing the exec step because we
-# already downloaded what we want
+# Now invoke the update script, overriding the source repository we've
+# just downloaded at the appropriate commit.
+# We invoke the script explicitly rather than via the make target to
+# close a security hole whereby the latter is overridden.
 echo "Running update"
 cd $REPO_ROOT
-boilerplate/update $TMPD
+BOILERPLATE_GIT_CLONE="git clone $TMPD" boilerplate/update
 
 # Okay, if anything has changed, that's bad.
 if [[ $(git status --porcelain | wc -l) -ne 0 ]]; then
-  err "Your boilerplate is dirty!
-Run 'git diff' to see what we think you shouldn't have changed.
-You can commit those changes to pass this check.
-Or you can run 'git reset --hard HEAD' to get back to where you were before."
-
+  echo "Your boilerplate is dirty!" >&2
+  git status --porcelain
+  exit 1
 fi
 
 echo "Your boilerplate is clean!"

--- a/boilerplate/update
+++ b/boilerplate/update
@@ -110,6 +110,12 @@ EOF
   echo "Updating the update script."
   rsync -a "${BP_CLONE}/boilerplate/update" "$0"
   echo "Copying utilities"
+  # HACK: Delete the utility dirs first because, in CI, rsync will fail
+  # to set things like mod times and permissions on the directories
+  # themselves, which have uid=gid=0.
+  for d in $(/bin/ls -d ${BP_CLONE}/boilerplate/_*); do
+    rm -fr $CONVENTION_ROOT/${d##*/}
+  done
   rsync -a -r --delete ${BP_CLONE}/boilerplate/_* $CONVENTION_ROOT
   echo "Reinvoking..."
   echo ""
@@ -195,6 +201,35 @@ for convention in $(scrubbed_conventions $CONFIG_FILE); do
   echo "***********************************************************************************"
   echo ""
 done
+
+# (Create and) edit .gitattributes to
+# - override hiding boilerplate files related to freeze-check (so they
+#   can't be hacked without you seeing it in the PR by default)
+# - unhide .gitattributes itself (so these rules can't be changed
+#   without you seeing it in the PR by default)
+echo "Processing .gitattributes"
+gitattributes=${REPO_ROOT}/.gitattributes
+if [[ -f "${gitattributes}" ]]; then
+    # Delete the previously generated section
+    ${SED?} -i '/BEGIN BOILERPLATE GENERATED/,/END BOILERPLATE GENERATED/d' "${gitattributes}"
+fi
+# .gitattributes is processed in top-down order. Putting these entries at the
+# end ensures they take precedence over earlier, manual entries.
+cat <<EOF>>"${gitattributes}"
+### BEGIN BOILERPLATE GENERATED -- DO NOT EDIT    ###
+### This block must be the last thing in your     ###
+### .gitattributes file; otherwise the 'validate' ###
+### CI check will fail.                           ###
+# Used to ensure nobody mucked with boilerplate files.
+boilerplate/_lib/freeze-check linguist-generated=false
+# Show the boilerplate commit hash update. It's only one line anyway.
+boilerplate/_data/last-boilerplate-commit linguist-generated=false
+# Used by freeze-check. Good place for attackers to inject badness.
+boilerplate/update linguist-generated=false
+# Make sure attackers can't hide changes to this configuration
+.gitattributes linguist-generated=false
+### END BOILERPLATE GENERATED ###
+EOF
 
 # If all that went well, record some metadata.
 mkdir -p ${CONVENTION_ROOT}/_data

--- a/test/case/convention/openshift/golang-osd-operator/02-make-boilerplate-freeze-check
+++ b/test/case/convention/openshift/golang-osd-operator/02-make-boilerplate-freeze-check
@@ -6,6 +6,27 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 
 source $REPO_ROOT/test/lib.sh
 
+# This is funky.
+# For security reasons, the freeze-check script is hardcoded to use the
+# real boilerplate repo as its source of truth for determining whether
+# anything has been changed. We need to override that in order to test
+# the current boilerplate commit. But of course, overriding the
+# freeze-check script will, by design, cause freeze-check to fail. So we
+# have to create a new clone of boilerplate, from the current commit,
+# then override that hardcoded variable in a *new* commit, then start
+# the freeze check from there.
+prep_freeze_check() {
+    orig_repo=$REPO_ROOT
+    export REPO_ROOT=$(mktemp -d -t boilerplate-freeze-check-XXXXXXXX)
+    add_cleanup $REPO_ROOT
+    export BOILERPLATE_GIT_REPO=$REPO_ROOT
+    git clone $orig_repo $REPO_ROOT
+    ${SED?} -i 's,^BOILERPLATE_GIT_REPO=.*$,BOILERPLATE_GIT_REPO='$REPO_ROOT',' $REPO_ROOT/boilerplate/_lib/freeze-check
+    git -C $REPO_ROOT config user.name "Test Boilerplate" >&2
+    git -C $REPO_ROOT config user.email "test@example.com" >&2
+    git -C $REPO_ROOT commit -am "Override BOILERPLATE_GIT_REPO for freeze-check"
+}
+
 echo "Testing freeze-check"
 repo=$(empty_repo)
 add_cleanup $repo
@@ -14,6 +35,7 @@ add_cleanup $repo
 test_project="file-generate"
 
 convention=openshift/golang-osd-operator
+prep_freeze_check
 bootstrap_project $repo ${test_project} ${convention}
 cd $repo
 

--- a/test/case/framework/01-bootstrap-update
+++ b/test/case/framework/01-bootstrap-update
@@ -21,6 +21,9 @@ if [ $? -ne 0 ] ; then
 	exit $?
 fi
 
+# So the next update starts "clean"
+./boilerplate/_lib/boilerplate-commit
+
 add_convention $repo test/test-base-convention
 make boilerplate-update
 

--- a/test/case/framework/03-nexus-makefile-include
+++ b/test/case/framework/03-nexus-makefile-include
@@ -53,6 +53,9 @@ check_update $repo
 # Nexus Makefile include should have only the header
 diff $expected/nmi-header $NEXUS_MK
 
+# So the next update starts "clean"
+./boilerplate/_lib/boilerplate-commit
+
 sub_hdr "Convention with no includes"
 add_convention $repo test/nexus-makefile-include/no-includes
 make boilerplate-update
@@ -60,8 +63,11 @@ check_update $repo
 # Nexus Makefile include should have only the header
 diff $expected/nmi-header $NEXUS_MK
 
-# Clear the config
+# Set up a new repo
+repo=$(empty_repo)
+add_cleanup $repo
 bootstrap_repo $repo
+cd $repo
 
 sub_hdr "Convention with one include"
 convention=test/nexus-makefile-include/one-include
@@ -82,8 +88,11 @@ ensure_nexus_makefile_include $repo
 $make_q one-one > $expected/actual-out
 diff $expected/expected-out $expected/actual-out
 
-# Reset Makefile and config
+# Set up a new repo
+repo=$(empty_repo)
+add_cleanup $repo
 bootstrap_repo $repo
+cd $repo
 
 sub_hdr "Convention with multiple includes"
 convention=test/nexus-makefile-include/multiple-includes
@@ -104,6 +113,7 @@ $make_q mult-one > $expected/actual-out
 diff $expected/expected-out $expected/actual-out
 
 # Reset Makefile and config
+./boilerplate/_lib/boilerplate-commit
 bootstrap_repo $repo
 
 sub_hdr "Multiple conventions"

--- a/test/case/framework/04-update-from-master-and-revert
+++ b/test/case/framework/04-update-from-master-and-revert
@@ -40,6 +40,8 @@ reset_boilerplate_repo
 
 make boilerplate-update || exit $?
 check_update $repo 04-check-new-version-update || exit $?
+# So the next update starts "clean"
+./boilerplate/_lib/boilerplate-commit
 
 override_boilerplate_repo $boilerplate_master || exit $?
 


### PR DESCRIPTION
- Document the "trust and ignore" philosophy that subscribers should adopt when reviewing PRs that include boilerplate updates.
- Secure `freeze-check` so you actually _can_ trust such changes.
- Lay down .gitattributes content such that, if a subscriber decides to suppress boilerplate deltas by default, certain files will still always be shown:
  - Because an attacker could attempt to subvert `freeze-check` by modifying that script or its dependencies, we explicitly exclude those from the hiding-by-default.
  - Because an attacker could try to subvert the hiding by appending entries to .gitattributes, we exclude THAT file from the hiding-by-default as well.

Security is hard.