### PR TITLE
Update ose-operator-registry

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/Dockerfile.olm-registry
+++ b/boilerplate/openshift/golang-osd-operator/Dockerfile.olm-registry
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/openshift4/ose-operator-registry:v4.12 AS builder
+FROM registry.redhat.io/openshift4/ose-operator-registry:v4.14 AS builder
 ARG SAAS_OPERATOR_DIR
 COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive


### PR DESCRIPTION
Update the ose-operator-registry version so that it includes the vulnerabilities fixes.

Tested with `podman build -f Dockerfile.olm-registry` in `boilerplate/openshift/golang-osd-operator`.

Not sure how should I test further.