### PR TITLE
KONFLUX-3729: add containerfile for konflux

### DIFF
--- a/config/Dockerfile.konflux
+++ b/config/Dockerfile.konflux
@@ -1,0 +1,3 @@
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22
+COPY build_image.sh /build_image.sh
+RUN /build_image.sh && rm /build_image.sh


### PR DESCRIPTION
the base image needs to be one built in Konflux, the brew golang builder works for now.

https://github.com/openshift/osd-example-operator/pull/290/checks?check_run_id=27879765416

Above is a test build of the image to show it builds correctly