### PR TITLE
add SRE group leads to owners aliases

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
+++ b/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
@@ -76,6 +76,10 @@ aliases:
     - fahlmant
     - dustman9000
     - wanghaoran1988
+  sre-group-leads:
+    - apahim
+    - maorfr
+    - rogbas
   srep-architects:
     - jewzaam
     - jharrington22


### PR DESCRIPTION
follow up on https://github.com/openshift/managed-cluster-config/pull/1841

to enable group leads to become owners in a streamlined way