### PR TITLE
Subscribe compliance-audit-router (CAR) to boilerplate

### DIFF
--- a/subscribers.yaml
+++ b/subscribers.yaml
@@ -56,6 +56,11 @@ subscribers:
       - name: openshift/golang-osd-operator
         status: manual
 
+  - name: openshift/compliance-audit-router
+    conventions:
+      - name: openshift/osd-container-image
+        status: manual
+
   - name: openshift/configure-alertmanager-operator
     conventions:
       - name: openshift/golang-osd-operator


### PR DESCRIPTION
Adds openshift/compliance-audit-router (CAR) to the boilerplate subscribers.yaml, with the osd-container-image convention.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
