### PR TITLE
golang-osd-operator-osde2e: mv e2e tests

### DIFF
--- a/boilerplate/openshift/golang-osd-operator-osde2e/e2e-harness-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/e2e-harness-generate.sh
@@ -15,7 +15,7 @@ EOF
 OPERATOR_NAME=$1
 OSDE2E_CONVENTION_DIR=$2
 REPO_ROOT=$(git rev-parse --show-toplevel)
-HARNESS_DIR=$REPO_ROOT/osde2e
+HARNESS_DIR=$REPO_ROOT/test/osde2e
 
 # Update operator name in templates
 export OPERATOR_UNDERSCORE_NAME=$(echo "$OPERATOR_NAME"| sed 's/-/_/g')

--- a/boilerplate/openshift/golang-osd-operator-osde2e/update
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/update
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+source ${CONVENTION_ROOT}/_lib/common.sh
+
+# No PRE
+[[ "$1" == "PRE" ]] && exit 0
+
+# Expect POST
+[[ "$1" == "POST" ]] || err "Got a parameter I don't understand: '$1'. Did the infrastructure change?"
+
+[[ ! -d osde2e ]] && exit 0
+[[ -d test/osde2e ]] && exit 0
+
+mkdir -p test/osde2e/
+mv osde2e/* test/osde2e/
+rm -rf osde2e/


### PR DESCRIPTION
on update, move the tests to tests/e2e

if the osde2e directory does not exist, exit
if the test/osde2e directory already exists, exit
otherwise move the files around.

Once everyone is updated, we can drop this code

also update the generation to point to this new location by default in case there are any left to generate.

after running from osd-example-operator:

```
	renamed:    osde2e/Dockerfile -> test/osde2e/Dockerfile
	renamed:    osde2e/osd_example_operator_runner_test.go -> test/osde2e/osd_example_operator_runner_test.go
	renamed:    osde2e/osd_example_operator_tests.go -> test/osde2e/osd_example_operator_tests.go
	renamed:    osde2e/test-harness-template.yml -> test/osde2e/test-harness-template.yml
```