### PR TITLE
golang-osd-operator: checkout branchs and check remote

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
@@ -90,9 +90,11 @@ fi
 if [[ "${RELEASE_BRANCHED_BUILDS}" ]]; then
   git clone ${GIT_PATH} "$SAAS_OPERATOR_DIR"
   pushd "${SAAS_OPERATOR_DIR}"
-  # if branch doesn't exist, checkout a new branch based on staging
-  if ! git show-ref --verify --quiet refs/heads/${BRANCH}; then
-      git checkout -b "${BRANCH}" --track origin/staging
+  # if branch doesn't exist, checkout a new branch based on production
+  if git ls-remote --exit-code --heads "${GIT_PATH}" "${BRANCH}"; then
+      git checkout "${BRANCH}"
+  else
+      git checkout -b "${BRANCH}" --track origin/production
   fi
   popd
 else


### PR DESCRIPTION
We weren't doing a `git pull --all` so the check on L94 was not working correctly. Use `ls-remote` to check instead and create