### PR TITLE
set golangci lint version to 1.53.3

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/ensure.sh
+++ b/boilerplate/openshift/golang-osd-operator/ensure.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh
 
-GOLANGCI_LINT_VERSION="1.30.0"
+GOLANGCI_LINT_VERSION="1.53.3"
 OPM_VERSION="v1.23.2"
 GRPCURL_VERSION="1.7.0"
 DEPENDENCY=${1:-}


### PR DESCRIPTION
Sets golangci lint version to 1.53.3

Fixes:
```
ERRO Running error: buildir: failed to load package goarch: could not load export data: cannot import "internal/goarch" (unknown bexport format version -1 ("u\x01\x00\x00\x00\x00\x00\x00\x003\x00\x00\x005\x00\x00\x007\x00\x00\x008\x00\x00\x00e\x00\x00\x00j\x00\x00\x00\x97\x00\x00\x00\xc4\x00\x00\x00\xf1\x00\x00\x00\xf1\x00\x00\x00\x00\x00\x00\x00\x06\x00\x00\x00\x15\x00\x00\x00:\x00\x00\x00H\x00\x00\x00M\x00\x00\x00P\x00\x00\x00U\x00\x00\x00_\x00\x00\x00h\x00\x00\x00{\x00\x00\x00\xa7\x00\x00\x00\xac\x00\x00\x00\xb2\x00\x00\x00\xb6\x00\x00\x00\xc0\x00\x00\x00\xc5\x00\x00\x00\xcc\x00\x00\x00\xd6\x00\x00\x00\xdb\x00\x00\x00\xe2\x00\x00\x00\xeb\x00\x00\x00\xf2\x00\x00\x00\xfb\x00\x00\x00\x01\x01\x00\x00\t\x01\x00\x00\x13\x01\x00\x00\x1e\x01\x00\x00+\x01\x00\x003\x01\x00\x008\x01\x00\x00?\x01\x00\x00H\x01\x00\x00O\x01\x00\x00X\x01\x00\x00^\x01\x00\x00e\x01\x00\x00l\x01\x00\x00u\x01\x00\x00{\x01\x00\x00\x82\x01\x00\x00\x86\x01\x00\x00\x8c\x01\x00\x00\x98\x01\x00\x00\xa1\x01\x00\x00\xa6\x01\x00\x00\xad\x01\x00\x00\xb4\x01\x00\x00\xb9\x01\x00\x00\xc3\x01\x00\x00\xc7\x01\x00\x00\xae\x02\x00\x00\xb1\x02\x00\x00\xb6\x02\x00\x00\xbb\x02\x00\x00\xc5\x02\x00\x00\xcd\x02\x00\x00\xd5\x02\x00\x00\xdd\x02\x00\x00\xe5\x02\x00\x00\xed\x02\x00\x00\xf5\x02\x00\x00\xfd\x02\x00\x00\x05\x03\x00\x00\r\x03\x00\x00\x15\x03\x00\x00\x1d\x03\x00\x00%\x03\x00\x00-\x03\x00\x005\x03\x00\x00=\x03\x00\x00E\x03\x00\x00M\x03\x00\x00U\x03\x00\x00]\x03\x00\x00e\x03\x00\x00m\x03\x00\x00u\x03\x00\x00}\x03\x00\x00\x85\x03\x00\x00\x8d\x03\x00\x00\x95\x03\x00\x00\x9d\x03\x00\x00\xa5\x03\x00\x00\xad\x03\x00\x00\xb5\x03\x00\x00\xbd\x03\x00\x00\xc5\x03\x00\x00\xcd\x03\x00\x00\xd5\x03\x00\x00\xdd\x03\x00\x00\xe5\x03\x00\x00\xed\x03\x00\x00\xf5\x03\x00\x00\xfd\x03\x00\x00\x05\x04\x00\x00\r\x04\x00\x00\x15\x04\x00\x00\x1d\x04\x00\x00%\x04\x00\x00-\x04\x00\x004\x04\x00\x007\x04\x00\x00:\x04\x00\x00=\x04\x00\x00@\x04\x00\x00N\x04\x00\x00Z\x04\x00\x00h\x04\x00\x00v\x04\x00\x00\x84\x04\x00\x00\x92\x04\x00\x00\xa1\x04\x00\x00\xb1\x04\x00\x00\xbf\x04\x00\x00\xcd\x04\x00\x00\xdb\x04\x00\x00\xe9\x04\x00\x00\xf7\x04\x00\x00\x05\x05\x00\x00\x13\x05\x00\x00!\x05\x00\x00/\x05\x00\x00=\x05\x00\x00K\x05\x00\x00Y\x05\x00\x00g\x05\x00\x00u\x05\x00\x00\x83\x05\x00\x00\x91\x05\x00\x00\x9f\x05\x00\x00\xad\x05\x00\x00\xbb\x05\x00\x00\xc9\x05\x00\x00\xd7\x05\x00\x00\xe5\x05\x00\x00\xf3\x05\x00\x00\x01\x06\x00\x00\x0f\x06\x00\x00\x1d\x06\x00\x00+\x06\x00\x009\x06\x00\x00G\x06\x00\x00U\x06\x00\x00c\x06\x00\x00q\x06\x00\x00\u007f\x06\x00\x00\x8d\x06\x00\x00\x9b\x06\x00\x00\xa9\x06\x00\x00\xb7\x06\x00\x00\xb8\x06\x00\x00\xbc\x06\x00\x00\xbd\x06\x00\x00\xbe\x06\x00\x00\xbf\x06\x00\x00\xc0\x06\x00\x00\xc1\x06\x00\x00\xc2\x06\x00\x00\xc3\x06\x00\x00\xc4\x06\x00\x00\xc5\x06\x00\x00\xc6\x06\x00\x00\xc7\x06\x00\x00\xc8\x06\x00\x00\xc9\x06\x00\x00\xca\x06\x00\x00\xcb\x06\x00\x00\xcc\x06\x00\x00\xcd\x06\x00\x00\xce\x06\x00\x00\xcf\x06\x00\x00\xd0\x06\x00\x00\xd1\x06\x00\x00\xd2\x06\x00\x00\xd3\x06\x00\x00\xd4\x06\x00\x00\xd5\x06\x00\x00\xd6\x06\x00\x00\xd7\x06\x00\x00\xd8\x06\x00\x00\xd9\x06\x00\x00\xda\x06\x00\x00\xdb\x06\x00\x00\xdc\x06\x00\x00\xdd\x06\x00\x00\xde\x06\x00\x00\xdf\x06\x00\x00\xe0\x06\x00\x00\xe1\x06\x00\x00\xe2\x06\x00\x00\xe3\x06\x00\x00\xe4\x06\x00\x00\xe5\x06\x00\x00\xe6\x06\x00\x00\xe7\x06\x00\x00\xef\x06\x00\x00\xf7\x06\x00\x00\xff\x06\x00\x00\a\a\x00\x00\x0f\a\x00\x00\x17\a\x00\x00\x1f\a\x00\x00'\a\x00\x00/\a\x00\x007\a\x00\x00?\a\x00\x00G\a\x00\x00O\a\x00\x00W\a\x00\x00_\a\x00\x00g\a\x00\x00o\a\x00\x00w\a\x00\x00\u007f\a\x00\x00\x87\a\x00\x00\x8f\a\x00\x00\x97\a\x00\x00\x9f\a\x00\x00\xa7\a\x00\x00\xaf\a\x00\x00\xb7\a\x00\x00\xbf\a\x00\x00\xc7\a\x00\x00\xcf\a\x00\x00\xd7\a\x00\x00\xdf\a\x00\x00\xe7\a\x00\x00\xef\a\x00\x00\xf7\a\x00\x00\xff\a\x00\x00\a\b\x00\x00\x0f\b\x00\x00\x17\b\x00\x00\x1f\b\x00\x00'\b\x00\x00/\b\x00\x007\b\x00\x00?\b\x00\x00G\b\x00\x00O\b\x00\x00goarchinternal/goarch$GOROOT/src/internal/goarch/goarch.goArchFamilyTypeAMD64ARMARM64ArchFamilyBigEndianDefaultPhysPageSize$GOROOT/src/internal/goarch/zgoarch_amd64.goamd64GOARCHI386Int64AlignIs386IsAmd64IsAmd64p32IsArmIsArm64IsArm64beIsArmbeIsLoong64IsMipsIsMips64IsMips64leIsMips64p32IsMips64p32leIsMipsleIsPpcIsPpc64IsPpc64leIsRiscvIsRiscv64IsS390IsS390xIsSparcIsSparc64IsWasmLOONG64MIPSMIPS64MinFrameSizePCQuantumPPC64PtrSizeRISCV64S390XStackAlignWASM.\x03\x00\x06\x00\x06\x01\x06\x02\x06\x03\x06\x04\x06\x05\x06\x06\x06\a\x06\b\x06\t\x06")), possibly version skew - reinstall package 
make: *** [boilerplate/openshift/golang-osd-operator/standard.mk:168: go-check] Error 3
```

in AAO when running:
```
golangci-lint run -c boilerplate/openshift/golang-osd-operator/golangci.yml ./...
```