### PR TITLE
[OSD-21903] Do not create a bundle that replaces itself.

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/common-generate-operator-bundle.py
@@ -58,6 +58,15 @@ skip_range_enabled=args.skip_range_enabled
 
 hasMultipleDeployments = False
 
+# Verify that this is not creating a cycle.
+if prev_version == full_version:
+    print(
+        "Previous version equals current version. "
+        "This would result in a cycle that can not be installed - aborting."
+    )
+    sys.exit(1)
+
+
 class UnsupportedRegistryResourceKind(Exception):
     def __init__(self, kind, path):
         super().__init__(

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
@@ -165,6 +165,15 @@ OPERATOR_PREV_VERSION=$(ls "$BUNDLE_DIR" | sort -t . -k 3 -g | tail -n 1)
 OPERATOR_NEW_VERSION="${operator_version}"
 OUTPUT_DIR=${BUNDLE_DIR}
 
+VERSION_DIR="${OUTPUT_DIR}/${OPERATOR_NEW_VERSION}"
+
+# Check if the VERSION_DIR already exists and is not empty - if so skip building
+# anything, as only timestamps would be changed.
+if [[ -d "${VERSION_DIR}" && -n $(ls -A "${VERSION_DIR}") ]]; then
+    echo "Output directory for bundle already exists and is not empty: ${VERSION_DIR}. Skipping bundle creation."
+    exit 1
+fi
+
 # If setting up a new SaaS repo, there is no previous version when building a bundle
 # Optionally pass it to the bundle generator in that case.
 if [[ -z "${OPERATOR_PREV_VERSION}" ]]; then


### PR DESCRIPTION
In certain cases it can happen that this tries to create a bundle that replaces itself, which will lead to installation failures.

As generally commits that create the same version should not be allowed csv-generate.sh checking for reverts, it should be safe to simply error out, as this seems to mostly happen, when an existing bundle gets updated with the incorrect replace, after it initially had the correct 'replaces' statement.