### PR TITLE
golang-osd-operator: resolve BRANCH and fix REPOSITORY

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/rvmo-bundle.sh
+++ b/boilerplate/openshift/golang-osd-operator/rvmo-bundle.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-REPOSITORY=${REPOSITORY:-"git@github.com:openshift/managed-release-bundle-osd.git"}
+REPOSITORY=${REPOSITORY:-"https://github.com/openshift/managed-release-bundle-osd.git"}
 BRANCH=${BRANCH:-main}
 DELETE_TEMP_DIR=${DELETE_TEMP_DIR:-true}
 TMPD=$(mktemp -d --suffix -rvmo-bundle)

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -42,6 +42,7 @@ endif
 
 # Generate version and tag information from inputs
 COMMIT_NUMBER=$(shell git rev-list `git rev-list --parents HEAD | grep -E "^[a-f0-9]{40}$$"`..HEAD --count)
+CURRENT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 CURRENT_COMMIT=$(shell git rev-parse --short=7 HEAD)
 OPERATOR_VERSION=$(VERSION_MAJOR).$(VERSION_MINOR).$(COMMIT_NUMBER)-$(CURRENT_COMMIT)
 
@@ -384,6 +385,7 @@ container-coverage:
 
 .PHONY: rvmo-bundle
 rvmo-bundle:
+	BRANCH=$(CURRENT_BRANCH) \
 	OPERATOR_NAME=$(OPERATOR_NAME) \
 	OPERATOR_VERSION=$(OPERATOR_VERSION) \
 	OPERATOR_OLM_REGISTRY_IMAGE=$(REGISTRY_IMAGE) \


### PR DESCRIPTION
REPOSITORY should be https, not ssh

The branch that is cloned of `openshift/managed-release-bundle-osd` should be the branch that the current branch of the operator executing the make target. Get the branch and pass it into the bundle script.