### PR TITLE
Update yq to v4

### DIFF
--- a/boilerplate/_lib/subscriber.sh
+++ b/boilerplate/_lib/subscriber.sh
@@ -69,13 +69,11 @@ SUBSCRIBERS_FILE=$REPO_ROOT/subscribers.yaml
 #       all:        Prints all subscribers
 #       onboarded:  Prints only onboarded subscribers
 subscriber_list() {
-    local filt
     case $1 in
-        all) filt='[*]';;
+        all) yq '.subscribers[] | .name' $SUBSCRIBERS_FILE;;
         # TODO: Right now subscribers are only "manual".
-        onboarded) filt='(conventions.**.status==manual)';;
+        onboarded) yq '.subscribers[] | select(.conventions[].status == "manual") | .name' $SUBSCRIBERS_FILE;;
     esac
-    yq r $SUBSCRIBERS_FILE "subscribers${filt}.name"
 }
 
 ## last_bp_commit ORG/PROJ

--- a/boilerplate/test/test-base-convention/update
+++ b/boilerplate/test/test-base-convention/update
@@ -29,5 +29,5 @@ echo "Validating variables exported from the main update driver"
 # Granny switch to disable this check for weird tests like reverting to master
 if [[ -z "$SKIP_IMAGE_TAG_CHECK" ]]; then
     # Update this when publishing a new image tag
-    [[ "$LATEST_IMAGE_TAG" == "image-v3.0.5" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
+    [[ "$LATEST_IMAGE_TAG" == "image-v3.0.6" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
 fi

--- a/config/build_image-v3.0.0.sh
+++ b/config/build_image-v3.0.0.sh
@@ -81,6 +81,12 @@ go install github.com/golang/mock/mockgen@${MOCKGEN_VERSION}
 GO_BINDATA_VERSION=v3.1.2
 go install github.com/go-bindata/go-bindata/...@${GO_BINDATA_VERSION}
 
+####
+# yq
+####
+YQ_VERSION="v4.34.2"
+go install github.com/mikefarah/yq/v4@${YQ_VERSION}
+
 # HACK: `go get` creates lots of things under GOPATH that are not group
 # accessible, even if umask is set properly. This causes failures of
 # subsequent go tool usage (e.g. resolving packages) by a non-root user,
@@ -91,18 +97,6 @@ dir=$(go env GOPATH)
 for bit in r x w; do
     find $dir -perm -u+${bit} -a ! -perm -g+${bit} -exec chmod g+${bit} '{}' +
 done
-
-####
-# yq
-####
-YQ_VERSION="3.4.1"
-YQ_SHA256SUM="adbc6dd027607718ac74ceac15f74115ac1f3caef68babfb73246929d4ffb23c"
-YQ_LOCATION=https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64
-
-curl -L -o yq $YQ_LOCATION
-echo ${YQ_SHA256SUM} yq | sha256sum -c
-chmod ugo+x yq
-mv yq /usr/local/bin
 
 ####
 # gh

--- a/doc/subscriber.md
+++ b/doc/subscriber.md
@@ -25,7 +25,7 @@ Some caveats:
 - The command lives at `./boilerplate/_lib/subscriber`. You may wish to alias or `$PATH` this. But note:
 - It (probably) only works if your PWD is the root of the boilerplate repository. (FIXME?)
 - Certain subcommands rely on the [`gh` command](https://github.com/cli/cli) being installed and properly configured.
-- It relies on [`yq` version 3.x](https://mikefarah.gitbook.io/yq/v/v3.x/). (FIXME: v3 is deprecated.)
+- It relies on [`yq` version 4.x](https://mikefarah.gitbook.io/yq/v/v4.x/).
 
 Subcommands follow:
 

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -3,7 +3,7 @@ if [ "$BOILERPLATE_SET_X" ]; then
 fi
 
 # NOTE: Change this when publishing a new image tag.
-LATEST_IMAGE_TAG=image-v3.0.5
+LATEST_IMAGE_TAG=image-v3.0.6
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 # Make all tests use this local clone by default.


### PR DESCRIPTION
As part of [OSD-15779](https://issues.redhat.com//browse/OSD-15779) [boilerplating RMO will require yq:v4](https://github.com/openshift/route-monitor-operator/blob/0a44ea3f12eaa6eec0fb4930e45fa8a4521530ad/Makefile#L113-L117). I think the right thing to do is update boilerplate to yq:v4 is the right thing to do because v3 has long since been deprecated even when `doc/subscriber.md` was written 2 years ago.

A `subscribers.yaml` exists at the root of this repo and can be used to validate this swap is valid (and likewise for the app-interface saas files):

With yq:v3
```
❯ yq r subscribers.yaml "subscribers(conventions.**.status==manual).name"
app-sre/deployment-validation-operator
openshift/aws-account-operator
openshift/aws-efs-operator
openshift/certman-operator
openshift/cloud-ingress-operator
openshift/configure-alertmanager-operator
openshift/custom-domains-operator
openshift/deadmanssnitch-operator
openshift/gcp-project-operator
openshift/managed-upgrade-operator
openshift/managed-velero-operator
openshift/must-gather-operator
openshift/osd-metrics-exporter
openshift/pagerduty-operator
openshift/rbac-permissions-operator
openshift/route-monitor-operator
openshift/splunk-forwarder-operator
```

With yq:v4
```
❯ yq '.subscribers[] | select(.conventions[].status == "manual") | .name' subscribers.yaml
app-sre/deployment-validation-operator
openshift/aws-account-operator
openshift/aws-efs-operator
openshift/certman-operator
openshift/cloud-ingress-operator
openshift/configure-alertmanager-operator
openshift/custom-domains-operator
openshift/deadmanssnitch-operator
openshift/gcp-project-operator
openshift/managed-upgrade-operator
openshift/managed-velero-operator
openshift/must-gather-operator
openshift/osd-metrics-exporter
openshift/pagerduty-operator
openshift/rbac-permissions-operator
openshift/route-monitor-operator
openshift/splunk-forwarder-operator
```