### PR TITLE
golang-osd-operator: bundle rvmo

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/rvmo-bundle.sh
+++ b/boilerplate/openshift/golang-osd-operator/rvmo-bundle.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+REPOSITORY=${REPOSITORY:-"git@github.com:openshift/managed-release-bundle.git"}
+BRANCH=${BRANCH:-main}
+DELETE_TEMP_DIR=${DELETE_TEMP_DIR:-true}
+TMPD=$(mktemp -d --suffix -rvmo-bundle)
+[[ "${DELETE_TEMP_DIR}" == "true" ]] && trap 'rm -rf ${TMPD}' EXIT
+
+cd "${TMPD}"
+git clone --single-branch -b "${BRANCH}" "${REPOSITORY}" .
+bash hack/update-operator-release.sh

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -380,3 +380,11 @@ container-validate:
 .PHONY: container-coverage
 container-coverage:
 	${BOILERPLATE_CONTAINER_MAKE} coverage
+
+.PHONY: rvmo-bundle
+rvmo-bundle:
+	OPERATOR_NAME=$(OPERATOR_NAME) \
+	OPERATOR_VERSION=$(OPERATOR_VERSION) \
+	OPERATOR_OLM_REGISTRY_IMAGE=$(REGISTRY_IMAGE) \
+	TEMPLATE_FILE=$(abspath hack/olm-registry/olm-artifacts-template.yaml) \
+	bash ${CONVENTION_DIR}/rvmo-bundle.sh


### PR DESCRIPTION
Initial scaffolding of released version managed openshift bundling using PKO.

This PR introduces a new make target for OSD operators which will execute a
script living in the new
[openshift/managed-release-bundle](https://github.com/openshift/managed-release-bundle)
repository to translate the established SSS used for deploying the operator,
into templated files written to disk and packaged in a container image.

SD-ADR-0093 for more information

[SDCICD-1208](https://issues.redhat.com//browse/SDCICD-1208)

Signed-off-by: Brady Pratt <bpratt@redhat.com>
