### PR TITLE
updates olm registry dockerfile to fix issues running on FIPS clusters

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/Dockerfile.olm-registry
+++ b/boilerplate/openshift/golang-osd-operator/Dockerfile.olm-registry
@@ -3,8 +3,15 @@ ARG SAAS_OPERATOR_DIR
 COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
+# addresses issues with registry images failing to run on FIPS enabled clusters
+FROM registry.access.redhat.com/ubi8/ubi:latest AS ubi-micro-build
+RUN mkdir -p /mnt/rootfs
+RUN yum install --installroot /mnt/rootfs --releasever 8 --setopt install_weak_deps=false --nodocs -y coreutils-single glibc-minimal-langpack openssl; yum clean all
+RUN rm -rf /mnt/rootfs/var/cache/*
+
 FROM registry.access.redhat.com/ubi8/ubi-micro:latest
 
+COPY --from=ubi-micro-build /mnt/rootfs/ /
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
 COPY --from=builder /bin/initializer /bin/initializer


### PR DESCRIPTION
As of 2 days ago, newer registry images built using boilerplate fail to run on clusters with FIPS enabled. The registry pod will fail to start with the only log being

`FIPS mode is enabled, but the required OpenSSL library is not available`

The issue appears to be realted to [OCPBUGS-16128](https://issues.redhat.com/browse/OCPBUGS-16128). This issue is currently impacting FedRAMP clusters as it would appeart the base image containing registry server, quay.io/openshift/origin-operator-registry:4.12, is being updated on a regular basis. At some point an update to the tagged image caused a breaking change.  

This PR adds openssl to the ubi-micro container running registry server to address the problem for now. 


Added: Most recent PR that would have affected 4.12
https://github.com/openshift/operator-framework-olm/pull/512