### PR TITLE
Dockerfile.appsre: fix ci image name from build farm

### DIFF
--- a/config/Dockerfile.appsre
+++ b/config/Dockerfile.appsre
@@ -1,8 +1,9 @@
 # Cumulative Dockerfile for app-sre. It should start FROM the base image
 # and then RUN all the build scripts in order.
 
-# https://github.com/openshift-eng/ocp-build-data/blob/599c9d2b3ab26d7e453f0d85567983d74b0ff6c8/streams.yml#L55-L64
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-release-golang-1.21-openshift-4.16
+# To check for existence of an image: https://docs.ci.openshift.org/docs/how-tos/use-registries-in-build-farm/
+# Log into build farm's registry and validate the image exists
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16
 
 COPY build_image-v5.0.0.sh /build.sh
 RUN /build.sh && rm -f /build.sh


### PR DESCRIPTION
`registry.ci.openshift.org/ocp/builder:rhel-8-release-golang-1.21-openshift-4.16` did not exist: `release` is not part of the image name for the ci farm image.

Validated `registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16` exists and added guidance on how to check this:
```
docker pull registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16
Trying to pull registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16...
Getting image source signatures
Copying blob 358a3bd58798 [--------------------------------------] 643.4KiB / 89.7MiB | 1.7 MiB/s
...
```
