### PR TITLE
Add govulncheck to the boilerplate image

### DIFF
--- a/boilerplate/test/test-base-convention/update
+++ b/boilerplate/test/test-base-convention/update
@@ -29,5 +29,5 @@ echo "Validating variables exported from the main update driver"
 # Granny switch to disable this check for weird tests like reverting to master
 if [[ -z "$SKIP_IMAGE_TAG_CHECK" ]]; then
     # Update this when publishing a new image tag
-    [[ "$LATEST_IMAGE_TAG" == "image-v3.0.4" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
+    [[ "$LATEST_IMAGE_TAG" == "image-v3.0.5" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
 fi

--- a/config/build_image-v3.0.0.sh
+++ b/config/build_image-v3.0.0.sh
@@ -63,6 +63,12 @@ go install k8s.io/code-generator/cmd/openapi-gen@${OPENAPI_GEN_VERSION}
 # We do not enforce versioning on setup-envtest
 go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
+##############
+# govulncheck
+##############
+GOVULNCHECK_VERSION=v1.0.0
+go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
+
 #########
 # mockgen
 #########

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -3,7 +3,7 @@ if [ "$BOILERPLATE_SET_X" ]; then
 fi
 
 # NOTE: Change this when publishing a new image tag.
-LATEST_IMAGE_TAG=image-v3.0.4
+LATEST_IMAGE_TAG=image-v3.0.5
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 # Make all tests use this local clone by default.


### PR DESCRIPTION
[OSD-15998](https://issues.redhat.com//browse/OSD-15998)

The goal is to allow the osd-container-image convention to use this first