### PR TITLE
[OSD-13681] Added a prefix 'g' to handle leading zeroes in CSV version

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -42,7 +42,7 @@ endif
 
 # Generate version and tag information from inputs
 COMMIT_NUMBER=$(shell git rev-list `git rev-list --parents HEAD | grep -E "^[a-f0-9]{40}$$"`..HEAD --count)
-CURRENT_COMMIT=$(shell git rev-parse --short=7 HEAD)
+CURRENT_COMMIT=g$(shell git rev-parse --short=7 HEAD)
 OPERATOR_VERSION=$(VERSION_MAJOR).$(VERSION_MINOR).$(COMMIT_NUMBER)-$(CURRENT_COMMIT)
 
 OPERATOR_IMAGE=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME)

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -42,8 +42,8 @@ endif
 
 # Generate version and tag information from inputs
 COMMIT_NUMBER=$(shell git rev-list `git rev-list --parents HEAD | grep -E "^[a-f0-9]{40}$$"`..HEAD --count)
-CURRENT_COMMIT=g$(shell git rev-parse --short=7 HEAD)
-OPERATOR_VERSION=$(VERSION_MAJOR).$(VERSION_MINOR).$(COMMIT_NUMBER)-$(CURRENT_COMMIT)
+CURRENT_COMMIT=$(shell git rev-parse --short=7 HEAD)
+OPERATOR_VERSION=$(VERSION_MAJOR).$(VERSION_MINOR).$(COMMIT_NUMBER)-g$(CURRENT_COMMIT)
 
 OPERATOR_IMAGE=$(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME)
 OPERATOR_IMAGE_TAG=v$(OPERATOR_VERSION)


### PR DESCRIPTION
In this commit, I added a prefix of 'g' to the hash to handle leading zeroes in CSV version, which was breaking OLM. 
This is a convention used in other places. For example:
machine-api-operator ran into this https://bugzilla.redhat.com/show_bug.cgi?id=2015188 and fixed this by prepending a "g" for git I guess https://github.com/openshift/doozer/pull/527. 


https://issues.redhat.com/browse/OSD-13681