### PR TITLE
Remove explicit configuration of envtest bin directory

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -251,7 +251,7 @@ SETUP_ENVTEST = setup-envtest
 
 .PHONY: setup-envtest
 setup-envtest:
-	$(eval KUBEBUILDER_ASSETS := "$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(PWD)/bin)")
+	$(eval KUBEBUILDER_ASSETS := "$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)")
 	
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.


### PR DESCRIPTION
While the previous [changes](https://github.com/openshift/boilerplate/pull/222) fixed validation check and tooling.
Environment tests are still failing with the error:
```
unable to make sure store is initialized: unable to make sure base binaries dir exists: mkdir /bin/k8s: permission denied
KUBEBUILDER_ASSETS="" go test  ...
```
This is because controller-runtime’s `envtest` requires kubectl, kube-apiserver, and etcd binaries be present locally to simulate the API portions of a real cluster. We are explicitly configuring `envtest` to use `$(pwd)/bin` as the installation directory for these binaries.

With this PR, we are removing this explicit configuration through which envtest will install the required binaries at `.local/share/kubebuilder-envtest/k8s/`.

I have tested the changes locally, containerized and it works: http://pastebin.test.redhat.com/1051677

This came up only after the tooling was fixed with the new build image else I would've patched this with the previous changes.

Related to: https://github.com/openshift/gcp-project-operator/pull/177
With this, the failing tests (currently 2) should be fixed as well. I'm hopeful as this checks out in the local containerized testing.

Ref: https://book.kubebuilder.io/reference/envtest.html#configuring-your-test-control-plane