### PR TITLE
Take container auth file from jenkins

### DIFF
--- a/boilerplate/openshift/golang-osd-operator-osde2e/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/standard.mk
@@ -19,17 +19,17 @@ HARNESS_IMAGE_TAG=$(CURRENT_COMMIT)
 # invocation; otherwise it could collide across jenkins jobs. We'll use
 # a .docker folder relative to pwd (the repo root).
 CONTAINER_ENGINE_CONFIG_DIR = .docker
-# But docker and podman use different options to configure it :eyeroll:
-# ==> Podman uses --authfile=PATH *after* the `login` subcommand; but
-# also accepts REGISTRY_AUTH_FILE from the env. See
-# https://www.mankier.com/1/podman-login#Options---authfile=path
 export REGISTRY_AUTH_FILE = ${CONTAINER_ENGINE_CONFIG_DIR}/config.json
+
 # If this configuration file doesn't exist, podman will error out. So
 # we'll create it if it doesn't exist.
 ifeq (,$(wildcard $(REGISTRY_AUTH_FILE)))
 $(shell mkdir -p $(CONTAINER_ENGINE_CONFIG_DIR))
-$(shell echo '{}' > $(REGISTRY_AUTH_FILE))
+# Copy the node container auth file so that we get access to the registries the
+# parent node has access to
+$(shell cp /var/lib/jenkins/.docker/config.json $(REGISTRY_AUTH_FILE))
 endif
+
 # ==> Docker uses --config=PATH *before* (any) subcommand; so we'll glue
 # that to the CONTAINER_ENGINE variable itself. (NOTE: I tried half a
 # dozen other ways to do this. This was the least ugly one that actually

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -21,17 +21,17 @@ endif
 # invocation; otherwise it could collide across jenkins jobs. We'll use
 # a .docker folder relative to pwd (the repo root).
 CONTAINER_ENGINE_CONFIG_DIR = .docker
-# But docker and podman use different options to configure it :eyeroll:
-# ==> Podman uses --authfile=PATH *after* the `login` subcommand; but
-# also accepts REGISTRY_AUTH_FILE from the env. See
-# https://www.mankier.com/1/podman-login#Options---authfile=path
 export REGISTRY_AUTH_FILE = ${CONTAINER_ENGINE_CONFIG_DIR}/config.json
+
 # If this configuration file doesn't exist, podman will error out. So
 # we'll create it if it doesn't exist.
 ifeq (,$(wildcard $(REGISTRY_AUTH_FILE)))
 $(shell mkdir -p $(CONTAINER_ENGINE_CONFIG_DIR))
-$(shell echo '{}' > $(REGISTRY_AUTH_FILE))
+# Copy the node container auth file so that we get access to the registries the
+# parent node has access to
+$(shell cp /var/lib/jenkins/.docker/config.json $(REGISTRY_AUTH_FILE))
 endif
+
 # ==> Docker uses --config=PATH *before* (any) subcommand; so we'll glue
 # that to the CONTAINER_ENGINE variable itself. (NOTE: I tried half a
 # dozen other ways to do this. This was the least ugly one that actually


### PR DESCRIPTION
In July all osd operators will be built in a rhel8 jenkins node. And that was causing a container registry access error, at least for osd-example-operator.

This change fixes the issue (at least for osd-example-operator). It's based on [this change to Hive](https://github.com/openshift/hive/pull/2321/files).