### PR TITLE
make target for fips on osd operators

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/README.md
+++ b/boilerplate/openshift/golang-osd-operator/README.md
@@ -104,3 +104,22 @@ Checks consist of:
 * `openapi-gen`. This is a no-op if your operator has no APIs.
 * `go generate`. This is a no-op if you have no `//go:generate`
   directives in your code.
+
+## FIPS (Federal Information Processing Standards)
+
+To enable FIPS in your build there is a `make ensure-fips` target.
+
+Add `FIPS_ENABLED=true` to your repos Makefile. Please ensure that this variable is added **before** including boilerplate Makefiles.
+
+e.g.
+```.mk
+FIPS_ENABLED=true
+
+include boilerplate/generated-includes.mk
+```
+
+`ensure-fips` will add a [fips.go](./fips.go) file in the same directory as the `main.go` file. (Please commit this file as normal)
+
+`fips.go` will import the necessary packages to restrict all TLS configuration to FIPS-approved settings.
+
+With `FIPS_ENABLED=true`, `ensure-fips` is always run before `make go-build`

--- a/boilerplate/openshift/golang-osd-operator/configure-fips.sh
+++ b/boilerplate/openshift/golang-osd-operator/configure-fips.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+CONVENTION_DIR="$REPO_ROOT/boilerplate/openshift/golang-osd-operator"
+PRE_V1_SDK_MANAGER_DIR="$REPO_ROOT/cmd/manager"
+
+if [[ -d "$PRE_V1_SDK_MANAGER_DIR" ]]
+then
+  MAIN_DIR=$PRE_V1_SDK_MANAGER_DIR
+else
+  MAIN_DIR=$REPO_ROOT
+fi
+
+echo "Writing fips file at $MAIN_DIR/fips.go"
+
+cp $CONVENTION_DIR/fips.go "$MAIN_DIR/fips.go"

--- a/boilerplate/openshift/golang-osd-operator/fips.go
+++ b/boilerplate/openshift/golang-osd-operator/fips.go
@@ -1,0 +1,15 @@
+// +build fips_enabled
+
+// BOILERPLATE GENERATED -- DO NOT EDIT
+// Run 'make ensure-fips' to regenerate
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+	"fmt"
+)
+
+func init() {
+	fmt.Println("***** Starting with FIPS crypto enabled *****")
+}


### PR DESCRIPTION
boilerplate support FIPS build

Jira: https://issues.redhat.com/browse/OSD-10744

- Adding a new flag to pass a fips build flag to operator builds
- new make target to create a standardised go file to import and enable fips when that build flag is used and ensure dockerfiles have the new flag set

Building on https://github.com/openshift/boilerplate/pull/204 which added the fips go toolset