### PR TITLE
Fixes

### DIFF
--- a/boilerplate/openshift/osd-golang-operator-osde2e/e2e-harness-generate.sh
+++ b/boilerplate/openshift/osd-golang-operator-osde2e/e2e-harness-generate.sh
@@ -6,14 +6,14 @@ cmd=${0##*/}
 
 usage() {
     cat <<EOF
-Usage: $0 OPERATOR_NAME CONVENTION_DIR
+Usage: $0 OPERATOR_NAME OSDE2E_CONVENTION_DIR
  
 EOF
     exit -1
 }
 
 OPERATOR_NAME=$1
-CONVENTION_DIR=$2
+OSDE2E_CONVENTION_DIR=$2
 REPO_ROOT=$(git rev-parse --show-toplevel)
 HARNESS_DIR=$REPO_ROOT/osde2e
 

--- a/boilerplate/openshift/osd-golang-operator-osde2e/standard.mk
+++ b/boilerplate/openshift/osd-golang-operator-osde2e/standard.mk
@@ -51,7 +51,7 @@ GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS="${GOFLAGS_MOD}"
 ALLOW_DIRTY_CHECKOUT?=false
 
 # TODO: Figure out how to discover this dynamically
-CONVENTION_DIR := boilerplate/openshift/osd-golang-operator-osde2e
+OSDE2E_CONVENTION_DIR := $(CURDIR)
 
 # Set the default goal in a way that works for older & newer versions of `make`:
 # Older versions (<=3.8.0) will pay attention to the `default` target.
@@ -84,7 +84,7 @@ container-engine-login:
 # create e2e scaffolding
 .PHONY: e2e-harness-generate
 e2e-harness-generate:
-	${CONVENTION_DIR}/e2e-harness-generate.sh $(OPERATOR_NAME) $(CONVENTION_DIR)
+	${OSDE2E_CONVENTION_DIR}/e2e-harness-generate.sh $(OPERATOR_NAME) $(OSDE2E_CONVENTION_DIR)
 
 # create binary
 GOFLAGS=-mod=mod
@@ -97,5 +97,5 @@ e2e-harness-build:
 .PHONY: e2e-image-build-push
 e2e-image-build-push:
 	echo imageurl1:$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(HARNESS_IMAGE_NAME):latest
-	${CONVENTION_DIR}/e2e-image-build-push.sh "./osde2e/Dockerfile $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(HARNESS_IMAGE_NAME):latest"
+	${OSDE2E_CONVENTION_DIR}/e2e-image-build-push.sh "./osde2e/Dockerfile $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(HARNESS_IMAGE_NAME):latest"
  

--- a/boilerplate/openshift/osd-golang-operator-osde2e/standard.mk
+++ b/boilerplate/openshift/osd-golang-operator-osde2e/standard.mk
@@ -51,7 +51,7 @@ GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS="${GOFLAGS_MOD}"
 ALLOW_DIRTY_CHECKOUT?=false
 
 # TODO: Figure out how to discover this dynamically
-OSDE2E_CONVENTION_DIR := $(CURDIR)
+OSDE2E_CONVENTION_DIR := boilerplate/openshift/osd-golang-operator-osde2e
 
 # Set the default goal in a way that works for older & newer versions of `make`:
 # Older versions (<=3.8.0) will pay attention to the `default` target.


### PR DESCRIPTION
Variable named CONVENTION_DIR in osde2e convention to OSDE2E_CONVENTION_DIR. It was conflicting with CONVENTION_DIR of golang-osd-operator convention which defines lint, converage and images targets used by prow jobs. This makes prow jobs fail. 

 