### PR TITLE
Fix app-sre-build-push after switch to podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ build-image-shallow: ## Builds the image starting from a recent release, like pr
 
 .PHONY: build-push
 build-push: ## Conditionally (only for a new tag) builds and pushes the backing image. Used in appsre. (Don't try this locally -- it's hardcoded to push to app-sre's quay. FIXME)
-	config/app-sre-build-push.sh quay.io app-sre $(IMG)
+	config/app-sre-build-push.sh
 
 .DEFAULT_GOAL := help
 .PHONY: help

--- a/config/app-sre-build-push.sh
+++ b/config/app-sre-build-push.sh
@@ -2,34 +2,11 @@
 
 set -ex
 
-# Usage: push.sh REGISTRY NAMESPACE NAME
-# e.g. push.sh quay.io app-sre boilerplate
+# Usage: app-sre-build-push.sh REGISTRY NAMESPACE NAME
+# e.g. app-sre-build-push push.sh quay.io app-sre boilerplate
 # Builds and pushes a new tagged image IF the most recent tag does not yet have an image.
 # Checks out the right version for the tag beforehand. 
 # Assumes $QUAY_USER and $QUAY_TOKEN are set in the env.
-
-registry=$1
-namespace=$2
-name=$3
-
-quay_image=$registry/$namespace/$name
-
-HERE=$(realpath ${0%/*})
-container_engine=${CONTAINER_ENGINE:-$(command -v podman || echo docker)}
-
-build_cumulative() {
-    local tag=$1
-    echo "Building for tag $tag"
-    $container_engine build -t ${name}:${tag} -f ${HERE}/Dockerfile.appsre ${HERE}
-}
-
-push_for_tag() {
-    local tag=$1
-    echo "Pushing for tag $tag"
-    skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-        "docker-daemon:${name}:$tag" \
-        "docker://${quay_image}:$tag"
-}
 
 # Get the most recent tag starting with "image-v*"
 latest_tag=$(git describe --tags --match "image-v*" --abbrev=0)
@@ -38,25 +15,33 @@ if [ -z ${latest_tag} ]; then
     exit 1
 fi
 
-# Run podman manifest inspect in a subshell and capture the output and rc
-inspect_output=$($container_engine manifest inspect "quay.io/app-sre/boilerplate:${latest_tag}" 2>&1) && return_code=0 || return_code=$?
+# E.g. quay.io/app-sre/boilerplate:image-v1.0.0
+IMAGE="quay.io/app-sre/boilerplate:${latest_tag}"
+
+HERE=$(realpath ${0%/*})
+CONTAINER_ENGINE_CONFIG_DIR=.docker
+mkdir -p "${CONTAINER_ENGINE_CONFIG_DIR}"
+REGISTRY_AUTH_FILE = ${CONTAINER_ENGINE_CONFIG_DIR}/config.json
+
+podman login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io
+
+# Check if the image exists already
+inspect_output=$(skopeo inspect "${IMAGE}" 2>&1)
+return_code=$?
 
 # We need to make sure we don't re-create in case there's a different error
 # so we also check that the returned output is something like 
-# podman manifest inspect quay.io/app-sre/boilerplate:image-v5.0.0
-# Error: reading image "docker://quay.io/app-sre/boilerplate:image-v5.0.0": reading manifest image-v5.0.0 in quay.io/app-sre/boilerplate: manifest unknow
-# docker manifest inspect quay.io/app-sre/boilerplate:image-v5.0.0
-# no such manifest: quay.io/app-sre/boilerplate:image-v5.0.0
+# skopeo inspect "docker://quay.io/app-sre/boilerplate:image-v5.0.1" 2>&1
+# time="2024-07-08T22:52:52-04:00" level=fatal msg="Error parsing image name \"docker://quay.io/app-sre/boilerplate:image-v5.0.1\": reading manifest image-v5.0.1 in quay.io/app-sre/boilerplate: manifest unknown"
 if [ "$return_code" -eq 0 ]; then
-    echo "Image 'quay.io/app-sre/boilerplate:${latest_tag}' already exists."
-elif [ "$return_code" -ne 0 ] && { [[ $inspect_output == *"manifest unknown"* ]] || [[ $inspect_output == *"no such manifest"* ]]; }; then
-    echo "Creating image 'quay.io/app-sre/boilerplate:${latest_tag}' does not exist."
+    echo "Image: ${IMAGE} already exists. Skipping image build/push."
+elif [ "$return_code" -ne 0 ] && { [[ $inspect_output == *"manifest unknown"* ]] }; then
+    echo "Image: ${IMAGE} does not exist. Starting image build/push"
     git checkout ${latest_tag}
-    echo "Creating image 'quay.io/app-sre/boilerplate:${latest_tag}'"
-    build_cumulative ${latest_tag}
-    push_for_tag ${latest_tag}
+    podman build "${HERE}" -f "${HERE}/Dockerfile.appsre" -t "${IMAGE}"
+    podman push "${IMAGE}"
 else
-    echo "Error checking for image existence. Exit code: $return_code, Output: $inspect_output"
+    echo "Unexpected error checking for image existence. Exit code: $return_code, Output: $inspect_output"
     exit 1
 fi
 


### PR DESCRIPTION
* This makes this podman-compatible after the recent CI change from docker --> podman.
* Refactored the existing script with some inspiration from https://github.com/openshift/hive/blob/37bc19e1664791bf36903d2984c48d1f39a2157c/hack/app_sre_build_deploy.sh
* Current CI failure https://ci.int.devshift.net/job/openshift-boilerplate-gh-build-master/373/console:
```
15:37:28 time="2024-07-08T19:37:28Z" level=fatal msg="initializing source docker-daemon:boilerplate:image-v5.0.1: loading image from docker engine: permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get \"http://%2Fvar%2Frun%2Fdocker.sock/v1.24/images/get?names=boilerplate%3Aimage-v5.0.1\": dial unix /var/run/docker.sock: connect: permission denied"
```

[OSD-24219](https://issues.redhat.com//browse/OSD-24219)