### PR TITLE
Add Cicada team to OWNER_ALIASES

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
+++ b/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
@@ -64,6 +64,12 @@ aliases:
     - xiaoyu74
     - Dee-6777
     - Tessg22
+  srep-infra-cicd:
+    - mmazur
+    - mrsantamaria
+    - ritmun
+    - jbpratt
+    - yiqinzhang
   srep-functional-leads:
     - rafael-azevedo
     - iamkirkbater
@@ -73,6 +79,7 @@ aliases:
     - mjlshen
     - sam-nguyen7
     - ravitri
+    - mmazur
   srep-team-leads:
     - NautiluX
     - rogbas


### PR DESCRIPTION
Cicada was the one team missing from the owners file despite being co-responsible for parts of and regularly contributing to a variety of srep-owned repos. And this commingling is going to increase in the future with rvmo, progressive delivery, konflux and the like.


Was conflicted on how to name it (Cicada is two reorgs away from being an actual functional team in srep, so I couldn't name it srep-functional-team-X), so I went with a "virtual" name that describes what the people are supposed to do, to make sure it's future-proof. If anybody got a better name, please suggest it.