### PR TITLE
removing gomod tidy, let go test update gomod

### DIFF
--- a/boilerplate/openshift/golang-osd-operator-osde2e/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/standard.mk
@@ -69,7 +69,6 @@ e2e-harness-generate:
 e2e-harness-build: GOFLAGS_MOD=-mod=mod
 e2e-harness-build: GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS="${GOFLAGS_MOD}"
 e2e-harness-build:
-	go mod tidy
 	${GOENV} go test ./osde2e -v -c --tags=integration -o harness.test
 
 # TODO: Push to a known image tag and commit id


### PR DESCRIPTION
Removing `go mod tidy` statement from e2e-harness-build target. `go test` should update mod file if necessary. 