### PR TITLE
Update golangci-lint to v1.50.1 in the golang-lint convention

### DIFF
--- a/boilerplate/openshift/golang-lint/ensure.sh
+++ b/boilerplate/openshift/golang-lint/ensure.sh
@@ -5,9 +5,7 @@ set -eo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh
 
-GOLANGCI_LINT_VERSION="1.30.0"
-OPM_VERSION="v1.23.2"
-GRPCURL_VERSION="1.7.0"
+GOLANGCI_LINT_VERSION="1.50.1"
 DEPENDENCY=${1:-}
 GOOS=$(go env GOOS)
 

--- a/boilerplate/openshift/golang-lint/golangci.yml
+++ b/boilerplate/openshift/golang-lint/golangci.yml
@@ -16,13 +16,10 @@ issues:
 linters:
   disable-all: true
   enable:
-  - deadcode
   - errcheck
   - gosimple
   - govet
   - ineffassign
   - staticcheck
-  - structcheck
   - typecheck
   - unused
-  - varcheck


### PR DESCRIPTION
Go 1.19 is out and about, but v1.48.0 is the oldest to support it - https://github.com/golangci/golangci-lint/releases

Might as well get the latest? Also found some cruft with unused OPM/GRPCURL versions being specified

There have since been some deprecated checks:
```
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [linters_context] structcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649. 
```

So I have disabled those as well.