### PR TITLE
Accept the latest ubi-minimal version

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -43,7 +43,7 @@ for file in $DOCKERFILES; do
 
   # Update any UBI images to use a versioned tag of ubi8/ubi-minimal that is compatible with dependabot
   for ubi_latest in $(grep -oE 'registry.access.redhat.com/ubi[7-9]/ubi.*?:.*' ${file}); do
-      replacement_image=$(skopeo inspect --override-os linux --override-arch amd64 docker://registry.access.redhat.com/ubi8/ubi-minimal --format "{{.Name}}:{{.Labels.version}}-{{.Labels.release}}" | ${SED?} 's,\.[0-9]\+$,,')
+      replacement_image=$(skopeo inspect --override-os linux --override-arch amd64 docker://registry.access.redhat.com/ubi8/ubi-minimal --format "{{.Name}}:{{.Labels.version}}-{{.Labels.release}}")
       echo "Overwriting ${file}'s ${ubi_latest} image to ${replacement_image}"
       ${SED?} -i "s,${ubi_latest},${replacement_image}," ${file}
   done


### PR DESCRIPTION
Specifically, version differences after the last period were previously excluded from consideration.

This is causing CI to fail when dependabot updates images, e.g. https://github.com/openshift/custom-domains-operator/pull/136 and https://github.com/openshift/aws-vpce-operator/pull/211

new
```
❯ skopeo inspect --override-os linux --override-arch amd64 docker://registry.access.redhat.com/ubi8/ubi-minimal --format "{{.Name}}:{{.Labels.version}}-{{.Labels.release}}"
registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072.1697626218
```

old
```
❯ skopeo inspect --override-os linux --override-arch amd64 docker://registry.access.redhat.com/ubi8/ubi-minimal --format "{{.Name}}:{{.Labels.version}}-{{.Labels.release}}" | gsed 's,\.[0-9]\+$,,'
registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072
```

[OSD-19351](https://issues.redhat.com//browse/OSD-19351)