### PR TITLE
Updates the version of the openshift-operator-registry image

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
@@ -56,7 +56,7 @@ EOF
 
 # Build registry
 cat <<EOF > $DOCKERFILE_REGISTRY
-FROM quay.io/openshift/origin-operator-registry:4.7.0
+FROM quay.io/openshift/origin-operator-registry:4.8.0
 COPY $SAAS_OPERATOR_DIR manifests
 RUN initializer --permissive
 CMD ["registry-server", "-t", "/tmp/terminate.log"]


### PR DESCRIPTION
Updates the version of the openshift-operator-registry image to 4.8.0,
to address several high vulnerabilities found in the 4.7.0 image.

Tested by:

1. Pulling the update into a local testing branch of splunk-forwarder-operator
2. Ran the App-SRE pipeline to generate the images
3. Tested these images in a staging cluster using Jason's "Splunk forwarder operator testing and iterating" document

This addresses 5 of the 8 image vulnerabilities identified in the Claire scan.  Unfortunately, the current latest version of openshift-operator-registry (4.9.0) still contains 3 vulnerabilities.  Since the images for that are only a few days old, this PR includes an update to 4.8.0, which has the same set and has been out for a bit longer.

REF: [OSD-6831](https://issues.redhat.com/browse/OSD-6831)

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
