### PR TITLE
USER 1001 doesn't have pip install permissions + updating pip

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
@@ -65,7 +65,9 @@ EOF
 cat <<EOF > $DOCKERFILE_REGISTRY
 FROM quay.io/openshift/origin-operator-registry:4.8.0
 COPY $SAAS_OPERATOR_DIR manifests
-RUN pip3 install urllib3==1.26.9
+USER 0
+RUN pip3 install urllib3==1.26.9 pip==21.3.1
+USER 1001
 RUN initializer --permissive
 CMD ["registry-server", "-t", "/tmp/terminate.log"]
 EOF


### PR DESCRIPTION
- USER 1001 from the base image (quay.io/openshift/origin-operator-registry:4.8.0) doesn't have the permission to run pip install
- Updating pip to satisfy the next vulnerability