### PR TITLE
fix: quotes preventing expansion

### DIFF
--- a/boilerplate/update
+++ b/boilerplate/update
@@ -110,7 +110,7 @@ EOF
   BP_CLONE="$(mktemp -d)"
 
   if [[ -z "${BOILERPLATE_IN_CI}" ]]; then
-    "${BOILERPLATE_GIT_CLONE}" "${BOILERPLATE_GIT_REPO}" "${BP_CLONE}"
+    ${BOILERPLATE_GIT_CLONE} "${BOILERPLATE_GIT_REPO}" "${BP_CLONE}"
   else
     # HACK: We can't get around safe.directory in CI, so just leverage cp instead of git
     cp -rf /go/src/github.com/openshift/boilerplate/* "${BP_CLONE}"


### PR DESCRIPTION
```
...
++ mktemp -d
+ BP_CLONE=/tmp/tmp.1P95PaSBNN
+ [[ -z '' ]]
+ git clone -b konflux-swapover git@github.com:jbpratt/boilerplate.git /tmp/tmp.1P95PaSBNN
Cloning into '/tmp/tmp.1P95PaSBNN'...
remote: Enumerating objects: 4473, done.
remote: Counting objects: 100% (792/792), done.
...
```