### PR TITLE
Ignoring autogenerated zz files for codecov

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/.codecov.yml
+++ b/boilerplate/openshift/golang-osd-operator/.codecov.yml
@@ -27,3 +27,4 @@ comment:
 
 ignore:
   - "**/mocks"
+  - "**/zz_generated*.go"


### PR DESCRIPTION
Similar to PR https://github.com/openshift/boilerplate/pull/238 and based on @2uasimojo's suggestion, excluding `zz_generated*.go` files as well. 