### PR TITLE
Add the new go:build syntax for `go fmt`

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/fips.go.tmplt
+++ b/boilerplate/openshift/golang-osd-operator/fips.go.tmplt
@@ -1,3 +1,4 @@
+//go:build fips_enabled
 // +build fips_enabled
 
 // BOILERPLATE GENERATED -- DO NOT EDIT


### PR DESCRIPTION
Currently if you run `go fmt` on fips.go it adds this line since Go 1.17 (boilerplate's latest image is on Go 1.19)

Ref: https://pkg.go.dev/cmd/go#hdr-Build_constraints
```
Go versions 1.16 and earlier used a different syntax for build constraints, with a "// +build" prefix. The gofmt command will add an equivalent //go:build constraint when encountering the older syntax.
```

The `// +build` syntax is deprecated, but leaving it for now for backwards compatibility and we can remove it later