### PR TITLE
Fix bug with printing output in Makefiles

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -94,7 +94,7 @@ GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPAT
 ifeq (${FIPS_ENABLED}, true)
 GOFLAGS_MOD+=-tags=fips_enabled
 GOFLAGS_MOD:=$(strip ${GOFLAGS_MOD})
-echo 'Setting GOEXPERIMENT=strictfipsruntime,boringcrypto - this generally does not work locally, if running locally consider FIPS_ENABLED=false.'
+$(warning Setting GOEXPERIMENT=strictfipsruntime,boringcrypto - this generally causes builds to fail unless building inside the provided Dockerfile. If building locally consider calling 'go build .')
 GOENV+=GOEXPERIMENT=strictfipsruntime,boringcrypto
 GOENV:=$(strip ${GOENV})
 endif


### PR DESCRIPTION
Currently, this results in:

```
boilerplate/openshift/golang-osd-operator/standard.mk:97: *** missing separator.  Stop.
```

Tested the replacement syntax and confirmed it works inside the CI container

[OSD-17665](https://issues.redhat.com//browse/OSD-17665)