### PR TITLE
Bump base image to v3.0.4 in CI

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   namespace: openshift
   name: boilerplate
-  tag: image-v3.0.3
+  tag: image-v3.0.4


### PR DESCRIPTION
Newly created from https://github.com/openshift/boilerplate/pull/298

[OSD-17665](https://issues.redhat.com//browse/OSD-17665)