### PR TITLE
CGO_ENABLED=1 for FIPS compliance

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -88,7 +88,7 @@ export HOME=/tmp/home
 endif
 PWD=$(shell pwd)
 
-GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS="${GOFLAGS_MOD}"
+GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=1 GOFLAGS="${GOFLAGS_MOD}"
 GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"
 
 ifeq (${FIPS_ENABLED}, true)

--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -41,9 +41,9 @@ for file in $DOCKERFILES; do
     ${SED?} -i "1s,.*,FROM $IMAGE_PULL_PATH AS builder," $file
   fi
 
-  # Update any UBI images using latest tags to use a versioned tag that is compatible with dependabot
-  for ubi_latest in $(grep -oE 'registry.access.redhat.com/ubi[7-9]/ubi.*?:latest' ${file}); do
-      replacement_image=$(skopeo inspect --override-os linux --override-arch amd64 docker://${ubi_latest} --format "{{.Name}}:{{.Labels.version}}-{{.Labels.release}}" | ${SED?} 's,\.[0-9]\+$,,')
+  # Update any UBI images to use a versioned tag of ubi8/ubi-minimal that is compatible with dependabot
+  for ubi_latest in $(grep -oE 'registry.access.redhat.com/ubi[7-9]/ubi.*?:.*' ${file}); do
+      replacement_image=$(skopeo inspect --override-os linux --override-arch amd64 docker://registry.access.redhat.com/ubi8/ubi-minimal --format "{{.Name}}:{{.Labels.version}}-{{.Labels.release}}" | ${SED?} 's,\.[0-9]\+$,,')
       echo "Overwriting ${file}'s ${ubi_latest} image to ${replacement_image}"
       ${SED?} -i "s,${ubi_latest},${replacement_image}," ${file}
   done


### PR DESCRIPTION
https://developers.redhat.com/articles/2022/05/31/your-go-application-fips-compliant

Additionally each consuming operator must use ubi-minimal, such as https://github.com/openshift/aws-vpce-operator/blob/b765a7f103a521e32a591ff5e4e64d6cd0324ec1/build/Dockerfile#L11

[OSD-17665](https://issues.redhat.com//browse/OSD-17665)