### PR TITLE
OSD-11082 Add `make prow-config` to osd-container-image

### DIFF
--- a/boilerplate/openshift/osd-container-image/.ci-operator.yaml
+++ b/boilerplate/openshift/osd-container-image/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: __NAME__
+  namespace: __NAMESPACE__
+  tag: __TAG__

--- a/boilerplate/openshift/osd-container-image/README.md
+++ b/boilerplate/openshift/osd-container-image/README.md
@@ -25,6 +25,7 @@ endef
 | `make osd-container-image-push` | Push the default container. |
 | `make osd-container-image-build-push` | Build and push the default container and `ADDITIONAL_IMAGE_SPECS`. Meant to be run by app-interface. |
 | `make isclean` | Ensure the local git checkout is clean. |
+| `make prow-config` | Updates the corresponding Prow config file in [openshift/release](https://github.com/openshift/release) to run `make test` on merge requests. This `test` make target should be defined by the consumer. If this is a new repository it should be onboarded to openshift/release first before this is run. |
 
 ## Linting/Testing
 

--- a/boilerplate/openshift/osd-container-image/prow-config
+++ b/boilerplate/openshift/osd-container-image/prow-config
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+source $REPO_ROOT/boilerplate/_lib/common.sh
+source $REPO_ROOT/boilerplate/_lib/release.sh
+
+cmd=${0##*/}
+
+usage() {
+    cat <<EOF
+Usage: $cmd [PATH_TO_RELEASE_CLONE]
+
+Creates a delta in $RELEASE_REPO standardizing prow configuration for a
+boilerplate consumer. Must be invoked from within a local clone of a repository
+already subscribed to the $CONVENTION_NAME convention.
+
+Parameters:
+    PATH_TO_RELEASE_CLONE   File system path to a local clone of
+                            https://github.com/$RELEASE_REPO. If not
+                            specified, the repository will be cloned in a
+                            temporary directory.
+EOF
+    exit -1
+}
+
+# Was a release repo clone specified?
+release_process_args "$@"
+
+release_validate_invocation
+
+release_prep_clone
+
+cd $RELEASE_CLONE
+release_branch=$CONSUMER_ORG-$CONSUMER_NAME-$DEFAULT_BRANCH-boilerplate-$cmd
+config_dir=ci-operator/config/${CONSUMER_ORG}/${CONSUMER_NAME}
+config=${CONSUMER_ORG}-${CONSUMER_NAME}-${DEFAULT_BRANCH}.yaml
+[[ -f $config_dir/$config ]] || err "
+$RELEASE_REPO bootstrapping is not fully supported! Recommend running 'make new-repo' first!
+To circumvent this warning (not recommended), run:
+
+git -C $RELEASE_CLONE checkout -b $release_branch
+mkdir -p $RELEASE_CLONE/$config_dir
+touch $RELEASE_CLONE/$config_dir/$config
+git -C $RELEASE_CLONE add $config_dir/$config
+git -C $RELEASE_CLONE commit
+$0 $RELEASE_CLONE"
+
+# If we get here, the config file exists. Replace it.
+# TODO: Edit it instead, replacing only the relevant sections. This would allow
+# the consumer to preserve any additional checks they want in prow.
+cat <<EOF > $config_dir/$config
+build_root:
+  from_repository: true
+images:
+- dockerfile_path: build/Dockerfile
+  to: unused
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: test
+  commands: make test
+  container:
+    from: src
+zz_generated_metadata:
+  branch: ${DEFAULT_BRANCH}
+  org: ${CONSUMER_ORG}
+  repo: ${CONSUMER_NAME}
+EOF
+
+make jobs
+
+release_done_msg $release_branch

--- a/boilerplate/openshift/osd-container-image/standard.mk
+++ b/boilerplate/openshift/osd-container-image/standard.mk
@@ -81,6 +81,11 @@ osd-container-image-build: isclean
 osd-container-image-push: osd-container-image-login osd-container-image-build
 	${CONTAINER_ENGINE} push ${IMAGE_URI}
 
+.PHONY: prow-config
+prow-config:
+	${CONVENTION_DIR}/prow-config ${RELEASE_CLONE}
+
+
 #########################
 # Targets used by app-sre
 #########################

--- a/boilerplate/openshift/osd-container-image/update
+++ b/boilerplate/openshift/osd-container-image/update
@@ -2,14 +2,19 @@
 
 set -e
 
-# Functions in common are currently unneeded
-# source $CONVENTION_ROOT/_lib/common.sh
+source $CONVENTION_ROOT/_lib/common.sh
 
 # No PRE
 [[ "$1" == "PRE" ]] && exit 0
 
 # Expect POST
 [[ "$1" == "POST" ]] || err "Got a parameter I don't understand: '$1'. Did the infrastructure change?"
+
+echo "Writing .ci-operator.yaml in your repository root with:"
+echo "    namespace: $IMAGE_NAMESPACE"
+echo "    name: $IMAGE_NAME"
+echo "    tag: $LATEST_IMAGE_TAG"
+${SED?} "s/__NAMESPACE__/$IMAGE_NAMESPACE/; s/__NAME__/$IMAGE_NAME/; s/__TAG__/$LATEST_IMAGE_TAG/" ${HERE}/.ci-operator.yaml > $REPO_ROOT/.ci-operator.yaml
 
 cat <<EOF
 
@@ -25,6 +30,8 @@ include boilerplate/generated-includes.mk
   boilerplate.)
 
 - Delete any obsolete files you're no longer including.
+
+- Define a `make test` target for Prow
 
 - Have a Dockerfile in ./build/Dockerfile and define IMAGE_NAME for it.
   Others container images can be specified with ADDITIONAL_IMAGE_SPECS


### PR DESCRIPTION
* It's not "smart" about templating out the prow job configuration and just overwrites it wholesale (smart templating perhaps to come in [OSD-10468](https://issues.redhat.com/browse/OSD-10468))
* Expects consumers to define a `make test` target for prow to run on MR checks - holding off on including linting/coverage for [OSD-10468](https://issues.redhat.com//browse/OSD-10468) again as the hope would be to just consume them and assemble a combined prow config.
* Updated README/update accordingly with directions

Tested this by having osd-cluster-ready pull from my personal fork's boilerplate