### PR TITLE
Add OWNER_ALIASES To golang-osd-operator Convention

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/OWNER_ALIASES
+++ b/boilerplate/openshift/golang-osd-operator/OWNER_ALIASES
@@ -1,0 +1,86 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#OWNERS_ALIASES
+aliases:
+  srep-functional-team-aurora:
+    - abyrne55
+    - bdematte
+    - boranx
+    - dakotalongRH
+    - lnguyen1401
+    - luis-falcon
+    - rafael-azevedo
+  srep-functional-team-fedramp:
+    - tonytheleg
+    - theautoroboto
+    - rhdedgar
+    - katherinelc321
+    - robotmaxtron
+    - rojasreinold
+  srep-functional-team-hulk:
+    - mrbarge
+    - a7vicky
+    - bmeng
+    - jwai7
+    - rendhalver
+    - ravitri
+    - shitaljante
+    - weherdh
+  srep-functional-team-orange:
+    - bng0y
+    - typeid
+    - Makdaam
+    - Nikokolas3270
+    - ninabauer
+    - RaphaelBut
+    - Tessg22
+    - thavlice
+  srep-functional-team-rocket:
+    - anispate
+    - yithian
+    - aliceh
+    - bdmiller3
+    - mjlshen
+    - sam-nguyen7
+    - tnierman
+  srep-functional-team-security:
+    - karthikperu7
+    - clcollins
+    - gsleeman
+    - jaybeeunix
+    - wshearn
+  srep-functional-team-thor:
+    - wanghaoran1988
+    - MitaliBhalla
+    - hectorakemp
+    - reetika-vyas
+    - feichashao
+    - supreeth7
+    - Tafhim
+  srep-functional-team-v1alpha1:
+    - iamkirkbater
+    - AlexVulaj
+    - T0MASD
+    - bergmannf
+    - dkeohane
+    - reedcort
+    - mrWinston
+  srep-functional-leads:
+    - mrbarge
+    - rafael-azevedo
+    - wanghaoran1988
+    - sam-nguyen7
+    - iamkirkbater
+    - bng0y
+    - tonytheleg
+    - karthikperu7
+  srep-team-leads:
+    - cblecker
+    - jharrington22
+    - NautiluX
+    - rogbas
+    - jewzaam
+    - fahlmant
+    - dustman9000
+  srep-architects:
+    - jewzaam
+    - jharrington22
+    - cblecker

--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -14,6 +14,10 @@ source $CONVENTION_ROOT/_lib/common.sh
 echo "Copying .codecov.yml to your repository root."
 cp ${HERE}/.codecov.yml $REPO_ROOT
 
+# Add OWNER_ALIASES to $REPO_ROOT
+echo "Copying OWNER_ALIASES to your repository root."
+cp ${HERE}/OWNER_ALIASES $REPO_ROOT
+
 # Add dependabot configuration
 mkdir -p $REPO_ROOT/.github
 echo "Copying dependabot.yml to .github/dependabot.yml"


### PR DESCRIPTION
This adds OWNER_ALIASES to make osd operator repo assignment easier to manage by assigning SREP functional team aliases to the OWNERS file instead of individual users. This will also ease the joiner/leaver process.