### PR TITLE
Add Pull Option to Docker Build Command

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
@@ -69,7 +69,7 @@ RUN initializer --permissive
 CMD ["registry-server", "-t", "/tmp/terminate.log"]
 EOF
 
-${CONTAINER_ENGINE} build -f $DOCKERFILE_REGISTRY --tag "${registry_image}:${operator_channel}-latest" .
+${CONTAINER_ENGINE} build --pull -f $DOCKERFILE_REGISTRY --tag "${registry_image}:${operator_channel}-latest" .
 
 if [ $? -ne 0 ] ; then
     echo "docker build failed, exiting..."


### PR DESCRIPTION
This ensures we always pull the base image during the build process to get security fixes.