### PR TITLE
KONFLUX-3729: install yq from konflux build

### DIFF
--- a/config/Dockerfile.konflux
+++ b/config/Dockerfile.konflux
@@ -1,3 +1,4 @@
+FROM quay.io/konflux-ci/yq:latest as yq
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22 AS builder
 
 ARG GOCILINT_VERSION="1.59.1"
@@ -27,16 +28,14 @@ ARG KUSTOMIZE_VERSION="v5.4.1" \
     OPENAPI_GEN_VERSION="v0.29.1" \
     ENVTEST_VERSION="release-0.18" \
     GOVULNCHECK_VERSION="v1.1.3" \
-    MOCKGEN_VERSION="v0.4.0" \
-    YQ_VERSION="v4.44.2"
+    MOCKGEN_VERSION="v0.4.0"
 
 RUN go install sigs.k8s.io/kustomize/kustomize/v5@${KUSTOMIZE_VERSION} && \
     go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION} && \
     go install k8s.io/code-generator/cmd/openapi-gen@${OPENAPI_GEN_VERSION} && \
     go install sigs.k8s.io/controller-runtime/tools/setup-envtest@${ENVTEST_VERSION} && \
     go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION} && \
-    go install go.uber.org/mock/mockgen@${MOCKGEN_VERSION} && \
-    go install github.com/mikefarah/yq/v4@${YQ_VERSION}
+    go install go.uber.org/mock/mockgen@${MOCKGEN_VERSION}
 
 # HACK: `go install` creates lots of things under GOPATH that are not group
 # accessible, even if umask is set properly. This causes failures of
@@ -49,6 +48,7 @@ RUN for bit in r x w; do find $(go env GOPATH) -perm -u+${bit} -a ! -perm -g+${b
 
 COPY --from=builder /usr/local/bin/golangci-lint /usr/local/bin
 COPY --from=builder /usr/local/bin/gh /usr/local/bin
+COPY --from=yq /usr/bin/yq /usr/bin/yq
 
 RUN dnf -y install openssh-clients jq skopeo python3-pyyaml && \
     dnf clean all && \


### PR DESCRIPTION
We are running into a `syft` bug/configuration issue that causes a github action file from yq to be flagged during scanning, blocking the release. This is due to building from source which clones and caches the repository in gomod cache. Instead, we can install from a konflux build of yq which is just a patch version ahead (v4.44.3)