### PR TITLE
Update operator-registry base image to 4.9.0

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
@@ -63,7 +63,7 @@ EOF
 
 # Build registry
 cat <<EOF > $DOCKERFILE_REGISTRY
-FROM quay.io/openshift/origin-operator-registry:4.8.0
+FROM quay.io/openshift/origin-operator-registry:4.9.0
 COPY $SAAS_OPERATOR_DIR manifests
 RUN initializer --permissive
 CMD ["registry-server", "-t", "/tmp/terminate.log"]


### PR DESCRIPTION
This updates the operator-registry base image from 4.8.0 to 4.9.0.

https://issues.redhat.com/browse/OSD-8587