### PR TITLE
Scope GO vars per make target instead of globally

### DIFF
--- a/boilerplate/openshift/golang-osd-operator-osde2e/e2e-image-build-push.sh
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/e2e-image-build-push.sh
@@ -13,7 +13,7 @@ dockerfile_path image_uri
 
 # This is the test harness image
 ./build/Dockerfile quay.io/app-sre/my-wizbang-operator-test-harness:latest
- 
+
 
     The parameter is mandatory; if only building the catalog image,
     specify the empty string.
@@ -28,7 +28,7 @@ source $REPO_ROOT/boilerplate/_lib/common.sh
 
 
 IMAGE_SPECS="$1"
- 
+
 
 while read dockerfile_path image_uri junk; do
     # Support comment lines
@@ -47,7 +47,7 @@ while read dockerfile_path image_uri junk; do
         echo "Invalid image spec: no such dockerfile: '$dockerfile_path'"
         exit 1
     fi
- 
+
     make IMAGE_URI="${image_uri}" DOCKERFILE_PATH="${dockerfile_path}" container-build-push-one
- 
+
 done <<< "$1"


### PR DESCRIPTION
The golang-osd-operator-osde2e convention was breaking the golang-osd-operator convention due to the setting of some global GO vars. Changed to set these per target, thus removing from global scope. Tested locally in the aws-vpce-operator repo.