### PR TITLE
fix: escaped quote in template

### DIFF
--- a/boilerplate/openshift/golang-osd-operator-osde2e/e2e-harness-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/e2e-harness-generate.sh
@@ -31,11 +31,11 @@ echo "
 FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder
 WORKDIR /go/src/github.com/openshift/aws-vpce-operator/
 COPY . .
-RUN  CGO_ENABLED=0 GOFLAGS="-mod=mod" go test ./osde2e -v -c --tags=integration -o /harness.test    
+RUN  CGO_ENABLED=0 GOFLAGS=\"-mod=mod\" go test ./osde2e -v -c --tags=integration -o /harness.test    
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 COPY --from=builder ./harness.test harness.test
-ENTRYPOINT [ "/harness.test" ]" > $HARNESS_DIR/Dockerfile
+ENTRYPOINT [ \"/harness.test\" ]" > $HARNESS_DIR/Dockerfile
 
 echo "package osde2etests
 


### PR DESCRIPTION
re-added missing quote escape in cat'ed dockerfile template 