### PR TITLE
Remove support for operator-sdk 0.15

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/operator-sdk-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator/operator-sdk-generate.sh
@@ -33,7 +33,7 @@ VER=$(osdk_version $OSDK)
 # - When OCP will remove support for v1beta1 (currently we know it's
 # deprecated in 4.6, but don't know when it's actually removed).
 case $VER in
-  'v0.15.1'|'v0.16.0')
+  'v0.16.0')
       # No-op: just declare support for these osdk versions.
       ;;
   'v0.17.0'|'v0.17.1'|'v0.17.2'|'v0.18.2')

--- a/boilerplate/test/test-base-convention/update
+++ b/boilerplate/test/test-base-convention/update
@@ -29,5 +29,5 @@ echo "Validating variables exported from the main update driver"
 # Granny switch to disable this check for weird tests like reverting to master
 if [[ -z "$SKIP_IMAGE_TAG_CHECK" ]]; then
     # Update this when publishing a new image tag
-    [[ "$LATEST_IMAGE_TAG" == "image-v1.0.1" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
+    [[ "$LATEST_IMAGE_TAG" == "image-v2.0.0" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
 fi

--- a/config/build.sh
+++ b/config/build.sh
@@ -5,6 +5,8 @@
 set -x
 set -euo pipefail
 
-echo NOOP
+# We no longer support operator-sdk < 0.16. Remove binaries to save
+# space.
+rm -f /usr/local/bin/operator-sdk-v0.15.1-x86_64-linux-gnu
 
 exit 0

--- a/test/case/convention/openshift/golang-osd-operator/01-generated-files-checker
+++ b/test/case/convention/openshift/golang-osd-operator/01-generated-files-checker
@@ -6,7 +6,7 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 
 source $REPO_ROOT/test/lib.sh
 
-for version in v0.15.1 v0.16.0 v0.17.0 v0.17.1 v0.17.2 v0.18.2; do
+for version in v0.16.0 v0.17.0 v0.17.1 v0.17.2 v0.18.2; do
     echo "Testing with operator-sdk ${version}"
     repo=$(empty_repo)
     add_cleanup $repo

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -3,7 +3,7 @@ if [ "$BOILERPLATE_SET_X" ]; then
 fi
 
 # NOTE: Change this when publishing a new image tag.
-LATEST_IMAGE_TAG=image-v1.0.1
+LATEST_IMAGE_TAG=image-v2.0.0
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 # Make all tests use this local clone by default.


### PR DESCRIPTION
All registered subscribers are at operator-sdk 0.16+, so remove 0.15.1 from the build image, tooling, and tests.