### PR TITLE
podman enablement

### DIFF
--- a/boilerplate/_lib/container-make
+++ b/boilerplate/_lib/container-make
@@ -12,8 +12,6 @@ source ${0%/*}/common.sh
 CONTAINER_ENGINE=$(command -v podman || command -v docker)
 [[ -n "$CONTAINER_ENGINE" ]] || err "Couldn't find a container engine. Are you already in a container?"
 
-CONTAINER_ENGINE_SHORT=${CONTAINER_ENGINE##*/}
-
 # Make sure the mount inside the container is named in such a way that
 # - openapi-gen (which relies on GOPATH) produces absolute paths; and
 # - other go-ish paths are writeable, e.g. for `go mod download`.
@@ -21,11 +19,12 @@ CONTAINER_MOUNT=/go/src/$(repo_import $REPO_ROOT)
 
 # First set up a detached container with the repo mounted.
 banner "Starting the container"
-if [[ $CONTAINER_ENGINE_SHORT == "podman" ]]; then
-		container_id=$($CONTAINER_ENGINE run --userns keep-id -d -v "$REPO_ROOT":"$CONTAINER_MOUNT":Z $IMAGE_PULL_PATH sleep infinity)
+if [[ "${CONTAINER_ENGINE##*/}" == "podman" ]]; then
+    CE_OPTS="--userns keep-id -v $REPO_ROOT:$CONTAINER_MOUNT:Z"
 else
-		container_id=$($CONTAINER_ENGINE run -d -v "$REPO_ROOT":"$CONTAINER_MOUNT" $IMAGE_PULL_PATH sleep infinity)
+    CE_OPTS="-v $REPO_ROOT:$CONTAINER_MOUNT"
 fi
+container_id=$($CONTAINER_ENGINE run -d ${CE_OPTS} $IMAGE_PULL_PATH sleep infinity)
 
 if [[ $? -ne 0 ]] || [[ -z "$container_id" ]]; then
   err "Couldn't start detached container"

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
@@ -23,6 +23,13 @@ while getopts "o:c:r:" option; do
     esac
 done
 
+# Detect the container engine to use, allowing override from the env
+CONTAINER_ENGINE=${CONTAINER_ENGINE:-$(command -v podman || command -v docker || true)}
+if [[ -z "$CONTAINER_ENGINE" ]]; then
+    echo "WARNING: Couldn't find a container engine! Defaulting to docker."
+    CONTAINER_ENGINE=docker
+fi
+
 # Checking parameters
 check_mandatory_params operator_channel operator_name
 
@@ -62,7 +69,7 @@ RUN initializer --permissive
 CMD ["registry-server", "-t", "/tmp/terminate.log"]
 EOF
 
-docker build -f $DOCKERFILE_REGISTRY --tag "${registry_image}:${operator_channel}-latest" .
+${CONTAINER_ENGINE} build -f $DOCKERFILE_REGISTRY --tag "${registry_image}:${operator_channel}-latest" .
 
 if [ $? -ne 0 ] ; then
     echo "docker build failed, exiting..."

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-publish.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-publish.sh
@@ -41,6 +41,17 @@ BUNDLE_DIR="${SAAS_OPERATOR_DIR}/${operator_name}"
 OPERATOR_NEW_VERSION=$(ls "${BUNDLE_DIR}" | sort -t . -k 3 -g | tail -n 1)
 OPERATOR_PREV_VERSION=$(ls "${BUNDLE_DIR}" | sort -t . -k 3 -g | tail -n 2 | head -n 1)
 
+# Get container engine
+CONTAINER_ENGINE=$(command -v podman || command -v docker || true)
+[[ -n "$CONTAINER_ENGINE" ]] || echo "WARNING: Couldn't find a container engine. Assuming you already in a container, running unit tests." >&2
+
+# Set SRC container transport based on container engine
+if [[ "${CONTAINER_ENGINE##*/}" == "podman" ]]; then
+    SRC_CONTAINER_TRANSPORT="containers-storage"
+else
+    SRC_CONTAINER_TRANSPORT="docker-daemon"
+fi
+
 # Checking SAAS_OPERATOR_DIR exist
 if [ ! -d "${SAAS_OPERATOR_DIR}/.git" ] ; then
     echo "${SAAS_OPERATOR_DIR} should exist and be a git repository"
@@ -85,7 +96,7 @@ popd
 if [ "$push_catalog" = true ] ; then
     # push image
     skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-        "docker-daemon:${registry_image}:${operator_channel}-latest" \
+        "${SRC_CONTAINER_TRANSPORT}:${registry_image}:${operator_channel}-latest" \
         "docker://${registry_image}:${operator_channel}-latest"
 
     if [ $? -ne 0 ] ; then
@@ -94,7 +105,7 @@ if [ "$push_catalog" = true ] ; then
     fi
 
     skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-        "docker-daemon:${registry_image}:${operator_channel}-latest" \
+        "${SRC_CONTAINER_TRANSPORT}:${registry_image}:${operator_channel}-latest" \
         "docker://${registry_image}:${operator_channel}-${operator_commit_hash}"
 
     if [ $? -ne 0 ] ; then

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
@@ -182,7 +182,12 @@ if [[ "$generate_script" = "common" ]] ; then
     if [[ -z "$CONTAINER_ENGINE" ]]; then
         ./boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py -o ${operator_name} -d ${OUTPUT_DIR} -p ${OPERATOR_PREV_VERSION} -i ${REPO_DIGEST} -V ${operator_version}
     else
-        $CONTAINER_ENGINE run --rm -v `pwd`:`pwd` -u `id -u`:0 -w `pwd` registry.access.redhat.com/ubi8/python-36:1-134 /bin/bash -c "python -m pip install oyaml; python ./boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py -o ${operator_name} -d ${OUTPUT_DIR} -p ${OPERATOR_PREV_VERSION} -i ${REPO_DIGEST} -V ${operator_version}"
+        if [[ ${CONTAINER_ENGINE##*/} == "podman" ]]; then
+            CE_OPTS="--userns keep-id -v `pwd`:`pwd`:Z"
+        else
+            CE_OPTS="-v `pwd`:`pwd`"
+        fi
+        $CONTAINER_ENGINE run --rm ${CE_OPTS} -u `id -u`:0 -w `pwd` registry.access.redhat.com/ubi8/python-36:1-134 /bin/bash -c "python -m pip install oyaml; python ./boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py -o ${operator_name} -d ${OUTPUT_DIR} -p ${OPERATOR_PREV_VERSION} -i ${REPO_DIGEST} -V ${operator_version}"
     fi
 elif [[ "$generate_script" = "hack" ]] ; then
     if [ -z "$OPERATOR_PREV_VERSION" ] ; then

--- a/boilerplate/test/test-base-convention/golint.sh
+++ b/boilerplate/test/test-base-convention/golint.sh
@@ -26,7 +26,7 @@ Exits zero if files are clean; nonzero if discrepancies are found.
 OPTIONS
     -f, --fix
         Fixes the problems it finds. (Don't forget to commit the
-	changes.)
+        changes.)
 
 TARGETS:
 $targets
@@ -49,12 +49,12 @@ eval set -- "$OPTS"
 FIX=
 while true; do
     case "$1" in
-	-f | --fix )
-	    FIX=1
-	    shift
-	    ;;
+        -f | --fix )
+            FIX=1
+            shift
+            ;;
         -h | --help ) usage;;
-	-- ) shift; break ;;
+        -- ) shift; break ;;
     esac
 done
 

--- a/boilerplate/test/test-base-convention/standard.mk
+++ b/boilerplate/test/test-base-convention/standard.mk
@@ -55,13 +55,13 @@ isclean:
 
 .PHONY: build
 build: isclean envtest
-	docker build . -f $(OPERATOR_DOCKERFILE) -t $(OPERATOR_IMAGE_URI)
-	docker tag $(OPERATOR_IMAGE_URI) $(OPERATOR_IMAGE_URI_LATEST)
+	${CONTAINER_ENGINE} build . -f $(OPERATOR_DOCKERFILE) -t $(OPERATOR_IMAGE_URI)
+	${CONTAINER_ENGINE} tag $(OPERATOR_IMAGE_URI) $(OPERATOR_IMAGE_URI_LATEST)
 
 .PHONY: push
 push:
-	docker push $(OPERATOR_IMAGE_URI)
-	docker push $(OPERATOR_IMAGE_URI_LATEST)
+	${CONTAINER_ENGINE} push $(OPERATOR_IMAGE_URI)
+	${CONTAINER_ENGINE} push $(OPERATOR_IMAGE_URI_LATEST)
 
 # These names are used by the app-sre pipeline targets
 .PHONY: docker-build

--- a/boilerplate/test/test-base-convention/test-sub-dir/standard.mk
+++ b/boilerplate/test/test-base-convention/test-sub-dir/standard.mk
@@ -55,13 +55,13 @@ isclean:
 
 .PHONY: build
 build: isclean envtest
-	docker build . -f $(OPERATOR_DOCKERFILE) -t $(OPERATOR_IMAGE_URI)
-	docker tag $(OPERATOR_IMAGE_URI) $(OPERATOR_IMAGE_URI_LATEST)
+	${CONTAINER_ENGINE} build . -f $(OPERATOR_DOCKERFILE) -t $(OPERATOR_IMAGE_URI)
+	${CONTAINER_ENGINE} tag $(OPERATOR_IMAGE_URI) $(OPERATOR_IMAGE_URI_LATEST)
 
 .PHONY: push
 push:
-	docker push $(OPERATOR_IMAGE_URI)
-	docker push $(OPERATOR_IMAGE_URI_LATEST)
+	${CONTAINER_ENGINE} push $(OPERATOR_IMAGE_URI)
+	${CONTAINER_ENGINE} push $(OPERATOR_IMAGE_URI_LATEST)
 
 # These names are used by the app-sre pipeline targets
 .PHONY: docker-build

--- a/test/case/framework/01-bootstrap-update
+++ b/test/case/framework/01-bootstrap-update
@@ -18,7 +18,7 @@ make boilerplate-update
 check_update $repo 01-no-convention
 
 if [ $? -ne 0 ] ; then
-	exit $?
+    exit $?
 fi
 
 # So the next update starts "clean"


### PR DESCRIPTION
- Podman and docker use different mechanisms to override the default path to the credentials cache. Accommodate both.
- Podman and docker use different transport prefixes to reference locally built images via skopeo. Accommodate both.
- Expand addition of `--userns keep-id` and `-v ...:Z` to more places.
- Resolve [OSD-6941](https://issues.redhat.com/browse/OSD-6941) by detecting the container engine in catalog-build.sh.

Co-Authored-By: @dofinn