### PR TITLE
Add container-make targets

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/README.md
+++ b/boilerplate/openshift/golang-osd-operator/README.md
@@ -14,6 +14,7 @@ This convention is suitable for both cluster- and hive-deployed operators.
 The following components are included:
 
 ## `make` targets and functions.
+
 **Note:** Your repository's main `Makefile` needs to be edited to include the
 "nexus makefile include":
 
@@ -28,7 +29,7 @@ following:
 ### Prow
 
 | Test name / `make` target | Purpose                                                                                                         |
-|---------------------------|-----------------------------------------------------------------------------------------------------------------|
+| ------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `validate`                | Ensure code generation has not been forgotten; and ensure generated and boilerplate code has not been modified. |
 | `lint`                    | Perform static analysis.                                                                                        |
 | `test`                    | "Local" unit and functional testing.                                                                            |
@@ -48,17 +49,25 @@ $ make RELEASE_CLONE=/home/me/github/openshift/release prow-config
 ```
 
 This will generate a delta configuring prow to:
+
 - Build your `build/Dockerfile`.
 - Run the above targets in presubmit tests.
 - Run the `coverage` target in a postsubmit. This is the step that
   updates your coverage report in codecov.io.
 
 #### Local Testing
+
 You can run these `make` targets locally during development to test your
 code changes. However, differences in platforms and environments may
 lead to unpredictable results. Therefore boilerplate provides a utility
 to run targets in a container environment that is designed to be as
 similar as possible to CI:
+
+```shell
+$ make container-{target}
+```
+
+or
 
 ```shell
 $ ./boilerplate/_lib/container-make {target}
@@ -72,8 +81,9 @@ By default it is configured to be run from the app-sre jenkins pipelines.
 Consult [this doc](app-sre.md) for information on local execution/testing.
 
 ## Code coverage
+
 - A `codecov.sh` script, referenced by the `coverage` `make` target, to
-run code coverage analysis per [this SOP](https://github.com/openshift/ops-sop/blob/93d100347746ce04ad552591136818f82043c648/services/codecov.md).
+  run code coverage analysis per [this SOP](https://github.com/openshift/ops-sop/blob/93d100347746ce04ad552591136818f82043c648/services/codecov.md).
 
 - A `.codecov.yml` configuration file for
   [codecov.io](https://docs.codecov.io/docs/codecov-yaml). Note that
@@ -94,15 +104,17 @@ The convention embeds default checks to ensure generated code generation is curr
 To trigger the check, you can use `make generate-check` provided your Makefile properly includes the boilerplate-generated include `boilerplate/generated-includes.mk`.
 
 Checks consist of:
-* Checking all files are committed to ensure a safe point to revert to in case of error
-* Running the `make generate` command (see below) to regenerate the needed code
-* Checking if this results in any new uncommitted files in the git project or if all is clean.
+
+- Checking all files are committed to ensure a safe point to revert to in case of error
+- Running the `make generate` command (see below) to regenerate the needed code
+- Checking if this results in any new uncommitted files in the git project or if all is clean.
 
 `make generate` does the following:
-* generate crds and deepcopy via controller-gen. This is a no-op if your
+
+- generate crds and deepcopy via controller-gen. This is a no-op if your
   operator has no APIs.
-* `openapi-gen`. This is a no-op if your operator has no APIs.
-* `go generate`. This is a no-op if you have no `//go:generate`
+- `openapi-gen`. This is a no-op if your operator has no APIs.
+- `go generate`. This is a no-op if you have no `//go:generate`
   directives in your code.
 
 ## FIPS (Federal Information Processing Standards)
@@ -112,6 +124,7 @@ To enable FIPS in your build there is a `make ensure-fips` target.
 Add `FIPS_ENABLED=true` to your repos Makefile. Please ensure that this variable is added **before** including boilerplate Makefiles.
 
 e.g.
+
 ```.mk
 FIPS_ENABLED=true
 

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -118,6 +118,7 @@ ALLOW_DIRTY_CHECKOUT?=false
 
 # TODO: Figure out how to discover this dynamically
 CONVENTION_DIR := boilerplate/openshift/golang-osd-operator
+BOILERPLATE_CONTAINER_MAKE := boilerplate/_lib/container-make
 
 # Set the default goal in a way that works for older & newer versions of `make`:
 # Older versions (<=3.8.0) will pay attention to the `default` target.
@@ -348,3 +349,26 @@ endif
 	rsync -a $(OLD_SDK_REPO_DIR)/Makefile .
 	rsync -a $(OLD_SDK_REPO_DIR)/.gitignore .
 	rsync -a $(OLD_SDK_REPO_DIR)/ . --exclude={'cmd','version','boilerplate','deploy','pkg'} --ignore-existing
+
+# Boilerplate container-make targets.
+# Runs 'make' in the boilerplate backing container.
+# If the command fails, starts a shell in the container so you can debug.
+.PHONY: container-test
+container-test:
+	${BOILERPLATE_CONTAINER_MAKE} test
+
+.PHONY: container-generate
+container-generate:
+	${BOILERPLATE_CONTAINER_MAKE} generate
+
+.PHONY: container-lint
+container-lint:
+	${BOILERPLATE_CONTAINER_MAKE} lint
+
+.PHONY: container-validate
+container-validate:
+	${BOILERPLATE_CONTAINER_MAKE} validate
+
+.PHONY: container-coverage
+container-coverage:
+	${BOILERPLATE_CONTAINER_MAKE} coverage


### PR DESCRIPTION
This PR adds `make container-{target}` targets to the convention Makefile making boilerplate's container-make more discoverable.

_The only con to this is duplication of targets, but given the enhanced discovery easing local testing, this should be plausible._