### PR TITLE
push latest harness tag

### DIFF
--- a/boilerplate/openshift/golang-osd-operator-osde2e/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/standard.mk
@@ -81,3 +81,4 @@ e2e-harness-build:
 .PHONY: e2e-image-build-push
 e2e-image-build-push:
 	${OSDE2E_CONVENTION_DIR}/e2e-image-build-push.sh "./osde2e/Dockerfile $(IMAGE_REGISTRY)/$(HARNESS_IMAGE_REPOSITORY)/$(HARNESS_IMAGE_NAME):$(HARNESS_IMAGE_TAG)"
+	${OSDE2E_CONVENTION_DIR}/e2e-image-build-push.sh "./osde2e/Dockerfile $(IMAGE_REGISTRY)/$(HARNESS_IMAGE_REPOSITORY)/$(HARNESS_IMAGE_NAME):latest"


### PR DESCRIPTION
Recently the latest tag on e2e test harness was replaced with operator version used in pipeline (commit hash)

Adding it back to continue testing `latest` tags on non-ci, periodic jobs, which will not refer to specific operator versions 