### PR TITLE
Generate CRD v1 by default

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -90,6 +90,7 @@ GOFLAGS_MOD ?=
 ifeq ($(HOME),/)
 export HOME=/tmp/home
 endif
+PWD=$(shell pwd)
 
 ifeq (${FIPS_ENABLED}, true)
 GOFLAGS_MOD+=-tags=fips_enabled
@@ -206,8 +207,8 @@ endif
 
 .PHONY: op-generate
 op-generate:
-	cd $(API_DIR); $(CONTROLLER_GEN) crd paths=./... output:dir=$(PWD)/deploy/crds
 ifeq ($(CRD_VERSION), v1beta1)
+	cd $(API_DIR); $(CONTROLLER_GEN) crd paths=./... output:dir=$(PWD)/deploy/crds
 	# HACK: Due to an OLM bug in 3.11, we need to remove the
 	# spec.validation.openAPIV3Schema.type from CRDs. Remove once
 	# 3.11 is no longer supported.
@@ -220,6 +221,8 @@ ifeq ($(CRD_VERSION), v1beta1)
 	find deploy/crds -name '*.yaml' | xargs -n1 -I{} yq d -i {} 'spec.**.x-kubernetes-list-type'
 	find deploy/crds -name '*.yaml' | xargs -n1 -I{} yq d -i {} 'spec.**.x-kubernetes-map-type'
 	find deploy/crds -name '*.yaml' | xargs -n1 -I{} yq d -i {} 'spec.**.x-kubernetes-struct-type'
+else
+	cd $(API_DIR); $(CONTROLLER_GEN) crd:crdVersions=v1 paths=./... output:dir=$(PWD)/deploy/crds
 endif
 	cd $(API_DIR); $(CONTROLLER_GEN) object paths=./...
 


### PR DESCRIPTION
Most existing operators are using CRD version v1.