### PR TITLE
SDCICD-1290: version catalogs by operator branch 

### DIFF
--- a/boilerplate/_lib/common.sh
+++ b/boilerplate/_lib/common.sh
@@ -107,12 +107,12 @@ image_exists_in_repo() {
         fi
         echo "Image ${image_uri} exists with digest $digest."
         return 0
-    elif [[ "$stderr" == *"manifest unknown"* ]]; then
+    elif [[ "$output" == *"manifest unknown"* || "$stderr" == *"manifest unknown"* ]]; then
         # We were able to talk to the repository, but the tag doesn't exist.
         # This is the normal "green field" case.
         echo "Image ${image_uri} does not exist in the repository."
         return 1
-    elif [[ "$stderr" == *"was deleted or has expired"* ]]; then
+    elif [[ "$output" == *"manifest unknown"* || "$stderr" == *"was deleted or has expired"* ]]; then
         # This should be rare, but accounts for cases where we had to
         # manually delete an image.
         echo "Image ${image_uri} was deleted from the repository."

--- a/boilerplate/openshift/golang-osd-operator/app-sre-build-deploy.sh
+++ b/boilerplate/openshift/golang-osd-operator/app-sre-build-deploy.sh
@@ -60,6 +60,20 @@ while read dockerfile_path image_uri junk; do
     fi
 done <<< "$3"
 
+if [[ "${RELEASE_BRANCHED_BUILDS}" ]]; then
+    # If the catalog image already exists, short out
+    if image_exists_in_repo "${REGISTRY_IMAGE}:${}"; then
+        echo "Catalog image ${REGISTRY_IMAGE}:${} already "
+        echo "exists. Assuming this means the saas bundle work has also been done "
+        echo "properly. Nothing to do!"
+    else
+        # build the CSV and create & push image catalog for the appropriate channel
+        make stable-csv-build stable-catalog-build stable-catalog-publish
+    fi
+
+    exit
+fi
+
 for channel in staging production; do
     # If the catalog image already exists, short out
     if image_exists_in_repo "${REGISTRY_IMAGE}:${channel}-${CURRENT_COMMIT}"; then

--- a/boilerplate/openshift/golang-osd-operator/app-sre-build-deploy.sh
+++ b/boilerplate/openshift/golang-osd-operator/app-sre-build-deploy.sh
@@ -62,8 +62,8 @@ done <<< "$3"
 
 if [[ "${RELEASE_BRANCHED_BUILDS}" ]]; then
     # If the catalog image already exists, short out
-    if image_exists_in_repo "${REGISTRY_IMAGE}:${}"; then
-        echo "Catalog image ${REGISTRY_IMAGE}:${} already "
+    if image_exists_in_repo "${REGISTRY_IMAGE}:v${OPERATOR_VERSION}"; then
+        echo "Catalog image ${REGISTRY_IMAGE}:v${OPERATOR_VERSION} already "
         echo "exists. Assuming this means the saas bundle work has also been done "
         echo "properly. Nothing to do!"
     else

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-build.sh
@@ -61,7 +61,12 @@ channels:
   currentCSV: ${operator_name}.v${OPERATOR_NEW_VERSION}
 EOF
 
-${CONTAINER_ENGINE} build --pull -f "${DOCKERFILE_REGISTRY}" --build-arg "SAAS_OPERATOR_DIR=${SAAS_OPERATOR_DIR}" --tag "${registry_image}:${operator_channel}-latest" .
+TAG="${operator_channel}-latest"
+if [[ "${RELEASE_BRANCHED_BUILDS}" ]]; then
+    TAG="v${OPERATOR_NEW_VERSION}"
+fi
+
+${CONTAINER_ENGINE} build --pull -f "${DOCKERFILE_REGISTRY}" --build-arg "SAAS_OPERATOR_DIR=${SAAS_OPERATOR_DIR}" --tag "${registry_image}:${TAG}" .
 
 if [ $? -ne 0 ] ; then
     echo "docker build failed, exiting..."

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-publish.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-publish.sh
@@ -95,6 +95,19 @@ popd
 
 if [ "$push_catalog" = true ] ; then
     # push image
+    if [[ "${RELEASE_BRANCHED_BUILDS}" ]]; then
+      skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+          "${SRC_CONTAINER_TRANSPORT}:${registry_image}:v${OPERATOR_NEW_VERSION}" \
+          "docker://${registry_image}:v${OPERATOR_NEW_VERSION}"
+
+      if [ $? -ne 0 ] ; then
+          echo "skopeo push of ${registry_image}:v${OPERATOR_NEW_VERSION}-latest failed, exiting..."
+          exit 1
+      fi
+
+      exit
+    fi
+
     skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
         "${SRC_CONTAINER_TRANSPORT}:${registry_image}:${operator_channel}-latest" \
         "docker://${registry_image}:${operator_channel}-latest"

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-publish.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/catalog-publish.sh
@@ -84,7 +84,7 @@ replaces ${OPERATOR_PREV_VERSION}
 removed versions: ${REMOVED_VERSIONS}"
 
 git commit -m "${MESSAGE}"
-git push origin "${operator_channel}"
+git push origin HEAD
 
 if [ $? -ne 0 ] ; then
     echo "git push failed, exiting..."

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.mk
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.mk
@@ -45,3 +45,25 @@ production-catalog-build-and-publish:
 	@$(MAKE) -s production-csv-build --no-print-directory
 	@$(MAKE) -s production-catalog-build --no-print-directory
 	@$(MAKE) -s production-catalog-publish --no-print-directory
+
+.PHONY: stable-csv-build
+stable-csv-build:
+	@${CONVENTION_DIR}/csv-generate/csv-generate.sh -o $(OPERATOR_NAME) -i $(OPERATOR_IMAGE) -V $(OPERATOR_VERSION) -c stable -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -s $(SUPPLEMENTARY_IMAGE) -e $(SKIP_RANGE_ENABLED)
+
+.PHONY: stable-catalog-build
+stable-catalog-build:
+	@${CONVENTION_DIR}/csv-generate/catalog-build.sh -o $(OPERATOR_NAME) -c stable -r ${REGISTRY_IMAGE}
+
+.PHONY: stable-saas-bundle-push
+stable-saas-bundle-push:
+	@${CONVENTION_DIR}/csv-generate/catalog-publish.sh -o $(OPERATOR_NAME) -c stable -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -r ${REGISTRY_IMAGE}
+
+.PHONY: stable-catalog-publish
+stable-catalog-publish:
+	@${CONVENTION_DIR}/csv-generate/catalog-publish.sh -o $(OPERATOR_NAME) -c stable -H $(CURRENT_COMMIT) -n $(COMMIT_NUMBER) -p -r ${REGISTRY_IMAGE}
+
+.PHONY: stable-catalog-build-and-publish
+stable-catalog-build-and-publish:
+	@$(MAKE) -s stable-csv-build --no-print-directory
+	@$(MAKE) -s stable-catalog-build --no-print-directory
+	@$(MAKE) -s stable-catalog-publish --no-print-directory

--- a/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
@@ -80,7 +80,11 @@ SAAS_OPERATOR_DIR="saas-${operator_name}-bundle"
 BUNDLE_DIR="$SAAS_OPERATOR_DIR/${operator_name}/"
 
 rm -rf "$SAAS_OPERATOR_DIR"
-git clone --branch "$operator_channel" ${GIT_PATH} "$SAAS_OPERATOR_DIR"
+BRANCH="$operator_channel"
+if [[ "${RELEASE_BRANCHED_BUILDS}" ]]; then
+    BRANCH="release-${operator_version%.*}"
+fi
+git clone --branch "${BRANCH}" ${GIT_PATH} "$SAAS_OPERATOR_DIR"
 
 # If this is a brand new SaaS setup, then set up accordingly
 if [[ ! -d "${BUNDLE_DIR}" ]]; then

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -323,6 +323,7 @@ coverage:
 # TODO: Boilerplate this script.
 .PHONY: build-push
 build-push:
+	OPERATOR_VERSION="${OPERATOR_VERSION}" \
 	${CONVENTION_DIR}/app-sre-build-deploy.sh ${REGISTRY_IMAGE} ${CURRENT_COMMIT} "$$IMAGES_TO_BUILD"
 
 .PHONY: opm-build-push


### PR DESCRIPTION
Produce catalog images that are versioned by the operator version with a single "stable" channel when `RELEASE_BRANCHED_BUILDS` variable is set. If set, build/push and short circuit to avoid existing behavior.

See each commit message for details

[SDCICD-1290](https://issues.redhat.com//browse/SDCICD-1290)

https://quay.io/repository/bpratt/must-gather-operator-registry?tab=tags
https://quay.io/repository/bpratt/must-gather-operator?tab=tags
https://gitlab.cee.redhat.com/bpratt/saas-must-gather-operator-bundle/-/tree/release-4.16?ref_type=heads