### PR TITLE
SDCICD-1205 add e2e harness build verification in operator pr-check

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/prow-config
+++ b/boilerplate/openshift/golang-osd-operator/prow-config
@@ -64,6 +64,12 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
+- as: e2e-binary-build-success
+  commands: |
+    make e2e-harness-build
+  container:
+    from: src
+  run_if_changed: ^(osde2e/.*|go\.mod|go\.sum)$
 - as: coverage
   commands: |
     export CODECOV_TOKEN=\$(cat /tmp/secret/CODECOV_TOKEN)


### PR DESCRIPTION
Add `make e2e-harness-build` target to pr-check jobs in operator prow template.

This target runs on operator build job. If this fails, operator builds will be blocked. So it should be ensured that the source for e2e tests builds correctly in pr checks.

[SDCICD-1205](https://issues.redhat.com//browse/SDCICD-1205)

Note: This will need to be followed up by adding this job to existing operator pipelines in release repo 