### PR TITLE
Create boilerplate v4.0.0 to support Go 1.20

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,6 @@
 build_root_image:
   namespace: openshift
-  name: boilerplate
-  tag: image-v3.0.6
+  # name: boilerplate
+  # tag: image-v4.0.0
+  name: release
+  tag: rhel-9-release-golang-1.20-openshift-4.14

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 ALLOW_DIRTY_CHECKOUT?=false
+SKIP_IMAGE_TAG_CHECK?=false
 IMG?=boilerplate
 CONTAINER_ENGINE?=$(shell command -v podman 2>/dev/null || echo "docker")
 

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py
@@ -13,11 +13,8 @@
 
 import datetime
 import os
-import sys
 import yaml
-import shutil
 import argparse
-import string
 
 # The registry is pinned to version 4.7 and only the following resouces are permitted in
 # the bundle. The full list can be found at https://github.com/operator-framework/operator-registry/blob/release-4.7/pkg/lib/bundle/supported_resources.go#L4-L19

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,3 +1,7 @@
 # This file is used to confirm that the imagestream is valid and working
 # the below statement will always be replaced by the source in .ci-operator.yaml
-FROM REPLACE_ME
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.14
+
+# TODO: remove this COPY/RUN
+COPY build_image-v4.0.0.sh /build.sh
+RUN /build.sh && rm /build.sh

--- a/config/Dockerfile.appsre
+++ b/config/Dockerfile.appsre
@@ -1,8 +1,8 @@
 # Cumulative Dockerfile for app-sre. It should start FROM the base image
 # and then RUN all the build scripts in order.
 
-# https://github.com/openshift-eng/ocp-build-data/blob/9494ba767c7e96654595f69509b0ff9513eea9b8/streams.yml#L36-L43
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12
+# https://github.com/openshift-eng/ocp-build-data/blob/599c9d2b3ab26d7e453f0d85567983d74b0ff6c8/streams.yml#L55-L64
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14
 
-COPY build_image-v3.0.0.sh /build.sh
+COPY build_image-v4.0.0.sh /build.sh
 RUN /build.sh && rm -f /build.sh

--- a/config/build_image-v4.0.0.sh
+++ b/config/build_image-v4.0.0.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 
 # This script comprises everything up to and including the boilerplate
-# backing image at version image-v3.0.0. It is no longer used since the
-# latest version is based on image-v4.0.0. It is kept for posterity.
+# backing image at version image-v3.0.0. It is used when performing a
+# full build in the appsre pipeline, but is bypassed during presubmit CI
+# in prow to make testing faster there. As such, there is a (very small)
+# possibility of those behaving slightly differently.
+
+# Compatible with Operator-SDK v1.25.0+ which first supported Go 1.19
+# https://github.com/operator-framework/operator-sdk/releases/tag/v1.25.0
 
 set -x
 set -euo pipefail
@@ -10,40 +15,19 @@ set -euo pipefail
 tmpd=$(mktemp -d)
 pushd $tmpd
 
-###############
-# golangci-lint
-###############
-GOCILINT_VERSION="1.50.0"
-GOCILINT_SHA256SUM="b4b329efcd913082c87d0e9606711ecb57415b5e6ddf233fde9e76c69d9b4e8b"
-GOCILINT_LOCATION=https://github.com/golangci/golangci-lint/releases/download/v${GOCILINT_VERSION}/golangci-lint-${GOCILINT_VERSION}-linux-amd64.tar.gz
-
-curl -L -o golangci-lint.tar.gz $GOCILINT_LOCATION
-echo ${GOCILINT_SHA256SUM} golangci-lint.tar.gz | sha256sum -c
-tar xzf golangci-lint.tar.gz golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint
-mv golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint /usr/local/bin
-
-###############
-# Set up go env
-###############
-# Get rid of -mod=vendor
-unset GOFLAGS
-# No, really, we want to use modules
-export GO111MODULE=on
-
-# print go version for fun
-go version
+# OCP's release images explicitly set -mod=vendor
+export GOFLAGS=-mod=mod
 
 ###########
 # kustomize
 ###########
-KUSTOMIZE_VERSION=v4.5.5
+KUSTOMIZE_VERSION="v5.2.1"
 go install sigs.k8s.io/kustomize/kustomize/${KUSTOMIZE_VERSION%%.*}@${KUSTOMIZE_VERSION}
 
 ################
 # controller-gen
 ################
-# controller-gen v0.10.0 is used by operator-sdk v1.25.0
-CONTROLLER_GEN_VERSION="v0.10.0"
+CONTROLLER_GEN_VERSION="v0.13.0"
 go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION}
 
 #############
@@ -61,25 +45,19 @@ go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 ##############
 # govulncheck
 ##############
-GOVULNCHECK_VERSION=v1.0.0
+GOVULNCHECK_VERSION="v1.0.1"
 go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
 
 #########
 # mockgen
 #########
-MOCKGEN_VERSION=v1.6.0
-go install github.com/golang/mock/mockgen@${MOCKGEN_VERSION}
-
-############
-# go-bindata
-############
-GO_BINDATA_VERSION=v3.1.2
-go install github.com/go-bindata/go-bindata/...@${GO_BINDATA_VERSION}
+MOCKGEN_VERSION="v0.3.0"
+go install go.uber.org/mock/mockgen@${MOCKGEN_VERSION}
 
 ####
 # yq
 ####
-YQ_VERSION="v4.34.2"
+YQ_VERSION="v4.35.2"
 go install github.com/mikefarah/yq/v4@${YQ_VERSION}
 
 # HACK: `go get` creates lots of things under GOPATH that are not group
@@ -93,35 +71,42 @@ for bit in r x w; do
     find $dir -perm -u+${bit} -a ! -perm -g+${bit} -exec chmod g+${bit} '{}' +
 done
 
+###############
+# golangci-lint
+###############
+GOCILINT_VERSION="1.55.2"
+GOCILINT_SHA256SUM="ca21c961a33be3bc15e4292dc40c98c8dcc5463a7b6768a3afc123761630c09c"
+GOCILINT_LOCATION=https://github.com/golangci/golangci-lint/releases/download/v${GOCILINT_VERSION}/golangci-lint-${GOCILINT_VERSION}-linux-amd64.tar.gz
+
+curl -L -o golangci-lint.tar.gz $GOCILINT_LOCATION
+echo ${GOCILINT_SHA256SUM} golangci-lint.tar.gz | sha256sum -c
+tar xzf golangci-lint.tar.gz golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint
+mv golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint /usr/local/bin
+rm -f golangci-lint.tar.gz
+
 ####
 # gh
 ####
-GH_VERSION=2.19.0
-GH_SHA256SUM="b1d062f1c0d44465e4f9f12521e93e9b3b650d3876eb157acf875347b971f4d8"
+GH_VERSION="2.38.0"
+GH_SHA256SUM="c56b80a03c3b4216cd1ab63f6c7bfa4c356c67bce265fc067953bec10cdf0f97"
 GH_LOCATION=https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz
 
 curl -L -o gh.tar.gz $GH_LOCATION
 echo ${GH_SHA256SUM} gh.tar.gz | sha256sum -c
-tar -xvzf gh.tar.gz gh_${GH_VERSION}_linux_amd64/bin/gh
+tar xzf gh.tar.gz gh_${GH_VERSION}_linux_amd64/bin/gh
 mv gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin
+rm -f gh.tar.gz
 
-##################
-# python libraries
-##################
-python3 -m pip install PyYAML==5.3.1
-
-#########
-# cleanup
-#########
-yum clean all
-yum -y autoremove
-
+#####
+# dnf
+#####
 # autoremove removes ssh (which it presumably wouldn't if we were able
 # to install git from a repository, because git has a dep on ssh.)
 # Do we care to restrict this to a particular version?
-yum -y install openssh-clients jq skopeo
-
-rm -rf /var/cache/yum
+dnf -y install openssh-clients jq skopeo python3-pyyaml
+dnf clean all
+dnf -y autoremove
+rm -rf /var/cache/dnf
 
 popd
 rm -fr $tmpd

--- a/test/projects/file-generate/deploy/crds/mygroup.operators.coreos.com_testkinds.yaml
+++ b/test/projects/file-generate/deploy/crds/mygroup.operators.coreos.com_testkinds.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: testkinds.mygroup.operators.coreos.com
 spec:
   group: mygroup.operators.coreos.com

--- a/test/projects/file-generate/expected/mygroup.operators.coreos.com_testkinds.yaml
+++ b/test/projects/file-generate/expected/mygroup.operators.coreos.com_testkinds.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: testkinds.mygroup.operators.coreos.com
 spec:
   group: mygroup.operators.coreos.com


### PR DESCRIPTION
OCP 4.14 is using Go 1.20 and we need to be able to support it when we pull in dependencies from OCP.

[OSD-19423](https://issues.redhat.com//browse/OSD-19423)