### PR TITLE
Increment boilerplate image-v3.0.1 and ensure jq is in the image

### DIFF
--- a/boilerplate/test/test-base-convention/update
+++ b/boilerplate/test/test-base-convention/update
@@ -29,5 +29,5 @@ echo "Validating variables exported from the main update driver"
 # Granny switch to disable this check for weird tests like reverting to master
 if [[ -z "$SKIP_IMAGE_TAG_CHECK" ]]; then
     # Update this when publishing a new image tag
-    [[ "$LATEST_IMAGE_TAG" == "image-v3.0.0" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
+    [[ "$LATEST_IMAGE_TAG" == "image-v3.0.1" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
 fi

--- a/config/build_image-v3.0.0.sh
+++ b/config/build_image-v3.0.0.sh
@@ -124,7 +124,7 @@ yum -y autoremove
 # autoremove removes ssh (which it presumably wouldn't if we were able
 # to install git from a repository, because git has a dep on ssh.)
 # Do we care to restrict this to a particular version?
-yum -y install openssh-clients
+yum -y install openssh-clients jq
 
 rm -rf /var/cache/yum
 

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -3,7 +3,7 @@ if [ "$BOILERPLATE_SET_X" ]; then
 fi
 
 # NOTE: Change this when publishing a new image tag.
-LATEST_IMAGE_TAG=image-v3.0.0
+LATEST_IMAGE_TAG=image-v3.0.1
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 # Make all tests use this local clone by default.


### PR DESCRIPTION
* Somehow `jq` isn't in this image even though it was in #247 - making sure it explicitly is in the image now.
* Incrementing boilerplate's image tag to image-v3.0.1

For [OSD-13790](https://issues.redhat.com//browse/OSD-13790), still need to increment image-v3.0.2 to speedup CI in a future PR