### PR TITLE
Osd 12367 fix build error check

### DIFF
--- a/boilerplate/openshift/custom-catalog-osd-operator/custom-catalog-build-push.sh
+++ b/boilerplate/openshift/custom-catalog-osd-operator/custom-catalog-build-push.sh
@@ -41,7 +41,7 @@ function build_catalog_image() {
     --tag ${image_tag} \
     --container-tool ${CONTAINER_ENGINE_SHORT} 2>&1 | tee /dev/fd/5; exit ${PIPESTATUS[0]})
   RC=$?
-  ERR_COUNT=$(echo $BUILD | grep -c 'non-existent replacement')
+  ERR_COUNT=$(echo $BUILD | grep -c 'replaces nonexistent bundle')
     
   if [[ ${RC} > 0 ]] && [[ ${ERR_COUNT} == 0 ]]; then
     echo "adding bundle failed"

--- a/boilerplate/openshift/custom-catalog-osd-operator/custom-catalog-build-push.sh
+++ b/boilerplate/openshift/custom-catalog-osd-operator/custom-catalog-build-push.sh
@@ -36,10 +36,10 @@ function build_catalog_image() {
 
   # preserve logging output from command by duplicating the file descriptor
   exec 5>&1
-  BUILD=$(${opm_local_executable} index add \
+  BUILD="$(${opm_local_executable} index add \
     --bundles ${bundle_image} \
     --tag ${image_tag} \
-    --container-tool ${CONTAINER_ENGINE_SHORT} 2>&1 | tee /dev/fd/5; exit ${PIPESTATUS[0]})
+    --container-tool ${CONTAINER_ENGINE_SHORT} 2>&1 | tee /dev/fd/5; exit ${PIPESTATUS[0]})"
   RC=$?
   ERR_COUNT=$(echo $BUILD | grep -c 'replaces nonexistent bundle')
     
@@ -76,6 +76,7 @@ BASE_IMAGE_PATH=${REGISTRY_IMAGE_URI%:*}
 if image_exists_in_repo "${REGISTRY_IMAGE_URI}"; then
   echo "Custom catalog image for the latest operator version already exists in the registry"
   echo "Nothing to do here"
+  exit 0
 else
   for f in ${VERSIONS_DIR}/*;
   do

--- a/boilerplate/openshift/custom-catalog-osd-operator/custom-catalog-build-push.sh
+++ b/boilerplate/openshift/custom-catalog-osd-operator/custom-catalog-build-push.sh
@@ -36,12 +36,12 @@ function build_catalog_image() {
 
   # preserve logging output from command by duplicating the file descriptor
   exec 5>&1
-  BUILD="$(${opm_local_executable} index add \
+  BUILD=$(${opm_local_executable} index add \
     --bundles ${bundle_image} \
     --tag ${image_tag} \
-    --container-tool ${CONTAINER_ENGINE_SHORT} 2>&1 | tee /dev/fd/5; exit ${PIPESTATUS[0]})"
+    --container-tool ${CONTAINER_ENGINE_SHORT} 2>&1 | tee /dev/fd/5; exit ${PIPESTATUS[0]})
   RC=$?
-  ERR_COUNT=$(echo $BUILD | grep -c 'replaces nonexistent bundle')
+  ERR_COUNT=$(echo "$BUILD" | grep -c 'replaces nonexistent bundle')
     
   if [[ ${RC} > 0 ]] && [[ ${ERR_COUNT} == 0 ]]; then
     echo "adding bundle failed"

--- a/boilerplate/openshift/custom-catalog-osd-operator/custom-catalog-build-push.sh
+++ b/boilerplate/openshift/custom-catalog-osd-operator/custom-catalog-build-push.sh
@@ -86,6 +86,9 @@ else
       echo "pushing image"
       cd ${REPO_ROOT}
       make docker-push-catalog
+    else
+      echo "failed to build catalog image"
+      exit 1
     fi
   done
 fi


### PR DESCRIPTION
- updates the string to check errors for as it has updated in the newer version of opm being used now (did not catch this as build tests were done before the code changes so i know the version of opm works...just bad error checking)
- made some of the other fixes as mentioned in the previous [PR](https://github.com/openshift/boilerplate/pull/234#discussion_r929004459)