### PR TITLE
Give RVMO code path proper branch/version detection

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/project.mk
+++ b/boilerplate/openshift/golang-osd-operator/project.mk
@@ -17,9 +17,30 @@ VERSION_MAJOR?=0
 VERSION_MINOR?=1
 
 ifdef RELEASE_BRANCHED_BUILDS
-    BRANCH_NAME := $(shell git rev-parse --abbrev-ref HEAD | grep -E '^release-[0-9]+\.[0-9]+$$')
-    ifneq ($(BRANCH_NAME),)
-        SEMVER := $(subst release-,,$(subst ., ,$(BRANCH_NAME)))
+    # RELEASE_BRANCH from env vars takes precedence; if not set, try to figure it out
+    RELEASE_BRANCH:=${RELEASE_BRANCH}
+    ifneq ($(RELEASE_BRANCH),)
+        # Sanity check, just to be nice
+        RELEASE_BRANCH_TEST := $(shell echo ${RELEASE_BRANCH} | grep -E '^release-[0-9]+\.[0-9]+$$')
+        ifeq ($(RELEASE_BRANCH_TEST),)
+            $(warning Provided RELEASE_BRANCH doesn't conform to "release-X.Y" pattern; you sure you didn't make a mistake?)
+        endif
+    endif
+
+    ifeq ($(RELEASE_BRANCH),)
+        # Check git repo's branch first
+        RELEASE_BRANCH := $(shell git rev-parse --abbrev-ref HEAD | grep -E '^release-[0-9]+\.[0-9]+$$')
+    endif
+
+    ifeq ($(RELEASE_BRANCH),)
+        # Try to parse it out of Jenkins' JOB_NAME
+        RELEASE_BRANCH := $(shell echo ${JOB_NAME} | grep -E --only-matching 'release-[0-9]+\.[0-9]+')
+    endif
+
+    ifeq ($(RELEASE_BRANCH),)
+        $(error RELEASE_BRANCHED_BUILDS is set, but couldn't detect a release branch and RELEASE_BRANCH is not set; giving up)
+    else
+        SEMVER := $(subst release-,,$(subst ., ,$(RELEASE_BRANCH)))
         VERSION_MAJOR := $(firstword $(SEMVER))
         VERSION_MINOR := $(lastword $(SEMVER))
     endif

--- a/boilerplate/openshift/golang-osd-operator/rvmo-bundle.sh
+++ b/boilerplate/openshift/golang-osd-operator/rvmo-bundle.sh
@@ -3,11 +3,15 @@
 set -e
 
 REPOSITORY=${REPOSITORY:-"https://github.com/openshift/managed-release-bundle-osd.git"}
-BRANCH=${BRANCH:-main}
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD|egrep '^main$|^release-[0-9]+\.[0-9]+$'|cat)
+RVMO_BRANCH=${CURRENT_BRANCH:-main}
+# You can override any branch detection by setting RELEASE_BRANCH
+BRANCH=${RELEASE_BRANCH:-$RVMO_BRANCH}
 DELETE_TEMP_DIR=${DELETE_TEMP_DIR:-true}
 TMPD=$(mktemp -d --suffix -rvmo-bundle)
 [[ "${DELETE_TEMP_DIR}" == "true" ]] && trap 'rm -rf ${TMPD}' EXIT
 
 cd "${TMPD}"
+echo "Cloning RVMO from ${REPOSITORY}:${BRANCH}"
 git clone --single-branch -b "${BRANCH}" "${REPOSITORY}" .
 bash hack/update-operator-release.sh

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -42,7 +42,6 @@ endif
 
 # Generate version and tag information from inputs
 COMMIT_NUMBER=$(shell git rev-list `git rev-list --parents HEAD | grep -E "^[a-f0-9]{40}$$"`..HEAD --count)
-CURRENT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 CURRENT_COMMIT=$(shell git rev-parse --short=7 HEAD)
 OPERATOR_VERSION=$(VERSION_MAJOR).$(VERSION_MINOR).$(COMMIT_NUMBER)-$(CURRENT_COMMIT)
 
@@ -385,7 +384,7 @@ container-coverage:
 
 .PHONY: rvmo-bundle
 rvmo-bundle:
-	BRANCH=$(CURRENT_BRANCH) \
+	RELEASE_BRANCH=$(RELEASE_BRANCH) \
 	OPERATOR_NAME=$(OPERATOR_NAME) \
 	OPERATOR_VERSION=$(OPERATOR_VERSION) \
 	OPERATOR_OLM_REGISTRY_IMAGE=$(REGISTRY_IMAGE) \


### PR DESCRIPTION
Release branched builds can only work correctly if they're being run from a branch named `release-4.Y`.

This gets complicated in two places:
* If a developer wants to locally build from their feature branch, which definitively isn't named `release-4.Y`. This is taken care of by being able to run `RELEASE_BRANCH=release-4.16 make …` to override current branch detection.
* Appiface Jenkins just doesn't provide the build branch to the environment ([see](https://ci.int.devshift.net/view/osde2e/job/openshift-osd-example-operator-gh-build-release-4.16/74/injectedEnvVars/)) and the project's git repo is checked out as a detached HEAD commit, so there's no "what's my branch" information in there either. Best I can do right now is to try to extract the branch from JOB_NAME, which is what this code does… for now.

On the last point, there should be `GIT_LOCAL_BRANCH` available in the env, but for some reason it's not. I'm talking to appsre about this and if we ever get that working, I'll remove the current JOB_NAME hack and just look at `GIT_LOCAL_BRANCH`. But for now, this is the only way I can get this to work in prod.