### PR TITLE
Include openapi-gen and setup-envtest in the backing image

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -181,11 +181,19 @@ rm -rf $$TMP_DIR ;\
 }
 endef
 
+# Deciding on the binary versions
 CONTROLLER_GEN_VERSION = v0.8.0
 CONTROLLER_GEN = controller-gen-$(CONTROLLER_GEN_VERSION)
+
+OPENAPI_GEN_VERSION = v0.19.4
+OPENAPI_GEN = openapi-gen-$(OPENAPI_GEN_VERSION)
+
 ifeq ($(USE_OLD_SDK), TRUE)
-#If we are using the old osdk, we use the default controller-gen and it's v0.3.0 for now.
+#If we are using the old osdk, we use the default controller-gen and openapi-gen versions.
+# Default version is 0.8.0 for now.
 CONTROLLER_GEN = controller-gen
+# Default version is 0.19.4 for now.
+OPENAPI_GEN = openapi-gen
 endif
 
 
@@ -216,7 +224,7 @@ endif
 .PHONY: openapi-generate
 openapi-generate:
 	find $(API_DIR) -maxdepth 2 -mindepth $(API_DIR_MIN_DEPTH) -type d | xargs -t -I% \
-		openapi-gen --logtostderr=true \
+		$(OPENAPI_GEN) --logtostderr=true \
 			-i % \
 			-o "" \
 			-O zz_generated.openapi \
@@ -239,12 +247,11 @@ go-build: ## Build binary
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
+SETUP_ENVTEST = setup-envtest
 
-SETUP_ENVTEST = $(shell pwd)/bin/setup-envtest
 .PHONY: setup-envtest
-setup-envtest: ## Download setup-envtest locally if necessary.
-	$(call go-get-tool,$(SETUP_ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
-	$(eval KUBEBUILDER_ASSETS = "$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(PWD)/bin)")
+setup-envtest:
+	$(eval KUBEBUILDER_ASSETS := "$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(PWD)/bin)")
 	
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.

--- a/boilerplate/test/test-base-convention/update
+++ b/boilerplate/test/test-base-convention/update
@@ -29,5 +29,5 @@ echo "Validating variables exported from the main update driver"
 # Granny switch to disable this check for weird tests like reverting to master
 if [[ -z "$SKIP_IMAGE_TAG_CHECK" ]]; then
     # Update this when publishing a new image tag
-    [[ "$LATEST_IMAGE_TAG" == "image-v2.3.1" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
+    [[ "$LATEST_IMAGE_TAG" == "image-v2.3.2" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
 fi

--- a/config/build_image-v2.0.0.sh
+++ b/config/build_image-v2.0.0.sh
@@ -53,10 +53,20 @@ ln -s $GOPATH/bin/controller-gen-v0.3.0 $GOPATH/bin/controller-gen
 #############
 # openapi-gen
 #############
-OPENAPI_GEN_VERSION=v0.19.4
-go install k8s.io/code-generator/cmd/openapi-gen@${OPENAPI_GEN_VERSION}
+OPENAPI_GEN_VERSIONS="v0.19.4 v0.23.0"
+for OPENAPI_GEN_VERSION in $OPENAPI_GEN_VERSIONS;do
+    go install k8s.io/code-generator/cmd/openapi-gen@${OPENAPI_GEN_VERSION}
+    mv $GOPATH/bin/openapi-gen $GOPATH/bin/openapi-gen-${OPENAPI_GEN_VERSION}
+done
+# Set v0.19.4 as the default version for backwards compatibility
+ln -s $GOPATH/bin/openapi-gen-v0.19.4 $GOPATH/bin/openapi-gen
 
 #########
+# ENVTEST
+#########
+# We do not enforce versioning on setup-envtest
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
 # mockgen
 #########
 MOCKGEN_VERSION=v1.4.4

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -3,7 +3,7 @@ if [ "$BOILERPLATE_SET_X" ]; then
 fi
 
 # NOTE: Change this when publishing a new image tag.
-LATEST_IMAGE_TAG=image-v2.3.1
+LATEST_IMAGE_TAG=image-v2.3.2
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 # Make all tests use this local clone by default.


### PR DESCRIPTION
1. The validation check on the PR [openshift/gcp-project-operator#177](https://github.com/openshift/gcp-project-operator/pull/177) is currently failing. This is due to the latest version of openapi-gen in which `github.com/go-openapi/spec` is replaced by `k8s.io/kube-openapi/pkg/validation/spec`. While `make validate` succeeds locally, the same fails when run containerized. 
Hence including openapi-gen v0.19.4 & v0.23.0 in the backing image to make it compatible with both the old & new operator-sdk versions.

2. Looking at setup-envtest
```
.PHONY: setup-envtest
setup-envtest: ## Download setup-envtest locally if necessary.
	$(call go-get-tool,$(SETUP_ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
	$(eval KUBEBUILDER_ASSETS := "$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(PWD)/bin)")

.PHONY: go-test
go-test: setup-envtest
	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test $(TESTOPTS) $(TESTTARGETS)

```
When run `make go-test`, this fails:

 ```
 $ make go-test
 KUBEBUILDER_ASSETS="" go test  github.com/openshift/gcp-project-operator ...
 ```
This is because shell bit is getting evaluated at "compile time", not at "runtime". To mitigate this I've included setup-envtest as part of the backing image and it is installed along with the other tools.
