### PR TITLE
Update push steps to use containerized skopeo

### DIFF
--- a/boilerplate/openshift/custom-catalog-osd-operator/custom-catalog-build-push.sh
+++ b/boilerplate/openshift/custom-catalog-osd-operator/custom-catalog-build-push.sh
@@ -7,7 +7,7 @@ CONTAINER_ENGINE=$(command -v podman || command -v docker)
 CONTAINER_ENGINE_SHORT=${CONTAINER_ENGINE##*/}
 REPO_ROOT=$(git rev-parse --show-toplevel)
 VERSIONS_DIR=${REPO_ROOT}/versions
-SKOPEO_IMAGE="quay.io/skopeo/stable:v1.8.0"
+SKOPEO_IMAGE="quay.io/skopeo/stable:v1.14.2"
 
 source $REPO_ROOT/boilerplate/_lib/common.sh
 

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-publish.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-publish.sh
@@ -95,7 +95,7 @@ popd
 
 if [ "$push_catalog" = true ] ; then
     # push image
-    skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    ${CONTAINER_ENGINE} run ${SKOPEO_IMAGE} -- skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
         "${SRC_CONTAINER_TRANSPORT}:${registry_image}:${operator_channel}-latest" \
         "docker://${registry_image}:${operator_channel}-latest"
 
@@ -104,7 +104,7 @@ if [ "$push_catalog" = true ] ; then
         exit 1
     fi
 
-    skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    ${CONTAINER_ENGINE} run ${SKOPEO_IMAGE} -- skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
         "${SRC_CONTAINER_TRANSPORT}:${registry_image}:${operator_channel}-latest" \
         "docker://${registry_image}:${operator_channel}-${operator_commit_hash}"
 

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/common.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/common.sh
@@ -2,6 +2,7 @@
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh
+SKOPEO_IMAGE="quay.io/skopeo/stable:v1.14.2"
 
 function check_mandatory_params() {
     local csv_missing_param_error

--- a/config/build_image-v5.0.0.sh
+++ b/config/build_image-v5.0.0.sh
@@ -39,8 +39,10 @@ go install k8s.io/code-generator/cmd/openapi-gen@${OPENAPI_GEN_VERSION}
 #########
 # ENVTEST
 #########
-# We do not enforce versioning on setup-envtest
-go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+# Latest is only compatible with Go 1.22
+# https://github.com/kubernetes-sigs/controller-runtime/issues/2744
+ENVTEST_VERSION="bf15e44028f908c790721fc8fe67c7bf2d06a611"
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@${ENVTEST_VERSION}
 
 ##############
 # govulncheck


### PR DESCRIPTION
Currently, we're depending on the version of skopeo installed on a Jenkins VM, which has gone out of date. Yes, the VM should be updated, but this gives us more control over the version of skopeo being used in CI.

[OSD-21843](https://issues.redhat.com//browse/OSD-21843)