### PR TITLE
image-v2.1.0: add `gh`

### DIFF
--- a/boilerplate/test/test-base-convention/update
+++ b/boilerplate/test/test-base-convention/update
@@ -29,5 +29,5 @@ echo "Validating variables exported from the main update driver"
 # Granny switch to disable this check for weird tests like reverting to master
 if [[ -z "$SKIP_IMAGE_TAG_CHECK" ]]; then
     # Update this when publishing a new image tag
-    [[ "$LATEST_IMAGE_TAG" == "image-v2.0.1" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
+    [[ "$LATEST_IMAGE_TAG" == "image-v2.1.0" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
 fi

--- a/config/build.sh
+++ b/config/build.sh
@@ -5,6 +5,16 @@
 set -x
 set -euo pipefail
 
-echo NOOP
+####
+# gh
+####
+GH_VERSION=1.10.3
+GH_SHA256SUM="257c5bf641d85606337bc91c6507066a21ba6c849be50231b768fe2fd07517ea"
+GH_LOCATION=https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz
+
+curl -L -o /tmp/gh.tgz $GH_LOCATION
+echo ${GH_SHA256SUM} /tmp/gh.tgz | sha256sum -c
+tar -xvzf /tmp/gh.tgz gh_${GH_VERSION}_linux_amd64/bin/gh
+mv gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin
 
 exit 0

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -3,7 +3,7 @@ if [ "$BOILERPLATE_SET_X" ]; then
 fi
 
 # NOTE: Change this when publishing a new image tag.
-LATEST_IMAGE_TAG=image-v2.0.1
+LATEST_IMAGE_TAG=image-v2.1.0
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 # Make all tests use this local clone by default.


### PR DESCRIPTION
Add the `gh` (GitHub CLI) executable to the backing image so CICD jobs can do consumer reports.

Part of [OSD-5962](https://issues.redhat.com/browse/OSD-5962)