### PR TITLE
Updating Hulk members and FL list

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
+++ b/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
@@ -19,13 +19,13 @@ aliases:
     - robotmaxtron
     - rojasreinold
   srep-functional-team-hulk:
-    - mrbarge
     - a7vicky
     - jwai7
     - rendhalver
     - ravitri
     - shitaljante
     - weherdh
+    - devppratik
   srep-functional-team-orange:
     - bng0y
     - typeid
@@ -72,6 +72,7 @@ aliases:
     - bmeng
     - mjlshen
     - sam-nguyen7
+    - ravitri
   srep-team-leads:
     - cblecker
     - jharrington22


### PR DESCRIPTION
Updating `boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES` file with following:

- Removing Matt Bargenquast from Team Hulk list
- Adding Pratik Panda to Team Hulk list
- Adding Ravi Trivedi to Functional Leads list