### PR TITLE
golang-osd-operator: set VERSION_MAJOR/MINOR

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/project.mk
+++ b/boilerplate/openshift/golang-osd-operator/project.mk
@@ -16,5 +16,14 @@ EnableOLMSkipRange?=$(shell sed -n 's/.*EnableOLMSkipRange .*"\([^"]*\)".*/\1/p'
 VERSION_MAJOR?=0
 VERSION_MINOR?=1
 
+ifdef RELEASE_BRANCHED_BUILDS
+    BRANCH_NAME := $(shell git rev-parse --abbrev-ref HEAD | grep -E '^release-[0-9]+\.[0-9]+$$')
+    ifneq ($(BRANCH_NAME),)
+        SEMVER := $(subst release-,,$(subst ., ,$(BRANCH_NAME)))
+        VERSION_MAJOR := $(firstword $(SEMVER))
+        VERSION_MINOR := $(lastword $(SEMVER))
+    endif
+endif
+
 REGISTRY_USER?=$(QUAY_USER)
 REGISTRY_TOKEN?=$(QUAY_TOKEN)


### PR DESCRIPTION
when RELEASE_BRANCHED_BUILDS is set and the branch name matches the release-4.\d\d expression, set VERSION_MAJOR and VERSION_MINOR to be the version contained in the branch name

This will make branching easier so we don't have to set up the versions per branch

```
❯ git diff
diff --git a/Makefile b/Makefile
index d0e3fd1..aff4480 100644
--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,7 @@ SHELL := /usr/bin/env bash
 export SKIP_SAAS_FILE_CHECKS=y
 .PHONY: boilerplate-update
 boilerplate-update:
-       @boilerplate/update
\ No newline at end of file
+       @boilerplate/update
+
+version:
+       @echo "$(VERSION_MAJOR):$(VERSION_MINOR)"
```

```
❯ RELEASE_BRANCHED_BUILDS=true make version
boilerplate/openshift/golang-osd-operator/standard.mk:113: Setting GOEXPERIMENT=strictfipsruntime,boringcrypto - this generally causes builds to fail unless building inside the provided Dockerfile. If building locally consider calling 'go build .'
go: unknown GOEXPERIMENT strictfipsruntime
4:12
```