### PR TITLE
feat(golangci): add gosec

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/golangci.yml
+++ b/boilerplate/openshift/golang-osd-operator/golangci.yml
@@ -18,6 +18,7 @@ linters:
   enable:
   - deadcode
   - errcheck
+  - gosec
   - gosimple
   - govet
   - ineffassign


### PR DESCRIPTION
per ticket  OSD-10161, this change should be running via CI on all osd operators.

this way we are always compliant to the gosec (as we have done one audit a forever ago and cleaned issues

this change should get approval before merging as this might cause initial work to upgrade to this version of boilerplate