### PR TITLE
Set MAINPACKAGE to base dir for v1 SDK operators

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -70,7 +70,7 @@ REGISTRY_USER ?=
 REGISTRY_TOKEN ?=
 
 BINFILE=build/_output/bin/$(OPERATOR_NAME)
-MAINPACKAGE = ./main.go
+MAINPACKAGE = ./
 API_DIR = $(NEW_API_DIR)
 ifeq ($(USE_OLD_SDK), TRUE)
 MAINPACKAGE = ./cmd/manager


### PR DESCRIPTION
### What type of PR is this?
Bugfix

### What this PR does / why we need it?
Currently, when FIPS support is enabled for operators that have migrated to SDK v1.x, this does not result in an image with FIPS support enabled. The reason is because `fips.go` is being left out of the `go build` call.

This doesn't happen with the pre-v1.x operators because they include a package dir rather than a single file.

The fix sets the `MAINPACKAGE` to be the base directory (`./`) for the new SDK so that it will pick up `fips.go` as part of the compile. Pre-1.x SDK will still use `cmd/manager` as normal.

### Which Jira/Github issue(s) this PR fixes?
Observed whilst reviewing migrated operators in [SDE-1972](https://issues.redhat.com//browse/SDE-1972)

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
