### PR TITLE
BUGFIX: Typo while accessing OLM_CATALOG_IMAGE env var

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
+++ b/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
@@ -348,7 +348,7 @@ function main() {
 
     local bundle_image_current_commit="${OLM_BUNDLE_IMAGE}:g${CURRENT_COMMIT}"
     local bundle_image_latest="$OLM_BUNDLE_IMAGE:latest"
-    local catalog_image_current_commit="{$OLM_CATALOG_IMAGE}:g${CURRENT_COMMIT}"
+    local catalog_image_current_commit="${OLM_CATALOG_IMAGE}:g${CURRENT_COMMIT}"
     local catalog_image_latest="$OLM_CATALOG_IMAGE:latest"
 
     bundle_image_current_commit=$(build_opm_bundle "${temp_dir}" \


### PR DESCRIPTION
### summary

* Fixed a typo when accessing an env var that caused the image to contain curly braces and thus fail to build.