### PR TITLE
`opm-build-push` compatibility fixes

### DIFF
--- a/boilerplate/openshift/golang-lint/ensure.sh
+++ b/boilerplate/openshift/golang-lint/ensure.sh
@@ -6,7 +6,7 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh
 
 GOLANGCI_LINT_VERSION="1.30.0"
-OPM_VERSION="v1.15.2"
+OPM_VERSION="v1.23.2"
 GRPCURL_VERSION="1.7.0"
 DEPENDENCY=${1:-}
 GOOS=$(go env GOOS)

--- a/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
+++ b/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
@@ -71,7 +71,7 @@ function check_bundle_contents_cmd() {
 # Check we are running an opm supported container engine
 function check_opm_supported_container_engine() {
     local image_builder=${1}
-    if [[ "$image_builder" != "docker" && "$image_builder" != "podman" ]]; then
+    if [[ "$image_builder" != docker* && "$image_builder" != "podman" ]]; then
         # opm error messages are obscure. Let's make this clear
         log "image_builder $image_builder is not one of docker or podman"
         return 1

--- a/boilerplate/openshift/golang-osd-operator/ensure.sh
+++ b/boilerplate/openshift/golang-osd-operator/ensure.sh
@@ -6,7 +6,7 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh
 
 GOLANGCI_LINT_VERSION="1.30.0"
-OPM_VERSION="v1.15.2"
+OPM_VERSION="v1.23.2"
 GRPCURL_VERSION="1.7.0"
 DEPENDENCY=${1:-}
 GOOS=$(go env GOOS)


### PR DESCRIPTION
### Summary

- Allows `opm-build-push` to work with an `image_builder` including a `--config` flag i.e. `docker --config ...`
- Fixes OLM incompatibilities caused by catalog images built with old OPM versions, see https://github.com/operator-framework/operator-registry/issues/619, in particular catalog images built with `v1.15.2` will fail on OCP 4.12+