### PR TITLE
enable make generate locally

### DIFF
--- a/boilerplate/_lib/container-make
+++ b/boilerplate/_lib/container-make
@@ -22,9 +22,9 @@ CONTAINER_MOUNT=/go/src/$(repo_import $REPO_ROOT)
 # First set up a detached container with the repo mounted.
 banner "Starting the container"
 if [[ $CONTAINER_ENGINE_SHORT == "podman" ]]; then
-		container_id=$($CONTAINER_ENGINE run --userns keep-id -d -v "$REPO_ROOT":"$CONTAINER_MOUNT":Z $IMAGE_PULL_PATH tail -f /dev/null)
+		container_id=$($CONTAINER_ENGINE run --userns keep-id -d -v "$REPO_ROOT":"$CONTAINER_MOUNT":Z $IMAGE_PULL_PATH sleep 900)
 else
-		container_id=$($CONTAINER_ENGINE run -d -v "$REPO_ROOT":"$CONTAINER_MOUNT" $IMAGE_PULL_PATH tail -f /dev/null)
+		container_id=$($CONTAINER_ENGINE run -d -v "$REPO_ROOT":"$CONTAINER_MOUNT" $IMAGE_PULL_PATH sleep 900)
 fi
 
 if [[ $? -ne 0 ]] || [[ -z "$container_id" ]]; then

--- a/boilerplate/_lib/container-make
+++ b/boilerplate/_lib/container-make
@@ -22,7 +22,7 @@ CONTAINER_MOUNT=/go/src/$(repo_import $REPO_ROOT)
 # First set up a detached container with the repo mounted.
 banner "Starting the container"
 if [[ $CONTAINER_ENGINE_SHORT == "podman" ]]; then
-		container_id=$($CONTAINER_ENGINE run --userns keep-id -d -v "$REPO_ROOT":"$CONTAINER_MOUNT":Z $IMAGE_PULL_PATH sleep 900)
+		container_id=$($CONTAINER_ENGINE run --userns keep-id -d -v "$REPO_ROOT":"$CONTAINER_MOUNT":Z $IMAGE_PULL_PATH sleep infinity)
 else
 		container_id=$($CONTAINER_ENGINE run -d -v "$REPO_ROOT":"$CONTAINER_MOUNT" $IMAGE_PULL_PATH sleep 900)
 fi

--- a/boilerplate/_lib/container-make
+++ b/boilerplate/_lib/container-make
@@ -24,7 +24,7 @@ banner "Starting the container"
 if [[ $CONTAINER_ENGINE_SHORT == "podman" ]]; then
 		container_id=$($CONTAINER_ENGINE run --userns keep-id -d -v "$REPO_ROOT":"$CONTAINER_MOUNT":Z $IMAGE_PULL_PATH sleep infinity)
 else
-		container_id=$($CONTAINER_ENGINE run -d -v "$REPO_ROOT":"$CONTAINER_MOUNT" $IMAGE_PULL_PATH sleep 900)
+		container_id=$($CONTAINER_ENGINE run -d -v "$REPO_ROOT":"$CONTAINER_MOUNT" $IMAGE_PULL_PATH sleep infinity)
 fi
 
 if [[ $? -ne 0 ]] || [[ -z "$container_id" ]]; then


### PR DESCRIPTION
After upgrading to F34, I can no longer run ` ./boilerplate/_lib/container-make generate` locally. Something has changed in either podman, conmon or other container mgmt services thar no longer accepts the use of `tail -f /dev/null` to maintain and active build container. 

`sleep 900` resolves this. Why 900? its a presumption that something else will timeout in 15 minutes and this cmd would not be responsible for killing the conainer..

```
$cat /etc/fedora-release                                                                                      
Fedora release 34 (Thirty Four)
$ podman version 
Version:      3.1.2
API Version:  3.1.2
Go Version:   go1.16.3
Built:        Thu May 13 05:27:59 2021
OS/Arch:      linux/amd64
$ conmon --version      
conmon version 2.0.27
```

result

```
./boilerplate/_lib/container-make generate                                                                    ✔  10  

==============================
Starting the container
==============================

==============================
Running: make generate
==============================
Error: can only create exec sessions on running containers: container state improper

==============================
The 'make' command failed! Starting a shell in the container for debugging. Just 'exit' when done.
==============================
Error: can only create exec sessions on running containers: container state improper

==============================
Cleaning up the container
==============================
```

```
journalctl
Jun 02 19:43:34 redhat.home podman[21994]: 2021-06-02 19:43:34.794474001 +1000 AEST m=+0.049662175 container died 6cac167a2000a89ca5ac9ea1e25bd311df3c61bae734d1d41d198ec1d3a2e742 (image=quay.io/app-sre/boilerplate:image-v1.0.0, name=exciting_ramanujan)
Jun 02 19:43:34 redhat.home podman[21994]: 2021-06-02 19:43:34.809529572 +1000 AEST m=+0.064717741 container cleanup 6cac167a2000a89ca5ac9ea1e25bd311df3c61bae734d1d41d198ec1d3a2e742 (image=quay.io/app-sre/boilerplate:image-v1.0.0, name=exciting_ramanujan, io.openshift.build.commit.id=1020beaa095238c72350142b9ad351b5b6a82e42, io.openshift.build.source-location=https://github.com/openshift/release.git, io.k8s.display-name=OpenShift Origin Release Environment (golang-1.16), org.label-schema.schema-version=1.0, io.k8s.description=This is the standard release image for OpenShift Origin and contains the necessary build tools to build the platform., org.label-schema.vendor=CentOS, org.label-schema.build-date=20201113, org.opencontainers.image.title=CentOS Base Image, org.opencontainers.image.created=2020-11-13 00:00:00+00:00, io.openshift.build.source-context-dir=clusters/build-clusters/01_cluster/ci/_origin-release-build/golang-1.16, io.buildah.version=1.16.4, io.openshift.build.name=origin-release-golang-1.16-4, io.openshift.build.commit.ref=master, org.label-schema.license=GPLv2, io.openshift.build.namespace=ci, io.openshift.build.commit.date=Wed Feb 17 13:39:45 2021 -0500, org.opencontainers.image.vendor=CentOS, io.openshift.build.commit.author=OpenShift Merge Robot <openshift-merge-robot@users.noreply.github.com>, io.openshift.build.commit.message=Merge pull request #15968 from hongkailiu/g_loki, org.opencontainers.image.licenses=GPL-2.0-only, org.label-schema.name=CentOS Base Image)
```