### PR TITLE
SDCICD-854  exclude osde2e folder from unit tests 

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -86,7 +86,7 @@ GOLANGCI_LINT_CACHE ?= /tmp/golangci-cache
 GOLANGCI_OPTIONAL_CONFIG ?=
 
 ifeq ($(origin TESTTARGETS), undefined)
-TESTTARGETS := $(shell ${GOENV} go list -e ./... | egrep -v "/(vendor)/")
+TESTTARGETS := $(shell ${GOENV} go list -e ./... | egrep -v "/(vendor)/" | egrep -v "/(osde2e)/")
 endif
 # ex, -v
 TESTOPTS :=


### PR DESCRIPTION
[SDCICD-854](https://issues.redhat.com//browse/SDCICD-854) adding /osde2e framework to operators. This creates a /osde2e folder with e2e tests within it. 

Need to exclude this folder from unit tests.