### PR TITLE
Update golangci lint version

### DIFF
--- a/boilerplate/openshift/golang-lint/ensure.sh
+++ b/boilerplate/openshift/golang-lint/ensure.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh
 
-GOLANGCI_LINT_VERSION="1.50.1"
+GOLANGCI_LINT_VERSION="1.54.2"
 DEPENDENCY=${1:-}
 GOOS=$(go env GOOS)
 

--- a/boilerplate/openshift/golang-osd-operator/ensure.sh
+++ b/boilerplate/openshift/golang-osd-operator/ensure.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh
 
-GOLANGCI_LINT_VERSION="1.30.0"
+GOLANGCI_LINT_VERSION="1.54.2"
 OPM_VERSION="v1.23.2"
 GRPCURL_VERSION="1.7.0"
 DEPENDENCY=${1:-}


### PR DESCRIPTION
This version is very old. Updated to match the one in [golang-lint convention](https://github.com/openshift/boilerplate/blob/master/boilerplate/openshift/golang-lint/ensure.sh#L8)

