### PR TITLE
Correctly select base image for AppSRE build process

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,6 +1,6 @@
 # This file is used to confirm that the imagestream is valid and working
 # the below statement will always be replaced by the source in .ci-operator.yaml
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.14
+FROM REPLACEME
 
 # TODO: remove this COPY/RUN
 COPY build_image-v4.0.0.sh /build.sh

--- a/config/Dockerfile.appsre
+++ b/config/Dockerfile.appsre
@@ -2,7 +2,7 @@
 # and then RUN all the build scripts in order.
 
 # https://github.com/openshift-eng/ocp-build-data/blob/599c9d2b3ab26d7e453f0d85567983d74b0ff6c8/streams.yml#L55-L64
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14
 
 COPY build_image-v4.0.0.sh /build.sh
 RUN /build.sh && rm -f /build.sh


### PR DESCRIPTION
When I updated [.ci-operator.yml](https://github.com/openshift/boilerplate/blob/b65ca0f70f747cbe0f2dd36ee628c881592cfb89/.ci-operator.yaml#L4), I forgot to update Dockerfile.appsre, so `quay.io/app-sre/boilerplate:image-v4.0.1` is still based on RHEL 9. Unfortunately, that means we need a new `image-v4.0.2` tag now.

```bash
❯ docker run --platform linux/amd64 --rm -it quay.io/app-sre/boilerplate:image-v4.0.1 cat /etc/os-release
NAME="Red Hat Enterprise Linux"
VERSION="9.0 (Plow)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="9.0"
PLATFORM_ID="platform:el9"
PRETTY_NAME="Red Hat Enterprise Linux 9.0 (Plow)"
ANSI_COLOR="0;31"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:redhat:enterprise_linux:9::baseos"
HOME_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://access.redhat.com/documentation/red_hat_enterprise_linux/9/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 9"
REDHAT_BUGZILLA_PRODUCT_VERSION=9.0
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="9.0"
```

[OSD-19423](https://issues.redhat.com//browse/OSD-19423)