### PR TITLE
setup a writable dir for go-test and setup-envtest target.

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -84,6 +84,13 @@ GOARCH?=$(shell go env GOARCH)
 unexport GOFLAGS
 GOFLAGS_MOD ?=
 
+# In openshift ci (Prow), we need to set $HOME to a writable directory else tests will fail
+# because they don't have permissions to create /.local or /.cache directories
+# as $HOME is set to "/" by default.
+ifeq ($(HOME),/)
+export HOME=/tmp/home
+endif
+
 ifeq (${FIPS_ENABLED}, true)
 GOFLAGS_MOD+=-tags=fips_enabled
 GOFLAGS_MOD:=$(strip ${GOFLAGS_MOD})
@@ -251,7 +258,7 @@ SETUP_ENVTEST = setup-envtest
 
 .PHONY: setup-envtest
 setup-envtest:
-	$(eval KUBEBUILDER_ASSETS := "$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)")
+	$(eval KUBEBUILDER_ASSETS := "$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir /tmp/envtest/bin)")
 	
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.


### PR DESCRIPTION
1. Set a home dir that are writable when do go test to workaround the issue we have in openshift ci
2. Set the test binary bin dir to a tmp dir
without this, we got errors like:

```
build cache is disabled by GOCACHE=off, but required as of Go 1.12
unable to make sure store is initialized: unable to make sure base binaries dir exists: mkdir /.local: permission denied
KUBEBUILDER_ASSETS="" GOCACHE=off go test  
build cache is disabled by GOCACHE=off, but required as of Go 1.12
make: *** [boilerplate/openshift/golang-osd-operator/standard.mk:264: go-test] Error 1
{"component":"entrypoint","error":"wrapped process failed: exit status 2","file":"k8s.io/test-infra/p
```