### PR TITLE
OSD-10311 Unexport GOFLAGS to fix bug when using container-make

### DIFF
--- a/boilerplate/openshift/golang-lint/standard.mk
+++ b/boilerplate/openshift/golang-lint/standard.mk
@@ -1,3 +1,6 @@
+# Defaults to -mod=vendor in the boilerplate image
+unexport GOFLAGS
+
 # GOLANGCI_LINT_CACHE needs to be set to a directory which is writeable
 # Relevant issue - https://github.com/golangci/golangci-lint/issues/734
 GOLANGCI_LINT_CACHE ?= /tmp/golangci-cache


### PR DESCRIPTION
See last comment in the story for more context, but essentially the boilerplate images (tested latest two, quay.io/app-sre/boilerplate:image-v2.1.0 and v2.2.0) have an environment variable `GOFLAGS=-mod=vendor`, while to my knowledge we don't typically vendor dependencies.

This was tripping up golangci-lint and this approach to `unexport GOFLAGS` is what existing conventions do (golang-osd-operator/golang-codecov), so went with this, but another approach would be to allow for a `--modules-download-mode=readonly` flag passed to the golangci-lint invocation.