### PR TITLE
OSD-25018 - Address opm bug

### DIFF
--- a/boilerplate/openshift/custom-catalog-osd-operator/custom-catalog-build-push.sh
+++ b/boilerplate/openshift/custom-catalog-osd-operator/custom-catalog-build-push.sh
@@ -39,6 +39,7 @@ function build_catalog_image() {
   exec 5>&1
   BUILD=$(${opm_local_executable} index add \
     --bundles ${bundle_image} \
+    --mode=semver \
     --tag ${image_tag} \
     --container-tool ${CONTAINER_ENGINE_SHORT} 2>&1 | tee /dev/fd/5; exit ${PIPESTATUS[0]})
   RC=$?

--- a/boilerplate/openshift/custom-catalog-osd-operator/install-opm.sh
+++ b/boilerplate/openshift/custom-catalog-osd-operator/install-opm.sh
@@ -3,7 +3,7 @@
 set -e
 
 # global envs
-OPM_VERSION="v1.23.2"
+OPM_VERSION="v1.46.0"
 GOOS=$(go env GOOS)
 REPO_ROOT=$(git rev-parse --show-toplevel)
 OPM_LOCAL_EXECUTABLE_DIR=${REPO_ROOT}/.opm/bin


### PR DESCRIPTION
This PR will address a documented bug with opm.

- Addressing an opm bug where the error "Error: Invalid bundle xxxx.vx.x.x, replaces nonexistent bundle xxxx.vx.x.x"
- Updating opm version