### PR TITLE
Fix bugs preventing registry from running in fips mode

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/Dockerfile.olm-registry
+++ b/boilerplate/openshift/golang-osd-operator/Dockerfile.olm-registry
@@ -1,9 +1,10 @@
-FROM quay.io/openshift/origin-operator-registry:4.12 AS builder
+FROM registry.redhat.io/openshift4/ose-operator-registry:v4.12 AS builder
 ARG SAAS_OPERATOR_DIR
 COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
-FROM registry.access.redhat.com/ubi8/ubi-micro:latest
+# ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/boilerplate/openshift/golang-osd-operator/dependabot.yml
+++ b/boilerplate/openshift/golang-osd-operator/dependabot.yml
@@ -10,5 +10,5 @@ updates:
     ignore:
       - dependency-name: "app-sre/boilerplate"
         # don't upgrade boilerplate via these means
-      - dependency-name: "openshift/origin-operator-registry"
-        # don't upgrade origin-operator-registry via these means
+      - dependency-name: "openshift4/ose-operator-registry"
+        # don't upgrade ose-operator-registry via these means


### PR DESCRIPTION
registry.redhat.io/openshift4/ose-operator-registry:v4.12 is the OCP released image that has more guarantees about its release process and ubi-micro needs OpenSSL to be available in order to run in fips mode. Validated that this Dockerfile produces a registry image that can run on a fips enabled cluster.

[OSD-17631](https://issues.redhat.com//browse/OSD-17631)