### PR TITLE
Boilerplate fixes

### DIFF
--- a/boilerplate/_lib/container-make
+++ b/boilerplate/_lib/container-make
@@ -19,14 +19,14 @@ CONTAINER_MOUNT=/go/src/$(repo_import $REPO_ROOT)
 
 # First set up a detached container with the repo mounted.
 banner "Starting the container"
+CE_OPTS="--platform=linux/amd64"
 if [[ "${CONTAINER_ENGINE##*/}" == "podman" ]]; then
-    if [[ $OSTYPE == *"darwin"* ]]; then
-        CE_OPTS="--userns keep-id -v $REPO_ROOT:$CONTAINER_MOUNT"
-    else
-        CE_OPTS="--userns keep-id -v $REPO_ROOT:$CONTAINER_MOUNT:Z"
-    fi
+    CE_OPTS="${CE_OPTS} --userns keep-id"
+fi
+if [[ "${CONTAINER_ENGINE##*/}" == "podman" ]] && [[ $OSTYPE == *"linux"* ]]; then
+    CE_OPTS="${CE_OPTS} -v $REPO_ROOT:$CONTAINER_MOUNT:Z"
 else
-    CE_OPTS="-v $REPO_ROOT:$CONTAINER_MOUNT"
+    CE_OPTS="${CE_OPTS} -v $REPO_ROOT:$CONTAINER_MOUNT"
 fi
 container_id=$($CONTAINER_ENGINE run -d ${CE_OPTS} $IMAGE_PULL_PATH sleep infinity)
 

--- a/boilerplate/openshift/golang-osd-operator/golangci.yml
+++ b/boilerplate/openshift/golang-osd-operator/golangci.yml
@@ -16,14 +16,11 @@ issues:
 linters:
   disable-all: true
   enable:
-  - deadcode
   - errcheck
   - gosec
   - gosimple
   - govet
   - ineffassign
   - staticcheck
-  - structcheck
   - typecheck
   - unused
-  - varcheck

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -26,6 +26,12 @@ CONTAINER_ENGINE_CONFIG_DIR = .docker
 # also accepts REGISTRY_AUTH_FILE from the env. See
 # https://www.mankier.com/1/podman-login#Options---authfile=path
 export REGISTRY_AUTH_FILE = ${CONTAINER_ENGINE_CONFIG_DIR}/config.json
+# If this configuration file doesn't exist, podman will error out. So
+# we'll create it if it doesn't exist.
+ifeq (,$(wildcard $(REGISTRY_AUTH_FILE)))
+$(shell mkdir -p $(CONTAINER_ENGINE_CONFIG_DIR))
+$(shell echo '{}' > $(REGISTRY_AUTH_FILE))
+endif
 # ==> Docker uses --config=PATH *before* (any) subcommand; so we'll glue
 # that to the CONTAINER_ENGINE variable itself. (NOTE: I tried half a
 # dozen other ways to do this. This was the least ugly one that actually
@@ -200,7 +206,7 @@ openapi-generate:
 			-p % \
 			-h /dev/null \
 			-r "-"
-	
+
 .PHONY: generate
 generate: op-generate go-generate openapi-generate
 
@@ -221,7 +227,7 @@ SETUP_ENVTEST = setup-envtest
 .PHONY: setup-envtest
 setup-envtest:
 	$(eval KUBEBUILDER_ASSETS := "$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir /tmp/envtest/bin)")
-	
+
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.


### PR DESCRIPTION
This contains two fixes:
- Updates containerized make commands to work properly on darwin using podman
- Removes deprecated linters (all of them have been combined into `unused` which is already run)