### PR TITLE
OSD-11587 fixes bug in how operator name is set

### DIFF
--- a/boilerplate/openshift/custom-catalog-osd-operator/current-version-getter.sh
+++ b/boilerplate/openshift/custom-catalog-osd-operator/current-version-getter.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-OPERATOR_NAME=$(basename ${REPO_ROOT}  | sed 's/-catalog//')
+VERSIONS_DIR="${REPO_ROOT}/versions"
+OPERATOR_NAME=$(jq -r '.operator_name' $VERSIONS_DIR/*)
 CERT_DIR="${REPO_ROOT}/service-account/rhcs-request"
 CERT_FILE_NAME="custom-catalog-source-index-builder"
 PYXIS_ENDPOINT="https://pyxis.engineering.redhat.com"
-VERSIONS_DIR="${REPO_ROOT}/versions"
+
 
 
 # compare_versions accepts two semvers.


### PR DESCRIPTION
- More details available [HERE](https://issues.redhat.com/browse/OSD-11587?focusedCommentId=20319041&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-20319041)
- changes the method of grabbing the operator name as the jenkins pipeline does not completely match the operator name and is not a reliable source

**Pipeline Run before change (debug turned on to show bad call)**
https://ci.int.devshift.net/view/osd-operators/job/service-container-security-operator-catalog-version-custom-catalog-source/20/console

**Pipeline run using updated boilerplate script**
https://ci.int.devshift.net/view/osd-operators/job/service-container-security-operator-catalog-version-custom-catalog-source/21/console