### PR TITLE
Use pwd as the repo dir

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/configure-fips.sh
+++ b/boilerplate/openshift/golang-osd-operator/configure-fips.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-REPO_ROOT=$(git rev-parse --show-toplevel)
+REPO_ROOT=${PWD}
 CONVENTION_DIR="$REPO_ROOT/boilerplate/openshift/golang-osd-operator"
 PRE_V1_SDK_MANAGER_DIR="$REPO_ROOT/cmd/manager"
 


### PR DESCRIPTION
router-monitor-operator is running a openshift binary build to run it's integration tests, when you run "oc start-build --from-dir", the source code was copied into the pod without any git staff, so "git rev-parse" will fail, as we already have "PWD" variable defined in the standard Makefile, we can use it directly. 

See the error logs: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_route-monitor-operator/171/pull-ci-openshift-route-monitor-operator-master-test-integration/1529983195339034624/build-log.txt

```
go: downloading github.com/hashicorp/golang-lru v0.5.4
boilerplate/openshift/golang-osd-operator/configure-fips.sh
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
```