### PR TITLE
Remove :Z mount option for podman in container-make

### DIFF
--- a/boilerplate/_lib/container-make
+++ b/boilerplate/_lib/container-make
@@ -20,7 +20,7 @@ CONTAINER_MOUNT=/go/src/$(repo_import $REPO_ROOT)
 # First set up a detached container with the repo mounted.
 banner "Starting the container"
 if [[ "${CONTAINER_ENGINE##*/}" == "podman" ]]; then
-    CE_OPTS="--userns keep-id -v $REPO_ROOT:$CONTAINER_MOUNT:Z"
+    CE_OPTS="--userns keep-id -v $REPO_ROOT:$CONTAINER_MOUNT"
 else
     CE_OPTS="-v $REPO_ROOT:$CONTAINER_MOUNT"
 fi

--- a/boilerplate/_lib/container-make
+++ b/boilerplate/_lib/container-make
@@ -20,7 +20,11 @@ CONTAINER_MOUNT=/go/src/$(repo_import $REPO_ROOT)
 # First set up a detached container with the repo mounted.
 banner "Starting the container"
 if [[ "${CONTAINER_ENGINE##*/}" == "podman" ]]; then
-    CE_OPTS="--userns keep-id -v $REPO_ROOT:$CONTAINER_MOUNT"
+    if [[ $OSTYPE == *"darwin"* ]]; then
+        CE_OPTS="--userns keep-id -v $REPO_ROOT:$CONTAINER_MOUNT"
+    else
+        CE_OPTS="--userns keep-id -v $REPO_ROOT:$CONTAINER_MOUNT:Z"
+    fi
 else
     CE_OPTS="-v $REPO_ROOT:$CONTAINER_MOUNT"
 fi


### PR DESCRIPTION
This change allows the container-make file to work on macs running podman.