### PR TITLE
Ignoring mock clients for codecov

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/.codecov.yml
+++ b/boilerplate/openshift/golang-osd-operator/.codecov.yml
@@ -24,3 +24,6 @@ comment:
   layout: "reach,diff,flags,tree"
   behavior: default
   require_changes: no
+
+ignore:
+  - "**/mocks"


### PR DESCRIPTION
Based on https://docs.codecov.com/docs/ignoring-paths#ignoring-specific-file-names, adding ignore path for any files/folders under `mocks` directory. This would improve the coverage for some of the repositories which have mock clients generated using `mockgen` for container-runtime or any other interfaces. 