### PR TITLE
Added env var to osde2e pod template

### DIFF
--- a/boilerplate/openshift/golang-osd-operator-osde2e/test-harness-template.yml
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/test-harness-template.yml
@@ -23,6 +23,8 @@ parameters:
   - name: IMAGE_TAG
     value: ''
     required: true
+  - name: LOG_BUCKET
+    value: 'osde2e-logs'
 objects:
   - apiVersion: batch/v1
     kind: Job
@@ -60,3 +62,5 @@ objects:
                   value: ${AWS_SECRET_ACCESS_KEY}
                 - name: AWS_REGION
                   value: ${AWS_REGION}
+                - name: LOG_BUCKET
+                  value: ${LOG_BUCKET}                 


### PR DESCRIPTION
Follow up change to osde2e update https://github.com/openshift/osde2e/pull/2244


Provides LOG_BUCKET env var to osde2e pod template in operator tekton jobs. 