### PR TITLE
Fix `quay.io/app-sre/yq:4` syntax as it leverages an ENTRYPOINT

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   namespace: openshift
   name: boilerplate
-  tag: image-v3.0.4
+  tag: image-v3.0.6

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
@@ -50,7 +50,7 @@ if [[ -z "$CONTAINER_ENGINE" ]]; then
 else
     yq_image="quay.io/app-sre/yq:4"
     $CONTAINER_ENGINE pull $yq_image
-    YQ_CMD="$CONTAINER_ENGINE run --rm -i $yq_image yq"
+    YQ_CMD="$CONTAINER_ENGINE run --rm -i $yq_image"
 fi
 
 # Get the image URI as repo URL + image digest


### PR DESCRIPTION
You can try this with:

Updated:

```
curl -s "https://gitlab.cee.redhat.com/service/app-interface/raw/master/data/services/osd-operators/cicd/saas/saas-pagerduty-operator.yaml" | docker run --rm -i quay.io/app-sre/yq:4 '.managedResourceTypes[0]' -

CatalogSource
```

Original:

```
curl -s "https://gitlab.cee.redhat.com/service/app-interface/raw/master/data/services/osd-operators/cicd/saas/saas-pagerduty-operator.yaml" | docker run --rm -i quay.io/app-sre/yq:4 yq '.managedResourceTypes[0]' -

Error: 1:1: invalid input text "yq"
```