### PR TITLE
Remove prescriptive URL from config/Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ isclean: ## Validate the local checkout is clean. Use ALLOW_DIRTY_CHECKOUT=true 
 
 .PHONY: tag-check
 tag-check: ## Perform a tag-check that validates a new tag has been created when changing the build image
-	config/tag-check.sh
+	@config/tag-check.sh
 
 .PHONY: test
 test: isclean ## Runs tests under the /case directory

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,2 +1,3 @@
-# NOTE: Keep this in sync with .ci-operator.yaml
-FROM registry.ci.openshift.org/openshift/boilerplate:image-v3.0.1
+# This file is used to confirm that the imagestream is valid and working
+# the below statement will always be replaced by the source in .ci-operator.yaml
+FROM REPLACE_ME

--- a/config/tag-check.sh
+++ b/config/tag-check.sh
@@ -24,7 +24,8 @@ fi
 
 # Since we're in a PR, and there may be multiple commits, we want to
 # check all of them; so compare against the fork point of this branch.
-# Don't compare
+# Don't compare the config/Dockerfile or config/tag-check.sh files, as
+# they're not impacted by build image changes.
 default_branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
 fork_point=$(git merge-base --fork-point $default_branch)
 diff=$(git diff $fork_point --name-only -- config/ ':!config/Dockerfile' ':!config/tag-check.sh')

--- a/config/tag-check.sh
+++ b/config/tag-check.sh
@@ -26,7 +26,7 @@ fi
 # check all of them; so compare against the fork point of this branch.
 # Don't compare the config/Dockerfile or config/tag-check.sh files, as
 # they're not impacted by build image changes.
-default_branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+default_branch="master"
 fork_point=$(git merge-base --fork-point $default_branch)
 diff=$(git diff $fork_point --name-only -- config/ ':!config/Dockerfile' ':!config/tag-check.sh')
 if [[ -n "${diff}" ]]; then


### PR DESCRIPTION
We don't really need this, as this dockerfile is only used in prow image builds, and the FROM line should get replaced. This tests that.

Also fixes a logic error in `make tag-check` where the default branch wasn't being detected properly.