### PR TITLE
Improve `subscriber report release`

### DIFF
--- a/boilerplate/_lib/release.sh
+++ b/boilerplate/_lib/release.sh
@@ -24,7 +24,7 @@ Failed to determine consumer name"
 #
 # E.g. "master"
 # This will produce something like refs/remotes/origin/master
-DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/upstream/HEAD || git symbolic-ref refs/remotes/origin/HEAD || echo defaulting/to/master)
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/upstream/HEAD 2>/dev/null || git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null || echo defaulting/to/master)
 # Strip off refs/remotes/{upstream|origin}/
 DEFAULT_BRANCH=${DEFAULT_BRANCH##*/}
 [[ -z "$DEFAULT_BRANCH" ]] && err "

--- a/boilerplate/_lib/subscriber-propose-update
+++ b/boilerplate/_lib/subscriber-propose-update
@@ -33,35 +33,17 @@ source $REPO_ROOT/boilerplate/_lib/subscriber.sh
 # Arguments are required
 [[ $# -eq 0 ]] && usage
 
-declare -A to_update
-
-ALL=0
-if [[ $# -eq 1 ]] && [[ "$1" == ALL ]]; then
-    ALL=1
-    shift
-fi
-for subscriber in $(subscriber_list onboarded); do
-    to_update[$subscriber]=$ALL
-done
-
-# Parse specified subscribers
-for a in "$@"; do
-    [[ $a == ALL ]] && err "Can't specify ALL with explicit subscribers"
-
-    [[ -n "${to_update[$a]}" ]] || err "Not an onboarded subscriber: '$a'"
-    if [[ "${to_update[$a]}" -eq 1 ]]; then
-        echo "Ignoring duplicate: '$a'"
-        continue
-    fi
-    to_update[$a]=1
-done
-
 TMPD=$(mktemp -d)
 trap "rm -fr $TMPD" EXIT
 
 propose_update() {
     local subscriber=$1
     local proj=${subscriber#*/}
+
+    if [[ -z "$DRY_RUN" ]]; then
+        echo "DRY RUN: Would propose update for $subscriber"
+        return 0
+    fi
 
     (
         # Clone my fork of the subscriber repo
@@ -93,8 +75,7 @@ propose_update() {
 
 bp_master=$(git rev-parse master)
 
-for subscriber in "${!to_update[@]}"; do
-    [[ "${to_update[$subscriber]}" -eq 1 ]] || continue
+for subscriber in $(subscriber_args "$@"); do
 
     # Does this one need an update?
     lbc=$(last_bp_commit $subscriber)

--- a/boilerplate/_lib/subscriber-report-release
+++ b/boilerplate/_lib/subscriber-report-release
@@ -6,16 +6,25 @@ source $REPO_ROOT/boilerplate/_lib/release.sh
 
 usage() {
     cat <<EOF
-$CMD
+$CMD SUBSCRIBER ...
 
 Analyzes the openshift/release footprint of onboarded boilerplate
 subscribers. For each subscriber, prints the delta, if any, between the
 existing and expected prow configuration.
+
+Arguments:
+    SUBSCRIBER  One or more subscriber repositories of the form
+                "org/name" (e.g. "openshift/deadmanssnitch-operator");
+                or the special keyword "ALL" to report on all onboarded
+                subscribers.
 EOF
     exit -1
 }
 
 source $REPO_ROOT/boilerplate/_lib/subscriber.sh
+
+# Arguments are required
+[[ $# -eq 0 ]] && usage
 
 ## prow_config ORG PROJ
 #
@@ -33,20 +42,21 @@ prow_config() {
         f=$org-$proj-$branch.yaml
         local c="$(curl -s $p/$f)"
         if [[ "$c" != "404: Not Found" ]]; then
-            # Remove the zz_generated_metadata section
-            echo "$c" | yq d - zz_generated_metadata > $TMPD/$f
+            echo "$c" > $TMPD/$f
             echo $TMPD/$f
             return
         fi
     done
 }
 
-## expected_prow_config PROJ
+## expected_prow_config ORG PROJ BRANCH
 #
-# Prints to stdout (most of) the expected prow configuration for the specified
-# PROJ. The `zz_generated_metadata` section is omitted.
+# Prints to stdout the expected prow configuration for the specified
+# ORG/PROJ.
 expected_prow_config() {
-    local consumer_name=$1
+    local org=$1
+    local consumer_name=$2
+    local branch=$3
     # TODO: DRY this with what's in prow-config.
     # Do it by making it a template in the convention dir.
     cat <<EOF
@@ -94,21 +104,28 @@ tests:
   commands: make validate
   container:
     from: src
+zz_generated_metadata:
+  branch: ${branch}
+  org: ${org}
+  repo: ${consumer_name}
 EOF
 }
 
 TMPD=$(mktemp -d)
 trap "rm -fr $TMPD" EXIT
 
-for subscriber in $(subscriber_list onboarded); do
+for subscriber in $(subscriber_args "$@"); do
     banner $subscriber
     org=${subscriber%/*}
     proj=${subscriber#*/}
     pc=$(prow_config $org $proj)
+    # Filename is of the form ...-$branch.yaml
+    branch=${pc##*-}
+    branch=${branch%.yaml}
     if [[ -z "$pc" ]]; then
         echo "=== No configuration ==="
     else
-        d="$(expected_prow_config $proj | diff -w - $pc)"
+        d="$(expected_prow_config $org $proj $branch | diff - $pc)"
         if [[ -z "$d" ]]; then
             echo "=== A-OK ==="
         else


### PR DESCRIPTION
This commit improves the `subscriber report release` tool in the following ways:
- It now requires a list of subscribers, or `ALL`, with the same semantics as `subscriber propose update`.
- It now produces a diff with which you can `patch -R` what's in the release repository to make it conform.