### PR TITLE
Copy the node container auth file to allow pulling from registry.ci.openshift.org

### DIFF
--- a/config/app-sre-build-push.sh
+++ b/config/app-sre-build-push.sh
@@ -17,16 +17,19 @@ fi
 
 # E.g. quay.io/app-sre/boilerplate:image-v1.0.0
 IMAGE="quay.io/app-sre/boilerplate:${latest_tag}"
-
 HERE=$(realpath ${0%/*})
+
+# Copy the node container auth file so that we get access to the registries the
+# parent node has access to, i.e. registry.ci.openshift.org
 CONTAINER_ENGINE_CONFIG_DIR=.docker
 mkdir -p "${CONTAINER_ENGINE_CONFIG_DIR}"
-REGISTRY_AUTH_FILE = ${CONTAINER_ENGINE_CONFIG_DIR}/config.json
+export REGISTRY_AUTH_FILE=${CONTAINER_ENGINE_CONFIG_DIR}/config.json
+cp /var/lib/jenkins/.docker/config.json "$REGISTRY_AUTH_FILE"
 
 podman login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io
 
 # Check if the image exists already
-inspect_output=$(skopeo inspect "${IMAGE}" 2>&1)
+inspect_output=$(skopeo inspect "docker://${IMAGE}" 2>&1)
 return_code=$?
 
 # We need to make sure we don't re-create in case there's a different error


### PR DESCRIPTION
Builds are still failing https://ci.int.devshift.net/job/openshift-boilerplate-gh-build-master/375/console because of a typo, but I learned that we actually need to copy this file over as well - from similar fixes in https://github.com/openshift/boilerplate/pull/366 and https://github.com/openshift/hive/pull/2321

```
10:58:28 + REGISTRY_AUTH_FILE = .docker/config.json
10:58:28 config/app-sre-build-push.sh: line 24: REGISTRY_AUTH_FILE: command not found
```

[OSD-24219](https://issues.redhat.com//browse/OSD-24219)