### PR TITLE
Use GOEXPERIMENT=strictfipsruntime

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -94,7 +94,8 @@ GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPAT
 ifeq (${FIPS_ENABLED}, true)
 GOFLAGS_MOD+=-tags=fips_enabled
 GOFLAGS_MOD:=$(strip ${GOFLAGS_MOD})
-GOENV+=GOEXPERIMENT=boringcrypto
+echo 'Setting GOEXPERIMENT=strictfipsruntime,boringcrypto - this generally does not work locally, if running locally consider FIPS_ENABLED=false.'
+GOENV+=GOEXPERIMENT=strictfipsruntime,boringcrypto
 GOENV:=$(strip ${GOENV})
 endif
 

--- a/boilerplate/test/test-base-convention/update
+++ b/boilerplate/test/test-base-convention/update
@@ -29,5 +29,5 @@ echo "Validating variables exported from the main update driver"
 # Granny switch to disable this check for weird tests like reverting to master
 if [[ -z "$SKIP_IMAGE_TAG_CHECK" ]]; then
     # Update this when publishing a new image tag
-    [[ "$LATEST_IMAGE_TAG" == "image-v3.0.3" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
+    [[ "$LATEST_IMAGE_TAG" == "image-v3.0.4" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
 fi

--- a/config/Dockerfile.appsre
+++ b/config/Dockerfile.appsre
@@ -1,7 +1,7 @@
 # Cumulative Dockerfile for app-sre. It should start FROM the base image
 # and then RUN all the build scripts in order.
 
-# https://github.com/openshift/ocp-build-data/blob/c368f52d7558eaa249c409f444596057bc5c737a/streams.yml#L43-L47
+# https://github.com/openshift-eng/ocp-build-data/blob/9494ba767c7e96654595f69509b0ff9513eea9b8/streams.yml#L36-L43
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12
 
 COPY build_image-v3.0.0.sh /build.sh

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -3,7 +3,7 @@ if [ "$BOILERPLATE_SET_X" ]; then
 fi
 
 # NOTE: Change this when publishing a new image tag.
-LATEST_IMAGE_TAG=image-v3.0.3
+LATEST_IMAGE_TAG=image-v3.0.4
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 # Make all tests use this local clone by default.


### PR DESCRIPTION
[OSD-17665](https://issues.redhat.com//browse/OSD-17665)

Set `GOEXPERIMENT=strictfipsruntime`

This ensures that the binary will fail to run if running in a non-FIPS
Compliant environment when built with `FIPS_ENABLED=true`.

`GOEXPERIMENT=strictfipsruntime` is not supported by Go generally and is
something that Red Hat is supporting in our own fork. When building 
locally, developers should set `FIPS_ENABLED=false` to get around this.

Using this requires that our boilerplate base image gets rebuilt to pull in the latest `registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12`