### PR TITLE
Allow generation of embedded ObjectMeta in CRDs

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -193,7 +193,7 @@ OPENAPI_GEN = openapi-gen
 .PHONY: op-generate
 ## CRD v1beta1 is no longer supported.
 op-generate:
-	cd ./api; $(CONTROLLER_GEN) crd:crdVersions=v1 paths=./... output:dir=$(PWD)/deploy/crds
+	cd ./api; $(CONTROLLER_GEN) crd:crdVersions=v1,generateEmbeddedObjectMeta=true paths=./... output:dir=$(PWD)/deploy/crds
 	cd ./api; $(CONTROLLER_GEN) object paths=./...
 
 .PHONY: openapi-generate


### PR DESCRIPTION
This will allow for using metav1.ObjectMeta's in nested fields. Without this option, the generated metadata field is non-functional as described in https://github.com/kubernetes-sigs/controller-tools/pull/557.

[OSD-15666](https://issues.redhat.com//browse/OSD-15666)