### PR TITLE
golang-osd-operator: set olm database location

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/Dockerfile.olm-registry
+++ b/boilerplate/openshift/golang-osd-operator/Dockerfile.olm-registry
@@ -20,3 +20,6 @@ COPY --from=builder /registry /registry
 EXPOSE 50051
 
 CMD ["registry-server", "-t", "/tmp/terminate.log"]
+
+# Set the DC specific label for the location of the DC database in the image
+LABEL operators.operatorframework.io.index.database.v1=/registry/bundles.db


### PR DESCRIPTION
OLM sets a standard label on registry images to point to the declarative config location (be it an sqlite database or flat files). This labels allows for `opm migrate ...` to process the registry image and migrate to the new file-based format. Without this label, the `migrate` subcommand is unable to locate the declarative config to load.

https://github.com/operator-framework/operator-registry/blob/9fdedc29d2575e021128050c5ef532f730fce2a5/pkg/containertools/dockerfilegenerator.go#L12-L13

This will help ease the migration process from the deprecated sqlite-based catalogs to the file-based catalog format.

before:

```
❯ opm migrate quay.io/app-sre/must-gather-operator-registry:staging-latest .
INFO[0000] rendering index "quay.io/app-sre/must-gather-operator-registry:staging-latest" as file-based catalog
FATA[0002] render catalog image: render reference "quay.io/app-sre/must-gather-operator-registry:staging-latest": render "quay.io/app-sre/must-gather-operator-registry:staging-latest": image type could not be determined, found labels
...
```

apply changes and rebuild:

```
❯ make staging-catalog-build
boilerplate/openshift/golang-osd-operator/standard.mk:113: Setting GOEXPERIMENT=strictfipsruntime,boringcrypto - this generally causes builds to fail unless building inside the provided Dockerfile. If building locally consider calling 'go build .'
go: unknown GOEXPERIMENT strictfipsruntime
[1/2] STEP 1/4: FROM registry.redhat.io/openshift4/ose-operator-registry:v4.12 AS builder
Trying to pull registry.redhat.io/openshift4/ose-operator-registry:v4.12...
...
[2/2] STEP 11/11: LABEL operators.operatorframework.io.index.database.v1=/registry/bundles.db
[2/2] COMMIT quay.io/app-sre/must-gather-operator-registry:staging-latest
--> 30ab80a68e7a
Successfully tagged quay.io/app-sre/must-gather-operator-registry:staging-latest
30ab80a68e7a4b053e8a3fd9e07d5b02cfed032cd5e58eb536a2c7390696ab06

❯ podman tag quay.io/app-sre/must-gather-operator-registry:staging-latest ghcr.io/jbpratt/mgo-registry:staging-latest

❯ podman push ghcr.io/jbpratt/mgo-registry:staging-latest
```

after:

```
❯ opm migrate ghcr.io/jbpratt/mgo-registry:staging-latest .
INFO[0000] rendering index "ghcr.io/jbpratt/mgo-registry:staging-latest" as file-based catalog
WARN[0006] DEPRECATION NOTICE:
Sqlite-based catalogs and their related subcommands are deprecated. Support for
them will be removed in a future release. Please migrate your catalog workflows
to the new file-based catalog format.
INFO[0006] wrote rendered file-based catalog to "."

❯ cat must-gather-operator/catalog.json | head
{
    "schema": "olm.package",
    "name": "must-gather-operator",
    "defaultChannel": "staging"
}
{
    "schema": "olm.channel",
    "name": "staging",
    "package": "must-gather-operator",
    "entries": [
```