### PR TITLE
App-SRE testing docs should suggest to rebase saas fork

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/app-sre.md
+++ b/boilerplate/openshift/golang-osd-operator/app-sre.md
@@ -21,6 +21,17 @@ If not, you will need to set the `IMAGE_REGISTRY` environment variable (see [bel
 The SaaS bundle repository for `$OPERATOR_NAME` should be located at `https://gitlab.cee.redhat.com/service/saas-{operator}-bundle`, e.g. https://gitlab.cee.redhat.com/service/saas-deadmanssnitch-operator-bundle.
 Fork it to your personal namespace.
 
+If you have already forked it to your personal namespace and/or used your fork for testing app-sre scripts at some time in the past, it is recommended that you bring your fork in sync with how upstream appears, or else the catalog you test with may not work correctly when deployed.
+
+An example of how to do this for the `staging` branch is below (`production` steps are the same):
+
+```
+git checkout staging
+git pull upstream staging
+git reset --hard upstream/staging                
+git push origin staging --force                                                                            
+```
+
 ## Set environment variables
 ```bash
 # The process creates artifacts in your git clone. Some of the make targets


### PR DESCRIPTION
This PR amends the "testing app-sre" documentation to recommend that the personal `saas-<operator>-bundle` fork be rebased off upstream if it already exists. Not doing this step has occasionally caused me issues with a badly operating catalog when I've previously polluted my fork's staging/production branches from prior tests.
