### PR TITLE
add GCP params to harness osde2e job template

### DIFF
--- a/boilerplate/openshift/golang-osd-operator-osde2e/test-harness-template.yml
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/test-harness-template.yml
@@ -11,12 +11,16 @@ parameters:
     required: true
   - name: OCM_TOKEN
     required: true
+  - name: OCM_CCS
+    required: false
   - name: AWS_ACCESS_KEY_ID
-    required: true
+    required: false
   - name: AWS_SECRET_ACCESS_KEY
-    required: true
+    required: false
   - name: AWS_REGION
-    required: true
+    required: false
+  - name: GCP_CREDS_JSON
+    required: false
   - name: JOBID
     generate: expression
     from: "[0-9a-z]{7}"
@@ -56,11 +60,15 @@ objects:
                   value: ${TEST_HARNESS_IMAGE}:${IMAGE_TAG}
                 - name: OCM_TOKEN
                   value: ${OCM_TOKEN}
+                - name: OCM_CCS
+                  value: ${OCM_CCS}
                 - name: AWS_ACCESS_KEY_ID
                   value: ${AWS_ACCESS_KEY_ID}
                 - name: AWS_SECRET_ACCESS_KEY
                   value: ${AWS_SECRET_ACCESS_KEY}
                 - name: AWS_REGION
                   value: ${AWS_REGION}
+                - name: GCP_CREDS_JSON
+                  value: ${GCP_CREDS_JSON}
                 - name: LOG_BUCKET
                   value: ${LOG_BUCKET}                 


### PR DESCRIPTION
Add params required for harness jobs that will run e2e tests on GCP clusters