### PR TITLE
Improving documentation around new image tags, cleanup old Operator-SDK logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,5 +76,6 @@ tags
 .vscode/*
 .history
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
+.idea
 .project
 .pydevproject

--- a/README.md
+++ b/README.md
@@ -369,36 +369,32 @@ See existing test cases for examples.
 If you make a change to the build image produced by boilerplate -- i.e.
 by changing anything in [config/](config/) -- you must:
 
-1. Publish a new tag. This will be picked up by appsre and used to
-   publish a new tagged image for consumption via `LATEST_IMAGE_TAG` in
-   conventions. The tag must be named `image-v{X}.{Y}.{Z}`, using
-   [semver](https://semver.org/) principles when deciding what
-   `{X}.{Y}.{Z}` should be.
-
-Example:
-
-```shell
-$ git tag image-v1.2.3
-$ git push origin --tags
-$ git push upstream --tags
-```
-
-**NOTE:** You must do the `upstream` push *after* creating your PR. Otherwise the
-tagged commit will not exist upstream.
-
-**NOTE:** Your commit must also update the tag in a couple of places in
-the repository. See https://github.com/openshift/boilerplate/pull/180
+1. Publish a new tag. This will be picked up by AppSRE and used to publish a new tagged image for consumption via
+`LATEST_IMAGE_TAG` in conventions. The tag must be named `image-v{X}.{Y}.{Z}`, using [semver](https://semver.org/)
+principles when deciding what `{X}.{Y}.{Z}` should be. See https://github.com/openshift/boilerplate/pull/180
 for an example.
 
-2. Import that tag via boilerplate's ImageStream in `openshift/release`
-   by adding an element to the `spec.tags` list in
-   [this configuration file](https://github.com/openshift/release/blob/master/clusters/app.ci/supplemental-ci-images/boilerplate/boilerplate.yaml).
+    ```shell
+    git tag image-v1.2.3
+    git push origin --tags
+    # Create PR here
+    # Typically only team leads can push tags to upstream, so they will need to continue by
+    # checking out your fork and then running
+    git push upstream --tags
+    ```
+
+    >**NOTE**: You must do the `upstream` push *after* creating your PR. Otherwise, the tagged commit will not exist
+upstream.
+
+2. Import that tag via boilerplate's ImageStream in `openshift/release` by adding an element to the `spec.tags` list in
+[this configuration file](https://github.com/openshift/release/blob/master/clusters/app.ci/supplemental-ci-images/boilerplate/boilerplate.yaml).
 
 #### Making CI Efficient
 The backing image is built in prow with every commit, even when nothing about it has changed.
-To make this faster, we periodically ratchet the base image (the `FROM` in the [Dockerfile](config/Dockerfile)) to point to the previously-released image, and clear out the [build script](config/build.sh) to start from that point.
+To make this faster, we periodically ratchet the base image (the `FROM` in the [Dockerfile](config/Dockerfile))
+to point to the previously-released image, and clear out the [build script](config/build.sh) to start from that point.
 However, in app-sre we build from scratch (exactly once per `image-v*` tag!), via a [separate Dockerfile](config/Dockerfile.appsre).
-Thus there is a (very small) chance that these builds will behave differently.
+Thus, there is a (very small) chance that these builds will behave differently.
 
 #### Picking Up (Security) Fixes
 We only build and publish a new build image on commits tagged with `image-v*`, which we [force](config/tag-check.sh) you to do whenever something about *boilerplate's* image configuration changes.

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -82,14 +82,15 @@ export HOME=/tmp/home
 endif
 PWD=$(shell pwd)
 
+GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS="${GOFLAGS_MOD}"
+GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"
+
 ifeq (${FIPS_ENABLED}, true)
 GOFLAGS_MOD+=-tags=fips_enabled
 GOFLAGS_MOD:=$(strip ${GOFLAGS_MOD})
+GOENV+=GOEXPERIMENT=boringcrypto
+GOENV:=$(strip ${GOENV})
 endif
-
-GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS="${GOFLAGS_MOD}"
-
-GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"
 
 # GOLANGCI_LINT_CACHE needs to be set to a directory which is writeable
 # Relevant issue - https://github.com/golangci/golangci-lint/issues/734


### PR DESCRIPTION
[OSD-13437](https://issues.redhat.com//browse/OSD-13437): Continuing cleanup work as a result of #246 before releasing a v3.0.1 

* Tidying up the README a bit and adding a callout that we need a team lead to help push tags
* Cleaning up some logic around old operator-sdk versions in the `golang-osd-operator` convention
* Sharing the `ALLOW_DIRTY_CHECKOUT` workaround in the error message of `make isclean`
* Updating fips logic as now we just need to set an environment variable `GOEXPERIMENT=boringcrypto` https://github.com/golang/go/issues/51940#issuecomment-1206852980