### PR TITLE
Setup KUBEBUILDER_ASSETS in go-test target

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -244,7 +244,6 @@ SETUP_ENVTEST = $(shell pwd)/bin/setup-envtest
 .PHONY: setup-envtest
 setup-envtest: ## Download setup-envtest locally if necessary.
 	$(call go-get-tool,$(SETUP_ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
-	$(eval KUBEBUILDER_ASSETS = "$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(PWD)/bin)")
 	
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
@@ -254,7 +253,7 @@ SHELL = /usr/bin/env bash -o pipefail
 
 .PHONY: go-test
 go-test: setup-envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test $(TESTOPTS) $(TESTTARGETS)
+	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(PWD)/bin)" go test $(TESTOPTS) $(TESTTARGETS)
 
 .PHONY: python-venv
 python-venv:


### PR DESCRIPTION
I have to move this into the 'go-test' target, or it will fail the first time you run it.
```
 make go-test            
bash: line 1: /home/haowang/go/src/github.com/openshift/gcp-project-operator/bin/setup-envtest: No such file or directory
go: creating new go.mod: module tmp
Downloading sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
Installed in /home/haowang/go/src/github.com/openshift/gcp-project-operator/bin/setup-envtest
KUBEBUILDER_ASSETS="" go test  github.com/openshift/gcp-project-operator github.com/openshift/gcp-project-operator/api/v1alpha1 github.com/openshift/gcp-project-operator/config github.com/openshift/gcp-project-operator/controllers github.com/openshift/gcp-project-operator/pkg/condition github.com/openshift/gcp-project-operator/pkg/configmap github.com/openshift/gcp-project-operator/pkg/gcpclient github.com/openshift/gcp-project-operator/pkg/util github.com/openshift/gcp-project-operator/pkg/util/errors github.com/openshift/gcp-project-operator/pkg/util/mocks github.com/openshift/gcp-project-operator/pkg/util/mocks/condition github.com/openshift/gcp-project-operator/pkg/util/mocks/controllers github.com/openshift/gcp-project-operator/pkg/util/mocks/gcpclient github.com/openshift/gcp-project-operator/pkg/util/mocks/projectclaim github.com/openshift/gcp-project-operator/pkg/util/mocks/structs

```

You can see KUBEBUILDER_ASSETS=""  is set to empty which is the reason why it fail the test for operator using latest osdk.