### PR TITLE
Update Team Aurora roster

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
+++ b/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
@@ -5,11 +5,9 @@
 aliases:
   srep-functional-team-aurora:
     - abyrne55
-    - AlexVulaj
     - dakotalongRH
     - lnguyen1401
     - luis-falcon
-    - rafael-azevedo
     - reedcort
   srep-functional-team-fedramp:
     - tonytheleg


### PR DESCRIPTION
Alex and Raf have moved on to other roles within Red Hat, so this PR removes them from the Team Aurora group