### PR TITLE
fix the opm-build-push target after d4f5e8add3d7afdd361c069d18ae758294…

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
+++ b/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
@@ -227,6 +227,14 @@ function build_opm_catalog() {
         from_arg="--from-index $OLM_CATALOG_IMAGE:$prev_commit"
     fi
 
+    # check if the previous catalog image is available
+    if [ $(${image_builder} pull $OLM_CATALOG_IMAGE:$prev_commit;echo $?) ]; then
+        # remove the first character
+        prev_commit=${prev_commit:1}
+        from_arg="--from-index $OLM_CATALOG_IMAGE:$prev_commit"
+    fi
+
+    log "Index argument is $from_arg"
     log "Creating catalog image $catalog_image_current_commit using opm"
     # shellcheck disable=SC2086
     $opm_local_executable index add --bundles "$bundle_image_current_commit" \
@@ -338,9 +346,9 @@ function main() {
         return 0
     fi
 
-    local bundle_image_current_commit="$OLM_BUNDLE_IMAGE:$CURRENT_COMMIT"
+    local bundle_image_current_commit="${OLM_BUNDLE_IMAGE}:g${CURRENT_COMMIT}"
     local bundle_image_latest="$OLM_BUNDLE_IMAGE:latest"
-    local catalog_image_current_commit="$OLM_CATALOG_IMAGE:$CURRENT_COMMIT"
+    local catalog_image_current_commit="{$OLM_CATALOG_IMAGE}:g${CURRENT_COMMIT}"
     local catalog_image_latest="$OLM_CATALOG_IMAGE:latest"
 
     bundle_image_current_commit=$(build_opm_bundle "${temp_dir}" \


### PR DESCRIPTION
…3273bd commit

The https://github.com/openshift/boilerplate/commit/d4f5e8add3d7afdd361c069d18ae7582943273bd broke the `opm-build-push`, because we don't have any catalog image with this `g` prefix so this is basically temporary workaround to fix that. 

