### PR TITLE
Do not need to surround yq string with single quotes

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
@@ -102,7 +102,7 @@ if [[ -z "$SKIP_SAAS_FILE_CHECKS" ]]; then
             $YQ_CMD '.managedResourceTypes[0]' -
     )
     if [[ "${MANAGED_RESOURCE_TYPE}" == "" ]]; then
-        echo "Unabled to determine if SAAS file managed resource type"
+        echo "Unable to determine if SAAS file managed resource type"
         exit 1
     fi
 
@@ -119,11 +119,7 @@ if [[ -z "$SKIP_SAAS_FILE_CHECKS" ]]; then
     if [[ "$operator_channel" == "production" ]]; then
         if [ -z "$DEPLOYED_HASH" ] ; then
             deployed_hash_yq_filter=".resourceTemplates[].targets[] | select(.namespace.\$ref == \"${resource_template_ns_path}\") | .ref"
-            DEPLOYED_HASH=$(
-                curl -s "${SAAS_FILE_URL}" | \
-                    # Surround yq filter in single quotes
-                    $YQ_CMD "'"${deployed_hash_yq_filter}"'" -
-            )
+            DEPLOYED_HASH="$(curl -s "${SAAS_FILE_URL}" | $YQ_CMD "${deployed_hash_yq_filter}" -)"
         fi
 
         # Ensure that our query for the current deployed hash worked


### PR DESCRIPTION
This is resulting in:

```
SAAS file is NOT applied to Hive, MANAGED_RESOURCE_TYPE=SelectorSyncSet

Error: 1:1: invalid input text "'.resourceTempla..."
```

Sample script to prove this now works (can also be used to prove it didn't work previously):

```bash
#!/usr/bin/env bash

set -x

SAAS_FILE_URL="https://gitlab.cee.redhat.com/service/app-interface/raw/master/data/services/osd-operators/cicd/saas/saas-route-monitor-operator.yaml"
YQ_CMD="docker run --rm -i quay.io/app-sre/yq:4"
MANAGED_RESOURCE_TYPE="$(curl -s "${SAAS_FILE_URL}" | $YQ_CMD '.managedResourceTypes[0]' -)"

echo ${MANAGED_RESOURCE_TYPE}

resource_template_ns_path="/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml"
deployed_hash_yq_filter=".resourceTemplates[].targets[] | select(.namespace.\$ref == \"${resource_template_ns_path}\") | .ref"
DEPLOYED_HASH="$(curl -s "${SAAS_FILE_URL}" | $YQ_CMD "${deployed_hash_yq_filter}" -)"

echo ${DEPLOYED_HASH}
```