### PR TITLE
Revert yq/python version bump

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
@@ -48,8 +48,9 @@ fi
 if [[ -z "$CONTAINER_ENGINE" ]]; then
     YQ_CMD="yq"
 else
-    $CONTAINER_ENGINE pull quay.io/app-sre/yq:4
-    YQ_CMD="$CONTAINER_ENGINE run --rm -i quay.io/app-sre/yq:4 yq"
+    yq_image="quay.io/app-sre/yq:3.4.1"
+    $CONTAINER_ENGINE pull $yq_image
+    YQ_CMD="$CONTAINER_ENGINE run --rm -i $yq_image yq"
 fi
 
 # Get the image URI as repo URL + image digest
@@ -176,5 +177,5 @@ else
     else
         CE_OPTS="-v `pwd`:`pwd`"
     fi
-    $CONTAINER_ENGINE run --pull=always --rm ${CE_OPTS} -u `id -u`:0 -w `pwd` registry.access.redhat.com/ubi8/python-39 /bin/bash -c "python -m pip install --disable-pip-version-check oyaml; python ./boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py -o ${operator_name} -d ${OUTPUT_DIR} ${PREV_VERSION_OPTS} -i ${REPO_DIGEST} -V ${operator_version}"
+    $CONTAINER_ENGINE run --pull=always --rm ${CE_OPTS} -u `id -u`:0 -w `pwd` registry.access.redhat.com/ubi8/python-36 /bin/bash -c "python -m pip install --disable-pip-version-check oyaml; python ./boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py -o ${operator_name} -d ${OUTPUT_DIR} ${PREV_VERSION_OPTS} -i ${REPO_DIGEST} -V ${operator_version}"
 fi


### PR DESCRIPTION
I didn't intend to bump the versions of these yet -- there's some incompatibilities.

Sets the versions back to pre- 4b929d2cb15df8fd9100797f39d67cdfa5dea0ab