### PR TITLE
image-v2.0.1: Ratchet base to image-v2.0.0

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@
 build_root_image:
   namespace: openshift
   name: boilerplate
-  tag: image-v1.0.0
+  tag: image-v2.0.0

--- a/boilerplate/test/test-base-convention/update
+++ b/boilerplate/test/test-base-convention/update
@@ -29,5 +29,5 @@ echo "Validating variables exported from the main update driver"
 # Granny switch to disable this check for weird tests like reverting to master
 if [[ -z "$SKIP_IMAGE_TAG_CHECK" ]]; then
     # Update this when publishing a new image tag
-    [[ "$LATEST_IMAGE_TAG" == "image-v2.0.0" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
+    [[ "$LATEST_IMAGE_TAG" == "image-v2.0.1" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
 fi

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,9 +1,5 @@
 # NOTE: Keep this in sync with .ci-operator.yaml
-# TODO: Ratchet this up to start FROM boilerplate:image-v2.0.0
-FROM registry.ci.openshift.org/openshift/release:golang-1.16
-
-COPY build_image-v2.0.0.sh /build.sh
-RUN /build.sh && rm -f /build.sh
+FROM registry.ci.openshift.org/openshift/boilerplate:image-v2.0.0
 
 COPY build.sh /build.sh
 RUN /build.sh && rm -f /build.sh

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -3,7 +3,7 @@ if [ "$BOILERPLATE_SET_X" ]; then
 fi
 
 # NOTE: Change this when publishing a new image tag.
-LATEST_IMAGE_TAG=image-v2.0.0
+LATEST_IMAGE_TAG=image-v2.0.1
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 # Make all tests use this local clone by default.


### PR DESCRIPTION
To speed up boilerplate CI, ratchet prow's Dockerfile to build FROM `image-v2.0.0`.