### PR TITLE
fix opm-build-push command to use python venv

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -328,7 +328,7 @@ build-push:
 	${CONVENTION_DIR}/app-sre-build-deploy.sh ${REGISTRY_IMAGE} ${CURRENT_COMMIT} "$$IMAGES_TO_BUILD"
 
 .PHONY: opm-build-push
-opm-build-push: docker-push
+opm-build-push: python-venv docker-push
 	OLM_BUNDLE_IMAGE="${OLM_BUNDLE_IMAGE}" \
 	OLM_CATALOG_IMAGE="${OLM_CATALOG_IMAGE}" \
 	CONTAINER_ENGINE="${CONTAINER_ENGINE}" \


### PR DESCRIPTION
This command is failing in RHEL 8 nodes (e.g https://ci.int.devshift.net/view/deployment-validation-operator/job/app-sre-deployment-validation-operator-gh-build-master/272/console) because of:

```
08:14:39 boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh: line 246: python: command not found
```