### PR TITLE
Reconcile RHEL versions and update build paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ it's not available in boilerplate:image-v2.Y.Z
 
 1. Update config/Dockerfile
     ```
-    FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12
+    FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17
     ```
 2. Then, update the rest of boilerplate accordingly, push a new tag, and mirror the image into openshift/release
 to create boilerplate:image-v3.0.0

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ it's not available in boilerplate:image-v2.Y.Z
 
 1. Update config/Dockerfile
     ```
-    FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17
+    FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17
     ```
 2. Then, update the rest of boilerplate accordingly, push a new tag, and mirror the image into openshift/release
 to create boilerplate:image-v3.0.0

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,4 +1,3 @@
-# When updating this default BASE_IMAGE, remember to also update it in app-sre-build-push.sh
 ARG BASE_IMAGE="registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17"
 FROM ${BASE_IMAGE} AS builder
 

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,5 +1,5 @@
 # When updating this default BASE_IMAGE, remember to also update it in app-sre-build-push.sh
-ARG BASE_IMAGE="registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17"
+ARG BASE_IMAGE="registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17"
 FROM ${BASE_IMAGE} AS builder
 
 ARG GOCILINT_VERSION="1.59.1"

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,5 +1,5 @@
 # When updating this default BASE_IMAGE, remember to also update it in app-sre-build-push.sh
-ARG BASE_IMAGE="registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17"
+ARG BASE_IMAGE="registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17"
 FROM ${BASE_IMAGE} AS builder
 
 ARG GOCILINT_VERSION="1.59.1"
@@ -12,7 +12,7 @@ RUN curl -L -o golangci-lint.tar.gz ${GOCILINT_LOCATION} && \
     mv golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint /usr/local/bin
 
 ARG GH_VERSION="2.58.0"
-ARG GH_SHA256SUM="84feae3d143bc360ea1004b474f124c8cfd75363a5e197d3ce63fe23d9f3a2ea "
+ARG GH_SHA256SUM="84feae3d143bc360ea1004b474f124c8cfd75363a5e197d3ce63fe23d9f3a2ea"
 ARG GH_LOCATION=https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz
 
 RUN curl -L -o gh.tar.gz ${GH_LOCATION} && \

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -11,8 +11,8 @@ RUN curl -L -o golangci-lint.tar.gz ${GOCILINT_LOCATION} && \
     tar xzf golangci-lint.tar.gz golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint && \
     mv golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint /usr/local/bin
 
-ARG GH_VERSION="2.51.0"
-ARG GH_SHA256SUM="d7725fb2a643ca024edf5b4e2f2cca0431a404bbc2e251086ffca2b25e37be11"
+ARG GH_VERSION="2.58.0"
+ARG GH_SHA256SUM="84feae3d143bc360ea1004b474f124c8cfd75363a5e197d3ce63fe23d9f3a2ea "
 ARG GH_LOCATION=https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz
 
 RUN curl -L -o gh.tar.gz ${GH_LOCATION} && \

--- a/config/Dockerfile.konflux
+++ b/config/Dockerfile.konflux
@@ -1,5 +1,4 @@
-ARG BASE_IMAGE='brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22'
-FROM ${BASE_IMAGE} AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22 AS builder
 
 ARG GOCILINT_VERSION="1.59.1"
 ARG GOCILINT_SHA256SUM="c30696f1292cff8778a495400745f0f9c0406a3f38d8bb12cef48d599f6c7791"
@@ -20,7 +19,7 @@ RUN curl -L -o gh.tar.gz ${GH_LOCATION} && \
     tar xzf gh.tar.gz gh_${GH_VERSION}_linux_amd64/bin/gh && \
     mv gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin
 
-FROM ${BASE_IMAGE}
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22
 ENV GOFLAGS=-mod=mod
 
 ARG KUSTOMIZE_VERSION="v5.4.1" \

--- a/config/Dockerfile.konflux
+++ b/config/Dockerfile.konflux
@@ -50,9 +50,10 @@ RUN for bit in r x w; do find $(go env GOPATH) -perm -u+${bit} -a ! -perm -g+${b
 COPY --from=builder /usr/local/bin/golangci-lint /usr/local/bin
 COPY --from=builder /usr/local/bin/gh /usr/local/bin
 
-RUN dnf -y install openssh-clients jq skopeo python3-pyyaml && \
+RUN dnf update && \
+    -y install openssh-clients jq skopeo python3-pyyaml && \
     dnf clean all && \
     dnf -y autoremove && \
     rm -rf /var/cach/dnf
 
-#COPY LICENSE /licenses/.
+COPY LICENSE /licenses/.

--- a/config/Dockerfile.konflux
+++ b/config/Dockerfile.konflux
@@ -9,8 +9,9 @@ RUN curl -L -o golangci-lint.tar.gz ${GOCILINT_LOCATION} && \
     tar xzf golangci-lint.tar.gz golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint && \
     mv golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint /usr/local/bin
 
-ARG GH_VERSION="2.51.0"
-ARG GH_SHA256SUM="d7725fb2a643ca024edf5b4e2f2cca0431a404bbc2e251086ffca2b25e37be11"
+
+ARG GH_VERSION="2.58.0"
+ARG GH_SHA256SUM="84feae3d143bc360ea1004b474f124c8cfd75363a5e197d3ce63fe23d9f3a2ea "
 ARG GH_LOCATION=https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz
 
 RUN curl -L -o gh.tar.gz ${GH_LOCATION} && \

--- a/config/Dockerfile.konflux
+++ b/config/Dockerfile.konflux
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE="brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22"
+ARG BASE_IMAGE='brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22'
 FROM ${BASE_IMAGE} AS builder
 
 ARG GOCILINT_VERSION="1.59.1"

--- a/config/Dockerfile.konflux
+++ b/config/Dockerfile.konflux
@@ -51,7 +51,7 @@ COPY --from=builder /usr/local/bin/golangci-lint /usr/local/bin
 COPY --from=builder /usr/local/bin/gh /usr/local/bin
 
 RUN dnf update && \
-    -y install openssh-clients jq skopeo python3-pyyaml && \
+    dnf -y install openssh-clients jq skopeo python3-pyyaml && \
     dnf clean all && \
     dnf -y autoremove && \
     rm -rf /var/cach/dnf

--- a/config/Dockerfile.konflux
+++ b/config/Dockerfile.konflux
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.22 AS builder
 
 ARG GOCILINT_VERSION="1.59.1"
 ARG GOCILINT_SHA256SUM="c30696f1292cff8778a495400745f0f9c0406a3f38d8bb12cef48d599f6c7791"
@@ -19,7 +19,7 @@ RUN curl -L -o gh.tar.gz ${GH_LOCATION} && \
     tar xzf gh.tar.gz gh_${GH_VERSION}_linux_amd64/bin/gh && \
     mv gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.22
 ENV GOFLAGS=-mod=mod
 
 ARG KUSTOMIZE_VERSION="v5.4.1" \

--- a/config/Dockerfile.konflux
+++ b/config/Dockerfile.konflux
@@ -19,7 +19,7 @@ RUN curl -L -o gh.tar.gz ${GH_LOCATION} && \
     tar xzf gh.tar.gz gh_${GH_VERSION}_linux_amd64/bin/gh && \
     mv gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.22
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17
 ENV GOFLAGS=-mod=mod
 
 ARG KUSTOMIZE_VERSION="v5.4.1" \
@@ -55,4 +55,4 @@ RUN dnf -y install openssh-clients jq skopeo python3-pyyaml && \
     dnf -y autoremove && \
     rm -rf /var/cach/dnf
 
-COPY LICENSE /licenses/.
+#COPY LICENSE /licenses/.

--- a/config/Dockerfile.konflux
+++ b/config/Dockerfile.konflux
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE="registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17"
+ARG BASE_IMAGE="brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22"
 FROM ${BASE_IMAGE} AS builder
 
 ARG GOCILINT_VERSION="1.59.1"
@@ -51,8 +51,7 @@ RUN for bit in r x w; do find $(go env GOPATH) -perm -u+${bit} -a ! -perm -g+${b
 COPY --from=builder /usr/local/bin/golangci-lint /usr/local/bin
 COPY --from=builder /usr/local/bin/gh /usr/local/bin
 
-RUN dnf update && \
-    dnf -y install openssh-clients jq skopeo python3-pyyaml && \
+RUN dnf -y install openssh-clients jq skopeo python3-pyyaml && \
     dnf clean all && \
     dnf -y autoremove && \
     rm -rf /var/cach/dnf

--- a/config/Dockerfile.konflux
+++ b/config/Dockerfile.konflux
@@ -11,7 +11,7 @@ RUN curl -L -o golangci-lint.tar.gz ${GOCILINT_LOCATION} && \
 
 
 ARG GH_VERSION="2.58.0"
-ARG GH_SHA256SUM="84feae3d143bc360ea1004b474f124c8cfd75363a5e197d3ce63fe23d9f3a2ea "
+ARG GH_SHA256SUM="84feae3d143bc360ea1004b474f124c8cfd75363a5e197d3ce63fe23d9f3a2ea"
 ARG GH_LOCATION=https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz
 
 RUN curl -L -o gh.tar.gz ${GH_LOCATION} && \

--- a/config/Dockerfile.konflux
+++ b/config/Dockerfile.konflux
@@ -1,4 +1,5 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.22 AS builder
+ARG BASE_IMAGE="registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17"
+FROM ${BASE_IMAGE} AS builder
 
 ARG GOCILINT_VERSION="1.59.1"
 ARG GOCILINT_SHA256SUM="c30696f1292cff8778a495400745f0f9c0406a3f38d8bb12cef48d599f6c7791"
@@ -19,7 +20,7 @@ RUN curl -L -o gh.tar.gz ${GH_LOCATION} && \
     tar xzf gh.tar.gz gh_${GH_VERSION}_linux_amd64/bin/gh && \
     mv gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin
 
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17
+FROM ${BASE_IMAGE}
 ENV GOFLAGS=-mod=mod
 
 ARG KUSTOMIZE_VERSION="v5.4.1" \

--- a/config/Dockerfile.konflux
+++ b/config/Dockerfile.konflux
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 AS builder
 
 ARG GOCILINT_VERSION="1.59.1"
 ARG GOCILINT_SHA256SUM="c30696f1292cff8778a495400745f0f9c0406a3f38d8bb12cef48d599f6c7791"
@@ -19,7 +19,7 @@ RUN curl -L -o gh.tar.gz ${GH_LOCATION} && \
     tar xzf gh.tar.gz gh_${GH_VERSION}_linux_amd64/bin/gh && \
     mv gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin
 
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22
 ENV GOFLAGS=-mod=mod
 
 ARG KUSTOMIZE_VERSION="v5.4.1" \

--- a/config/app-sre-build-push.sh
+++ b/config/app-sre-build-push.sh
@@ -69,7 +69,6 @@ fi
 
 # E.g. quay.io/app-sre/boilerplate:image-v1.0.0
 IMAGE="quay.io/app-sre/boilerplate:${latest_tag}"
-BASE_IMAGE="registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17"
 HERE=$(realpath ${0%/*})
 
 # Copy the node container auth file so that we get access to the registries the
@@ -89,7 +88,7 @@ fi
 
 echo "Image: ${IMAGE} does not exist. Starting image build/push"
 git checkout ${latest_tag}
-podman build "${HERE}" -f "${HERE}/Dockerfile" --build-arg BASE_IMAGE="${BASE_IMAGE}" -t "${IMAGE}"
+podman build "${HERE}" -f "${HERE}/Dockerfile" -t "${IMAGE}"
 podman push "${IMAGE}"
 
 exit 0

--- a/config/app-sre-build-push.sh
+++ b/config/app-sre-build-push.sh
@@ -69,7 +69,7 @@ fi
 
 # E.g. quay.io/app-sre/boilerplate:image-v1.0.0
 IMAGE="quay.io/app-sre/boilerplate:${latest_tag}"
-BASE_IMAGE="registry.ci.openshift.org/ocp/builder:rhel-8-release-golang-1.22-openshift-4.17"
+BASE_IMAGE="registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17"
 HERE=$(realpath ${0%/*})
 
 # Copy the node container auth file so that we get access to the registries the

--- a/config/app-sre-build-push.sh
+++ b/config/app-sre-build-push.sh
@@ -69,7 +69,7 @@ fi
 
 # E.g. quay.io/app-sre/boilerplate:image-v1.0.0
 IMAGE="quay.io/app-sre/boilerplate:${latest_tag}"
-BASE_IMAGE="registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17"
+BASE_IMAGE="registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.22-openshift-4.17"
 HERE=$(realpath ${0%/*})
 
 # Copy the node container auth file so that we get access to the registries the


### PR DESCRIPTION
The image path at registry.ci.openshift.org/ocp/builder is causing issues. Updating this to registry.ci.openshift.org/openshift/release to try to remedy this.

Initially the build was also updated to change images from rhel-8 to rhel-9, but this introduced more issues in testing. I've removed that part of this PR and will continue troubleshooting. The rhel-8 to rhel-9 upgrade will come in a later PR.