### PR TITLE
Fixes to allow olm-registry dockerfiles to work

### DIFF
--- a/boilerplate/_lib/freeze-check
+++ b/boilerplate/_lib/freeze-check
@@ -70,9 +70,9 @@ cd $REPO_ROOT
 BOILERPLATE_GIT_CLONE="git clone $TMPD" boilerplate/update
 
 # Okay, if anything has changed, that's bad.
-if [[ $(git status --porcelain | wc -l) -ne 0 ]]; then
+if [[ $(git status --porcelain -- ':!build/Dockerfile*' | wc -l) -ne 0 ]]; then
   echo "Your boilerplate is dirty!" >&2
-  git status --porcelain
+  git status --porcelain -- ':!build/Dockerfile*'
   exit 1
 fi
 

--- a/boilerplate/test/test-base-convention/update
+++ b/boilerplate/test/test-base-convention/update
@@ -29,5 +29,5 @@ echo "Validating variables exported from the main update driver"
 # Granny switch to disable this check for weird tests like reverting to master
 if [[ -z "$SKIP_IMAGE_TAG_CHECK" ]]; then
     # Update this when publishing a new image tag
-    [[ "$LATEST_IMAGE_TAG" == "image-v3.0.2" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
+    [[ "$LATEST_IMAGE_TAG" == "image-v3.0.3" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
 fi

--- a/config/build_image-v3.0.0.sh
+++ b/config/build_image-v3.0.0.sh
@@ -124,7 +124,7 @@ yum -y autoremove
 # autoremove removes ssh (which it presumably wouldn't if we were able
 # to install git from a repository, because git has a dep on ssh.)
 # Do we care to restrict this to a particular version?
-yum -y install openssh-clients jq
+yum -y install openssh-clients jq skopeo
 
 rm -rf /var/cache/yum
 

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -3,7 +3,7 @@ if [ "$BOILERPLATE_SET_X" ]; then
 fi
 
 # NOTE: Change this when publishing a new image tag.
-LATEST_IMAGE_TAG=image-v3.0.2
+LATEST_IMAGE_TAG=image-v3.0.3
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 # Make all tests use this local clone by default.


### PR DESCRIPTION
Two changes:
- First, install skopeo into the build image
- Second, don't fail validations if there is a difference in the Dockerfiles. We expect some customization here with using dependabot to update images