### PR TITLE
osde2e convention fix: Adding necessary "Test" prefix to e2e test runner function

### DIFF
--- a/boilerplate/openshift/golang-osd-operator-osde2e/e2e-harness-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/e2e-harness-generate.sh
@@ -69,7 +69,7 @@ const (
 )
 
 // Test entrypoint. osde2e runs this as a test suite on test pod.
-func $REPLACE_FUNC(t *testing.T) {
+func Test$REPLACE_FUNC(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	suiteConfig, reporterConfig := GinkgoConfiguration()


### PR DESCRIPTION
Main test function is missing "Test" prefix. This makes `go test` not recognize the osde2e folder at all. 