### PR TITLE
Fix "unbound variable" error

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
+++ b/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
@@ -49,7 +49,7 @@ function check_required_environment() {
 function setup_temp_dir() {
     local temp_dir
     temp_dir=$(mktemp -d --suffix "-$(basename "$0")")
-    [[ "$DELETE_TEMP_DIR" == "true" ]] && trap 'rm -rf $temp_dir' EXIT
+    [[ "$DELETE_TEMP_DIR" == "true" ]] && trap "rm -rf $temp_dir" EXIT
 
     echo "$temp_dir"
 }


### PR DESCRIPTION
The OPM build still showed

```
boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh: line 1: temp_dir: unbound variable
```

Turns out this was coming from an `EXIT` trap which was deferring interpolation of `$temp_dir` when it should have been doing it right away. Fix.