### PR TITLE
Add OPERATOR_IMAGE as an env var for OSD operators

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py
@@ -318,6 +318,17 @@ if 'Role' in by_kind:
 deploy = by_kind['Deployment'][0]
 # Use the operator image pull spec we were passed
 deploy['spec']['template']['spec']['containers'][0]['image'] = operator_image
+# Add or replace OPERATOR_IMAGE env var
+env = deploy['spec']['template']['spec']['containers'][0]['env']
+# Does OPERATOR_IMAGE key already exist in spec? If so, update value
+for entry in env:
+    if entry['name'] == 'OPERATOR_IMAGE':
+        entry['value'] = operator_image
+        break
+# If not, add it
+else:
+    env.append(dict(name='OPERATOR_IMAGE', value=operator_image))
+
 csv['spec']['install']['spec']['deployments'] = [
     {
         'name': deploy['metadata']['name'],

--- a/test/projects/file-generate/hack/generate-operator-bundle.py
+++ b/test/projects/file-generate/hack/generate-operator-bundle.py
@@ -102,6 +102,7 @@ with open('deploy/operator.yaml', 'r') as stream:
 
 # Update the deployment to use the defined image:
 csv['spec']['install']['spec']['deployments'][0]['spec']['template']['spec']['containers'][0]['image'] = operator_image
+csv['spec']['install']['spec']['deployments'][0]['spec']['template']['spec']['containers'][0]['env'].append(dict(name='OPERATOR_IMAGE', value=operator_image))
 
 # Update the versions to include git hash:
 csv['metadata']['name'] = "{}.v{}".format(operator_name, full_version)


### PR DESCRIPTION
Sometimes an operator needs to create a pod (e.g. via a Job) that invokes (a different code path in) the operator binary. With this PR the operator can easily discover the exact image that invoked it and avoid version drift.