### PR TITLE
Add tools target

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/README.md
+++ b/boilerplate/openshift/golang-osd-operator/README.md
@@ -14,6 +14,7 @@ This convention is suitable for both cluster- and hive-deployed operators.
 The following components are included:
 
 ## `make` targets and functions.
+
 **Note:** Your repository's main `Makefile` needs to be edited to include the
 "nexus makefile include":
 
@@ -28,11 +29,12 @@ following:
 ### Prow
 
 | Test name / `make` target | Purpose                                                                                                         |
-|---------------------------|-----------------------------------------------------------------------------------------------------------------|
+| ------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `validate`                | Ensure code generation has not been forgotten; and ensure generated and boilerplate code has not been modified. |
 | `lint`                    | Perform static analysis.                                                                                        |
 | `test`                    | "Local" unit and functional testing.                                                                            |
 | `coverage`                | [Code coverage](#code-coverage) analysis and reporting.                                                         |
+| `tools`                   | Install the correct version of binaries locally.                                                                |
 
 To standardize your prow configuration, you may run:
 
@@ -48,12 +50,14 @@ $ make RELEASE_CLONE=/home/me/github/openshift/release prow-config
 ```
 
 This will generate a delta configuring prow to:
+
 - Build your `build/Dockerfile`.
 - Run the above targets in presubmit tests.
 - Run the `coverage` target in a postsubmit. This is the step that
   updates your coverage report in codecov.io.
 
 #### Local Testing
+
 You can run these `make` targets locally during development to test your
 code changes. However, differences in platforms and environments may
 lead to unpredictable results. Therefore boilerplate provides a utility
@@ -72,8 +76,9 @@ By default it is configured to be run from the app-sre jenkins pipelines.
 Consult [this doc](app-sre.md) for information on local execution/testing.
 
 ## Code coverage
+
 - A `codecov.sh` script, referenced by the `coverage` `make` target, to
-run code coverage analysis per [this SOP](https://github.com/openshift/ops-sop/blob/93d100347746ce04ad552591136818f82043c648/services/codecov.md).
+  run code coverage analysis per [this SOP](https://github.com/openshift/ops-sop/blob/93d100347746ce04ad552591136818f82043c648/services/codecov.md).
 
 - A `.codecov.yml` configuration file for
   [codecov.io](https://docs.codecov.io/docs/codecov-yaml). Note that
@@ -94,15 +99,17 @@ The convention embeds default checks to ensure generated code generation is curr
 To trigger the check, you can use `make generate-check` provided your Makefile properly includes the boilerplate-generated include `boilerplate/generated-includes.mk`.
 
 Checks consist of:
-* Checking all files are committed to ensure a safe point to revert to in case of error
-* Running the `make generate` command (see below) to regenerate the needed code
-* Checking if this results in any new uncommitted files in the git project or if all is clean.
+
+- Checking all files are committed to ensure a safe point to revert to in case of error
+- Running the `make generate` command (see below) to regenerate the needed code
+- Checking if this results in any new uncommitted files in the git project or if all is clean.
 
 `make generate` does the following:
-* generate crds and deepcopy via controller-gen. This is a no-op if your
+
+- generate crds and deepcopy via controller-gen. This is a no-op if your
   operator has no APIs.
-* `openapi-gen`. This is a no-op if your operator has no APIs.
-* `go generate`. This is a no-op if you have no `//go:generate`
+- `openapi-gen`. This is a no-op if your operator has no APIs.
+- `go generate`. This is a no-op if you have no `//go:generate`
   directives in your code.
 
 ## FIPS (Federal Information Processing Standards)
@@ -112,6 +119,7 @@ To enable FIPS in your build there is a `make ensure-fips` target.
 Add `FIPS_ENABLED=true` to your repos Makefile. Please ensure that this variable is added **before** including boilerplate Makefiles.
 
 e.g.
+
 ```.mk
 FIPS_ENABLED=true
 

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -200,8 +200,10 @@ OPENAPI_GEN = openapi-gen-$(OPENAPI_GEN_VERSION)
 ifeq ($(USE_OLD_SDK), TRUE)
 #If we are using the old osdk, we use the default controller-gen and openapi-gen versions.
 # Default version is 0.3.0 for now.
+CONTROLLER_GEN_VERSION = v0.3.0
 CONTROLLER_GEN = controller-gen
 # Default version is 0.19.4 for now.
+OPENAPI_GEN_VERSION = v0.19.4
 OPENAPI_GEN = openapi-gen
 endif
 
@@ -239,6 +241,16 @@ go-build: ## Build binary
 	# Force GOOS=linux as we may want to build containers in other *nix-like systems (ie darwin).
 	# This is temporary until a better container build method is developed
 	${GOENV} GOOS=linux go build ${GOBUILDFLAGS} -o ${BINFILE} ${MAINPACKAGE}
+
+.PHONY: tools
+tools: ## Install binaries locally
+	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	go install k8s.io/code-generator/cmd/openapi-gen@${OPENAPI_GEN_VERSION}
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION}
+	@if [ "$(USE_OLD_SDK)" == "FALSE" ]; then \
+		ln -sf $(GOBIN)/openapi-gen $(GOBIN)/$(OPENAPI_GEN); \
+		ln -sf $(GOBIN)/controller-gen $(GOBIN)/$(CONTROLLER_GEN); \
+	fi
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23


### PR DESCRIPTION
Currently, boilerplate consuming repositories are of different operator-sdk versions; v0.x or v1.x. 
This requires specific versions of generator binaries that the developer has to manually install and configure (rename) to be compatible with the boilerplate's standard make commands.
This PR adds a new target called 'tools' to aid in the local installation of binaries.
<hr>

Resolves: [OSD-13024](https://issues.redhat.com/browse/OSD-13024)