### PR TITLE
updating docker registry credentials for test-harness for ci-operator

### DIFF
--- a/boilerplate/openshift/golang-osd-operator-osde2e/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/standard.mk
@@ -11,15 +11,10 @@ endif
 
 ### Accommodate docker or podman
 #
-# The docker/podman creds cache needs to be in a location unique to this
-# invocation; otherwise it could collide across jenkins jobs. We'll use
-# a .docker folder relative to pwd (the repo root).
-CONTAINER_ENGINE_CONFIG_DIR = .docker
-# But docker and podman use different options to configure it :eyeroll:
-# ==> Podman uses --authfile=PATH *after* the `login` subcommand; but
-# also accepts REGISTRY_AUTH_FILE from the env. See
-# https://www.mankier.com/1/podman-login#Options---authfile=path
-export REGISTRY_AUTH_FILE = ${CONTAINER_ENGINE_CONFIG_DIR}/config.json
+# secret file volume for prow jobs
+CONTAINER_ENGINE_CONFIG_DIR = /etc/pull-secret
+# docker config file loaded by prow  
+export REGISTRY_AUTH_FILE = ${CONTAINER_ENGINE_CONFIG_DIR}/.dockerconfigjson
 # If this configuration file doesn't exist, podman will error out. So
 # we'll create it if it doesn't exist.
 ifeq (,$(wildcard $(REGISTRY_AUTH_FILE)))


### PR DESCRIPTION
Currently operator postsubmit job for `osde2e test harness image publish` is failing as the secret path specified in makefile doesn't match the secrets available to the test container. 

This PR updates the `osde2e convention` makefile to use prow provided creds per the example prowgen postsubmit  job https://github.com/openshift/release/blob/master/ci-operator/jobs/openshift/aws-vpce-operator/openshift-aws-vpce-operator-main-postsubmits.yaml#L67

Surfaced by https://issues.redhat.com/browse/SDCICD-888 