### PR TITLE
allow gitattributes delta

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
@@ -56,7 +56,7 @@ EOF
 
 # Build registry
 cat <<EOF > $DOCKERFILE_REGISTRY
-FROM quay.io/openshift/origin-operator-registry:4.7.0
+FROM quay.io/openshift/origin-operator-registry:4.8.0
 COPY $SAAS_OPERATOR_DIR manifests
 RUN initializer --permissive
 CMD ["registry-server", "-t", "/tmp/terminate.log"]

--- a/boilerplate/update
+++ b/boilerplate/update
@@ -73,12 +73,14 @@ scrubbed_conventions() {
 # This function ignores uncommitted changes to:
 # - Makefile: Editing this file is part of bootstrapping, and we don't
 #   want to force an additional commit in the bootstrapping process.
+# - .gitattributes: This file is created as part of the bootstrapping
+#   process. See above.
 # - ?? boilerplate/: I.e. the boilerplate subdirectory is brand new,
 #   meaning you're bootstrapping. See above.
 # - boilerplate/update.cfg: Changing this file prior to an update is
 #   part of the process of subscribing to new conventions.
 unacceptable_deltas() {
-  ignores="Makefile|boilerplate/(update\.cfg)?"
+  ignores="Makefile|.gitattributes|boilerplate/(update\.cfg)?"
   git status --porcelain | grep -E -v $1 " ($ignores)$"
 }
 


### PR DESCRIPTION
- Updates the version of the openshift-operator-registry image
- Adds .gitattributes to unacceptable_deltas "ignores" list
