### PR TITLE
golang-osd-operator: only checkout new branch on RELEASE_BRANCHED_BUILDS

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
@@ -87,13 +87,17 @@ if [[ "${RELEASE_BRANCHED_BUILDS}" ]]; then
     BRANCH="release-${operator_version%.*}"
 fi
 
-git clone ${GIT_PATH} "$SAAS_OPERATOR_DIR"
-pushd "${SAAS_OPERATOR_DIR}"
-# if branch doesn't exist, checkout a new branch based on staging
-if ! git show-ref --verify --quiet refs/heads/${BRANCH}; then
-    git checkout -b "${BRANCH}" --track origin/staging
+if [[ "${RELEASE_BRANCHED_BUILDS}" ]]; then
+  git clone ${GIT_PATH} "$SAAS_OPERATOR_DIR"
+  pushd "${SAAS_OPERATOR_DIR}"
+  # if branch doesn't exist, checkout a new branch based on staging
+  if ! git show-ref --verify --quiet refs/heads/${BRANCH}; then
+      git checkout -b "${BRANCH}" --track origin/staging
+  fi
+  popd
+else
+  git clone --branch "$operator_channel" ${GIT_PATH} "$SAAS_OPERATOR_DIR"
 fi
-popd
 
 # If this is a brand new SaaS setup, then set up accordingly
 if [[ ! -d "${BUNDLE_DIR}" ]]; then


### PR DESCRIPTION
this broke the build pipelines as they would checkout production and track is based on staging which would lead to a failure when pushing the branch

```
...
10:14:40 Switched to a new branch 'production'
10:14:40 Branch 'production' set up to track remote branch 'staging' from 'origin'.
...
```

```
10:14:49 To https://gitlab.cee.redhat.com/service/saas-managed-upgrade-operator-bundle.git
10:14:49  ! [rejected]        HEAD -> production (non-fast-forward)
10:14:49 error: failed to push some refs to 'https://app:****@gitlab.cee.redhat.com/service/saas-managed-upgrade-operator-bundle.git'
10:14:49 hint: Updates were rejected because the tip of your current branch is behind
10:14:49 hint: its remote counterpart. Integrate the remote changes (e.g.
10:14:49 hint: 'git pull ...') before pushing again.
10:14:49 hint: See the 'Note about fast-forwards' in 'git push --help' for details.
10:14:49 make[1]: *** [production-catalog-publish] Error 1
```

https://redhat-internal.slack.com/archives/CFJD1NZFT/p1717588851642199