### PR TITLE
use image-v4.0.0 in .ci-operator

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,6 +1,4 @@
 build_root_image:
   namespace: openshift
-  # name: boilerplate
-  # tag: image-v4.0.0
   name: release
   tag: rhel-9-release-golang-1.20-openshift-4.14

--- a/boilerplate/test/test-base-convention/update
+++ b/boilerplate/test/test-base-convention/update
@@ -29,5 +29,5 @@ echo "Validating variables exported from the main update driver"
 # Granny switch to disable this check for weird tests like reverting to master
 if [[ -z "$SKIP_IMAGE_TAG_CHECK" ]]; then
     # Update this when publishing a new image tag
-    [[ "$LATEST_IMAGE_TAG" == "image-v3.0.6" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
+    [[ "$LATEST_IMAGE_TAG" == "image-v4.0.0" ]] || err "Bad LATEST_IMAGE_TAG: '$LATEST_IMAGE_TAG'"
 fi

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -3,7 +3,7 @@ if [ "$BOILERPLATE_SET_X" ]; then
 fi
 
 # NOTE: Change this when publishing a new image tag.
-LATEST_IMAGE_TAG=image-v3.0.6
+LATEST_IMAGE_TAG=image-v4.0.0
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 # Make all tests use this local clone by default.


### PR DESCRIPTION
Now that the image exists we can us it directly to speed up boilerplate CI
 
Closes [OSD-19423](https://issues.redhat.com//browse/OSD-19423)