### PR TITLE
Fix incorrect bash syntax in build image

### DIFF
--- a/boilerplate/test/test-base-convention/update
+++ b/boilerplate/test/test-base-convention/update
@@ -29,5 +29,5 @@ echo "Validating variables exported from the main update driver"
 # Granny switch to disable this check for weird tests like reverting to master
 if [[ -z "$SKIP_IMAGE_TAG_CHECK" ]]; then
     # Update this when publishing a new image tag
-    [[ "$LATEST_IMAGE_TAG" == "image-v2.3.0" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
+    [[ "$LATEST_IMAGE_TAG" == "image-v2.3.1" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
 fi

--- a/config/build_image-v2.0.0.sh
+++ b/config/build_image-v2.0.0.sh
@@ -42,7 +42,7 @@ go install sigs.k8s.io/kustomize/kustomize/${KUSTOMIZE_VERSION%%.*}@${KUSTOMIZE_
 # controller-gen
 ################
 # v0.3.0 is used by the old operator-sdk, v0.8.0 is used by the latest
-CONTROLLER_GEN_VERSIONS=["v0.3.0", "v0.8.0"]
+CONTROLLER_GEN_VERSIONS="v0.3.0 v0.8.0"
 for CONTROLLER_GEN_VERSION in $CONTROLLER_GEN_VERSIONS;do
     go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION}
     mv $GOPATH/bin/controller-gen $GOPATH/bin/controller-gen-${CONTROLLER_GEN_VERSION}

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -3,7 +3,7 @@ if [ "$BOILERPLATE_SET_X" ]; then
 fi
 
 # NOTE: Change this when publishing a new image tag.
-LATEST_IMAGE_TAG=image-v2.3.0
+LATEST_IMAGE_TAG=image-v2.3.1
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 # Make all tests use this local clone by default.


### PR DESCRIPTION
PR to fix failing App-SRE deploy pipeline due to incorrect bash syntax.