### PR TITLE
OSD-11742, OSD-12367 - bug and CVE fixes for catalog operators

### DIFF
--- a/boilerplate/openshift/custom-catalog-osd-operator/custom-catalog-build-push.sh
+++ b/boilerplate/openshift/custom-catalog-osd-operator/custom-catalog-build-push.sh
@@ -12,7 +12,7 @@ source $REPO_ROOT/boilerplate/_lib/common.sh
 
 function usage() {
     cat <<EOF
-    Usage: $0 REGISTRY_IMAGE_URI BASE_IMAGE_PATH
+    Usage: $0 REGISTRY_IMAGE_URI
     REGISTRY_IMAGE_URI is the complete image URI that needs to be built
 EOF
     exit -1
@@ -81,7 +81,6 @@ else
   do
     bundle_image=$( cat ${f} | jq -r .bundle_image )
     build_catalog_image ${bundle_image} ${REGISTRY_IMAGE_URI}
-    echo $?
     if [[ ${?} == 0 ]]; then
       echo "pushing image"
       cd ${REPO_ROOT}

--- a/boilerplate/openshift/custom-catalog-osd-operator/custom-catalog-build-push.sh
+++ b/boilerplate/openshift/custom-catalog-osd-operator/custom-catalog-build-push.sh
@@ -14,7 +14,7 @@ function usage() {
     cat <<EOF
     Usage: $0 REGISTRY_IMAGE_URI BASE_IMAGE_PATH
     REGISTRY_IMAGE_URI is the complete image URI that needs to be built
-    BASE_IMAGE_PATH is the base URI path in the contaienr registry (ie. quay.io/app-sre/image)
+    BASE_IMAGE_PATH is the base URI path in the container registry (ie. quay.io/app-sre/image)
 EOF
     exit -1
 }
@@ -33,11 +33,15 @@ function build_catalog_image() {
   ${CONTAINER_ENGINE} pull ${bundle_image}
   # some upstream bundles images are built specifying a "replaces" field, which means it builds on top of the 
   # previous minor version. we need to check if the build fails for that reason and use another method
-  echo "testing build..."
-  BUILD=$(${opm_local_executable} index add --bundles ${bundle_image} --tag ${image_tag} --container-tool ${CONTAINER_ENGINE_SHORT} 2>&1)
+  echo "building catalog image..."
+  BUILD=$(${opm_local_executable} index add \
+    --bundles ${bundle_image} \
+    --tag ${image_tag} \
+    --container-tool ${CONTAINER_ENGINE_SHORT} 2>&1)
+  
   ERR_COUNT=$(echo $BUILD | grep -c 'non-existent replacement')
   
-  # Dump output of build since its stderr and won't show for to variable capture to work
+  # Dump output of build since its stderr and won't show with the variable capture in place
   echo -e "\n$BUILD\n"
 
   if [[ ${ERR_COUNT} > 0 ]]; then 

--- a/boilerplate/openshift/custom-catalog-osd-operator/install-opm.sh
+++ b/boilerplate/openshift/custom-catalog-osd-operator/install-opm.sh
@@ -3,7 +3,7 @@
 set -e
 
 # global envs
-OPM_VERSION="v1.15.2"
+OPM_VERSION="v1.23.2"
 GOOS=$(go env GOOS)
 REPO_ROOT=$(git rev-parse --show-toplevel)
 OPM_LOCAL_EXECUTABLE_DIR=${REPO_ROOT}/.opm/bin

--- a/boilerplate/openshift/custom-catalog-osd-operator/standard.mk
+++ b/boilerplate/openshift/custom-catalog-osd-operator/standard.mk
@@ -10,7 +10,7 @@ REGISTRY_TOKEN?=$(QUAY_TOKEN)
 
 
 # Accommodate docker or podman
-CONTAINER_ENGINE=$(shell command -v podman 2>/dev/null || echo docker --config=$(CONTAINER_ENGINE_CONFIG_DIR))
+CONTAINER_ENGINE=$(shell command -v podman 2>/dev/null || echo "docker --config=$(CONTAINER_ENGINE_CONFIG_DIR)")
 
 # Generate version and tag information from inputs
 CURRENT_COMMIT=$(shell git rev-parse --short=7 HEAD)
@@ -50,7 +50,7 @@ install-opm: ## install opm binary used to build the catalog image if it not alr
 
 .PHONY: catalog-build-push
 catalog-build-push:  docker-login-rh-registry docker-login install-opm ## called by app-sre automation to build a new catalog image
-	${CONVENTION_DIR}/custom-catalog-build-push.sh ${REGISTRY_IMAGE_URI} ${REGISTRY_IMAGE}
+	${CONVENTION_DIR}/custom-catalog-build-push.sh ${REGISTRY_IMAGE_URI}
 
 .PHONY: update-versions
 update-versions: ## update the version file with the latest operator version (if available)

--- a/boilerplate/openshift/custom-catalog-osd-operator/standard.mk
+++ b/boilerplate/openshift/custom-catalog-osd-operator/standard.mk
@@ -14,6 +14,7 @@ CONTAINER_ENGINE=$(shell command -v podman 2>/dev/null || command -v docker 2>/d
 
 # Generate version and tag information from inputs
 CURRENT_COMMIT=$(shell git rev-parse --short=7 HEAD)
+PREVIOUS_COMMIT=$(shell git rev-list --max-count=2 --reverse HEAD | head -n 1 -c 7)
 
 REGISTRY_IMAGE=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME)
 REGISTRY_IMAGE_URI=$(REGISTRY_IMAGE):$(CURRENT_COMMIT)
@@ -25,20 +26,20 @@ CONVENTION_DIR := boilerplate/openshift/custom-catalog-osd-operator
 
 .PHONY: docker-push-catalog
 docker-push-catalog: docker-login ## push custom catalog image to quay.io
-	${CONTAINER_ENGINE} --config=${CONTAINER_ENGINE_CONFIG_DIR} push ${REGISTRY_IMAGE_URI}
+	${CONTAINER_ENGINE}  push ${REGISTRY_IMAGE_URI}
 
 .PHONY: docker-login
 docker-login: ## docker login to quay.io
 	@test "${REGISTRY_USER}" != "" && test "${REGISTRY_TOKEN}" != "" || (echo "REGISTRY_USER and REGISTRY_TOKEN must be defined" && exit 1)
 	mkdir -p ${CONTAINER_ENGINE_CONFIG_DIR}
-	@${CONTAINER_ENGINE} --config=${CONTAINER_ENGINE_CONFIG_DIR} login -u="${REGISTRY_USER}" -p="${REGISTRY_TOKEN}" quay.io
+	@${CONTAINER_ENGINE} login -u="${REGISTRY_USER}" -p="${REGISTRY_TOKEN}" quay.io
 
 
 .PHONY: docker-login-rh-registry
  docker-login-rh-registry: ## docker login to registry.redhat.io
 	@test "${REGISTRY_RH_IO_USER}" != "" && test "${REGISTRY_RH_IO_TOKEN}" != "" || (echo "REGISTRY_RH_IO_USER and REGISTRY_RH_IO_TOKEN must be defined" && exit 1)
 	mkdir -p ${CONTAINER_ENGINE_CONFIG_DIR}
-	@${CONTAINER_ENGINE} --config=${CONTAINER_ENGINE_CONFIG_DIR} login -u="${REGISTRY_RH_IO_USER}" -p="${REGISTRY_RH_IO_TOKEN}" registry.redhat.io
+	@${CONTAINER_ENGINE}  login -u="${REGISTRY_RH_IO_USER}" -p="${REGISTRY_RH_IO_TOKEN}" registry.redhat.io
 
 .PHONY: install-opm
 install-opm: ## install opm binary used to build the catalog image if it not already installed
@@ -50,7 +51,7 @@ install-opm: ## install opm binary used to build the catalog image if it not alr
 
 .PHONY: catalog-build-push
 catalog-build-push:  docker-login-rh-registry docker-login install-opm ## called by app-sre automation to build a new catalog image
-	${CONVENTION_DIR}/custom-catalog-build-push.sh ${REGISTRY_IMAGE_URI}
+	${CONVENTION_DIR}/custom-catalog-build-push.sh ${REGISTRY_IMAGE_URI} ${REGISTRY_IMAGE}
 
 .PHONY: update-versions
 update-versions: ## update the version file with the latest operator version (if available)

--- a/boilerplate/openshift/custom-catalog-osd-operator/standard.mk
+++ b/boilerplate/openshift/custom-catalog-osd-operator/standard.mk
@@ -14,7 +14,6 @@ CONTAINER_ENGINE=$(shell command -v podman 2>/dev/null || command -v docker 2>/d
 
 # Generate version and tag information from inputs
 CURRENT_COMMIT=$(shell git rev-parse --short=7 HEAD)
-PREVIOUS_COMMIT=$(shell git rev-list --max-count=2 --reverse HEAD | head -n 1 -c 7)
 
 REGISTRY_IMAGE=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME)
 REGISTRY_IMAGE_URI=$(REGISTRY_IMAGE):$(CURRENT_COMMIT)
@@ -26,20 +25,20 @@ CONVENTION_DIR := boilerplate/openshift/custom-catalog-osd-operator
 
 .PHONY: docker-push-catalog
 docker-push-catalog: docker-login ## push custom catalog image to quay.io
-	${CONTAINER_ENGINE}  push ${REGISTRY_IMAGE_URI}
+	${CONTAINER_ENGINE} --config=${CONTAINER_ENGINE_CONFIG_DIR} push ${REGISTRY_IMAGE_URI}
 
 .PHONY: docker-login
 docker-login: ## docker login to quay.io
 	@test "${REGISTRY_USER}" != "" && test "${REGISTRY_TOKEN}" != "" || (echo "REGISTRY_USER and REGISTRY_TOKEN must be defined" && exit 1)
 	mkdir -p ${CONTAINER_ENGINE_CONFIG_DIR}
-	@${CONTAINER_ENGINE} login -u="${REGISTRY_USER}" -p="${REGISTRY_TOKEN}" quay.io
+	@${CONTAINER_ENGINE} --config=${CONTAINER_ENGINE_CONFIG_DIR} login -u="${REGISTRY_USER}" -p="${REGISTRY_TOKEN}" quay.io
 
 
 .PHONY: docker-login-rh-registry
  docker-login-rh-registry: ## docker login to registry.redhat.io
 	@test "${REGISTRY_RH_IO_USER}" != "" && test "${REGISTRY_RH_IO_TOKEN}" != "" || (echo "REGISTRY_RH_IO_USER and REGISTRY_RH_IO_TOKEN must be defined" && exit 1)
 	mkdir -p ${CONTAINER_ENGINE_CONFIG_DIR}
-	@${CONTAINER_ENGINE}  login -u="${REGISTRY_RH_IO_USER}" -p="${REGISTRY_RH_IO_TOKEN}" registry.redhat.io
+	@${CONTAINER_ENGINE} --config=${CONTAINER_ENGINE_CONFIG_DIR} login -u="${REGISTRY_RH_IO_USER}" -p="${REGISTRY_RH_IO_TOKEN}" registry.redhat.io
 
 .PHONY: install-opm
 install-opm: ## install opm binary used to build the catalog image if it not already installed

--- a/boilerplate/openshift/custom-catalog-osd-operator/standard.mk
+++ b/boilerplate/openshift/custom-catalog-osd-operator/standard.mk
@@ -10,7 +10,7 @@ REGISTRY_TOKEN?=$(QUAY_TOKEN)
 
 
 # Accommodate docker or podman
-CONTAINER_ENGINE=$(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
+CONTAINER_ENGINE=$(shell command -v podman 2>/dev/null || echo docker --config=$(CONTAINER_ENGINE_CONFIG_DIR))
 
 # Generate version and tag information from inputs
 CURRENT_COMMIT=$(shell git rev-parse --short=7 HEAD)
@@ -25,20 +25,20 @@ CONVENTION_DIR := boilerplate/openshift/custom-catalog-osd-operator
 
 .PHONY: docker-push-catalog
 docker-push-catalog: docker-login ## push custom catalog image to quay.io
-	${CONTAINER_ENGINE} --config=${CONTAINER_ENGINE_CONFIG_DIR} push ${REGISTRY_IMAGE_URI}
+	${CONTAINER_ENGINE} push ${REGISTRY_IMAGE_URI}
 
 .PHONY: docker-login
 docker-login: ## docker login to quay.io
 	@test "${REGISTRY_USER}" != "" && test "${REGISTRY_TOKEN}" != "" || (echo "REGISTRY_USER and REGISTRY_TOKEN must be defined" && exit 1)
 	mkdir -p ${CONTAINER_ENGINE_CONFIG_DIR}
-	@${CONTAINER_ENGINE} --config=${CONTAINER_ENGINE_CONFIG_DIR} login -u="${REGISTRY_USER}" -p="${REGISTRY_TOKEN}" quay.io
+	@${CONTAINER_ENGINE} login -u="${REGISTRY_USER}" -p="${REGISTRY_TOKEN}" quay.io
 
 
 .PHONY: docker-login-rh-registry
  docker-login-rh-registry: ## docker login to registry.redhat.io
 	@test "${REGISTRY_RH_IO_USER}" != "" && test "${REGISTRY_RH_IO_TOKEN}" != "" || (echo "REGISTRY_RH_IO_USER and REGISTRY_RH_IO_TOKEN must be defined" && exit 1)
 	mkdir -p ${CONTAINER_ENGINE_CONFIG_DIR}
-	@${CONTAINER_ENGINE} --config=${CONTAINER_ENGINE_CONFIG_DIR} login -u="${REGISTRY_RH_IO_USER}" -p="${REGISTRY_RH_IO_TOKEN}" registry.redhat.io
+	@${CONTAINER_ENGINE} login -u="${REGISTRY_RH_IO_USER}" -p="${REGISTRY_RH_IO_TOKEN}" registry.redhat.io
 
 .PHONY: install-opm
 install-opm: ## install opm binary used to build the catalog image if it not already installed


### PR DESCRIPTION
- updates `custom-catalog-build-push.sh` to check the build for any failures regarding non-existent replacements in the index, and if it failed, builds specifying `--from-index` flag targeting the latest catalog image (not all upstream operators specify this value)
- updates custom catalog make file to fix issues with using podman and it trying to pass `--config` into certain commands
- bumps opm version to v1.23.2 to resolve CVE's found using the older version of opm injected by the base container image it uses