### PR TITLE
Exclude build/Dockerfile* From Freeze Check Script

### DIFF
--- a/boilerplate/_lib/freeze-check
+++ b/boilerplate/_lib/freeze-check
@@ -35,7 +35,7 @@ BOILERPLATE_GIT_REPO=https://github.com/openshift/boilerplate.git
 # and reapply the diff? Messy and error-prone -- and I would be
 # seriously ticked off if something went wrong and lost my in-flight
 # changes.
-if ! [ -z "$(git status --porcelain)" ]; then
+if ! [ -z "$(git status --porcelain -- ':!build/Dockerfile*')" ]; then
   echo "Can't validate boilerplate in a dirty repository. Please commit your changes and try again." >&2
   exit 1
 fi


### PR DESCRIPTION
This adds the `build/Dockerfile*` to the initial `git status --porcelain` check in the freeze-check script that was missed in a prior PR (https://github.com/openshift/boilerplate/pull/275).