### PR TITLE
golang-osd-operator: use new path to TEMPLATE_FILE

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -386,5 +386,5 @@ rvmo-bundle:
 	OPERATOR_NAME=$(OPERATOR_NAME) \
 	OPERATOR_VERSION=$(OPERATOR_VERSION) \
 	OPERATOR_OLM_REGISTRY_IMAGE=$(REGISTRY_IMAGE) \
-	TEMPLATE_FILE=$(abspath hack/olm-registry/olm-artifacts-template.yaml) \
+	TEMPLATE_FILE=$(abspath hack/artifacts/olm-artifacts-template.gotmpl) \
 	bash ${CONVENTION_DIR}/rvmo-bundle.sh


### PR DESCRIPTION
this file will not exist in most repositories yet, it will need to be added during the migration process