### PR TITLE
OSD-18002 - Prevent operator commit reverts

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
@@ -161,6 +161,13 @@ OUTPUT_DIR=${BUNDLE_DIR}
 if [[ -z "${OPERATOR_PREV_VERSION}" ]]; then
     PREV_VERSION_OPTS=""
 else
+    OPERATOR_PREV_COMMIT_NUMBER=$(echo "${OPERATOR_PREV_VERSION}" | awk -F. '{print $3}' | awk -F- '{print $1}')
+    if [[ "${OPERATOR_PREV_COMMIT_NUMBER}" -gt "${operator_commit_number}" ]];
+    then
+        echo "Revert detected. Reverting OLM operators is not allowed"
+	exit 99
+    fi
+
     PREV_VERSION_OPTS="-p ${OPERATOR_PREV_VERSION}"
 fi
 # Jenkins can't be relied upon to have py3, so run the generator in


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-18002

---

Adds guardrails to prevent operators from reverting commits, as doing so breaks OLM bundle generation automation.