### PR TITLE
Rebuild registry image from 4.10.0 into a ubi-micro image

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
@@ -71,6 +71,7 @@ FROM registry.access.redhat.com/ubi8/ubi-micro:8.5-836
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
+COPY --from=builder /bin/initializer /bin/initializer
 
 WORKDIR /registry
 RUN chgrp -R 0 /registry && chmod -R g+rwx /registry

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
@@ -63,12 +63,24 @@ EOF
 
 # Build registry
 cat <<EOF > $DOCKERFILE_REGISTRY
-FROM quay.io/openshift/origin-operator-registry:4.8.0
+FROM quay.io/openshift/origin-operator-registry:4.10.0 AS builder
 COPY $SAAS_OPERATOR_DIR manifests
-USER 0
-RUN pip3 install urllib3==1.26.9 pip==21.3.1
-USER 1001
 RUN initializer --permissive
+
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.5-836
+
+COPY --from=builder /bin/registry-server /bin/registry-server
+COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
+
+WORKDIR /registry
+RUN chgrp -R 0 /registry && chmod -R g+rwx /registry
+
+USER 1001
+
+COPY --from=builder /registry /registry
+
+EXPOSE 50051
+
 CMD ["registry-server", "-t", "/tmp/terminate.log"]
 EOF
 


### PR DESCRIPTION
This PR is inspired from [OSD-10496](https://issues.redhat.com/browse/OSD-10496) work by @Nikokolas3270. Intent of the PR is to minimise the registry image size for SRE operators to reduce number of CVE reported by the repos. 