### PR TITLE
config: dl yq from gh releases

### DIFF
--- a/config/build_image.sh
+++ b/config/build_image.sh
@@ -52,7 +52,13 @@ go install go.uber.org/mock/mockgen@${MOCKGEN_VERSION}
 # yq
 ####
 YQ_VERSION="v4.44.2"
-go install github.com/mikefarah/yq/v4@${YQ_VERSION}
+YQ_SHA256SUM=e4c2570249e3993e33ffa44e592b5eee8545bd807bfbeb596c2986d86cb6c85c
+YQ_LOCATION=https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64.tar.gz
+curl -LO ${YQ_LOCATION}
+echo ${YQ_SHA256SUM} yq_linux_amd64.tar.gz | sha256sum -c
+tar xvf yq_linux_amd64.tar.gz ./yq_linux_amd64
+mv yq_linux_amd64 /usr/local/bin/yq
+rm -f yq_linux_amd64.tar.gz
 
 # HACK: `go get` creates lots of things under GOPATH that are not group
 # accessible, even if umask is set properly. This causes failures of


### PR DESCRIPTION
go mod cache downloads the entire git repo to build the project, and this cache stays in the final image. When scanned by `Syft`, it finds the github workflow files for `yq`. This then generates a garbage package URL which causes a false positive.

This is likely a bug in Syft, but we can work around it for now by downloading directly from GH releases.

```
cosign download sbom quay.io/redhat-user-workloads/boilerplate-cicada-tenant/boilerplate-master/image:b969e799fd24b328ead839ddc49a8f6eeb1e77a1 | jq '.components[] | select(.purl | test("pandoc"))
```

```
{
  "bom-ref": "518056d3d1ed1d98",
  "type": "library",
  "name": "docker://pandoc/core:2.14.2",
  "cpe": "cpe:2.3:a:docker\\:\\/\\/pandoc\\/core\\:2.14.2:docker\\:\\/\\/pandoc\\/core\\:2.14.2:*:*:*:*:*:*:*:*",
  "purl": "pkg:github/docker:/#pandoc/core:2.14.2",
  "properties": [
    {
      "name": "syft:package:foundBy",
      "value": "github-actions-usage-cataloger"
    },
    {
      "name": "syft:package:type",
      "value": "github-action"
    },
    {
      "name": "syft:location:0:path",
      "value": "/go/pkg/mod/github.com/mikefarah/yq/v4@v4.44.2/.github/workflows/release.yml"
    }
  ]
}
```

https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1722411065681639?thread_ts=1722365748.535409&cid=C04PZ7H0VA8

```
❯ podman run -it --rm localhost/boilerplate:latest yq
Usage:
  yq [flags]
  yq [command]

Examples:
...
```