### PR TITLE
Adds .gitattributes to unacceptable_deltas "ignores" list

### DIFF
--- a/boilerplate/update
+++ b/boilerplate/update
@@ -73,12 +73,14 @@ scrubbed_conventions() {
 # This function ignores uncommitted changes to:
 # - Makefile: Editing this file is part of bootstrapping, and we don't
 #   want to force an additional commit in the bootstrapping process.
+# - .gitattributes: This file is created as part of the bootstrapping
+#   process. See above.
 # - ?? boilerplate/: I.e. the boilerplate subdirectory is brand new,
 #   meaning you're bootstrapping. See above.
 # - boilerplate/update.cfg: Changing this file prior to an update is
 #   part of the process of subscribing to new conventions.
 unacceptable_deltas() {
-  ignores="Makefile|boilerplate/(update\.cfg)?"
+  ignores="Makefile|.gitattributes|boilerplate/(update\.cfg)?"
   git status --porcelain | grep -E -v $1 " ($ignores)$"
 }
 

--- a/test/case/framework/04-update-from-master-and-revert
+++ b/test/case/framework/04-update-from-master-and-revert
@@ -35,6 +35,8 @@ override_boilerplate_repo $boilerplate_master || exit $?
 add_convention $repo test/test-base-convention
 make boilerplate-update || exit $?
 check_update $repo 04-check-after-init || exit $?
+# So the next update starts "clean"
+./boilerplate/_lib/boilerplate-commit
 
 reset_boilerplate_repo
 


### PR DESCRIPTION
With a recent update to boilerplate, a .gitattributes file is created
during the bootstrap process.  This is causing failures in the
"framework/04-update-from-master-and-revert" test, which currently
doesn't expect the .gitattributes file to exist, uncommitted, after the
test bootstrap.

This adds the .gitattributes file to the "ignores" list in the
unacceptable_deltas function of boilerplate/update.

Also runs `./boilerplate/_lib/boilerplate-commit` to "clean" before the
next test run.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
