### PR TITLE
KONFLUX-3729: swap to new base image on update

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -32,6 +32,8 @@ if [[ -f ${REPO_ROOT}/.gitignore ]]; then
   ${SED?} -i "/Dockerfile.olm-registry/d" ${REPO_ROOT}/.gitignore
 fi
 
+IMAGE_PULL_PATH="quay.io/redhat-services-prod/openshift/boilerplate:${LATEST_IMAGE_TAG}"
+
 # Update Dockerfile builder image
 DOCKERFILES=$(ls -1 $REPO_ROOT/build/Dockerfile*)
 for file in $DOCKERFILES; do


### PR DESCRIPTION
operators should now start pointing to the konflux built base image, it is public and can be pulled from Jenkins without issue; this swap will be required when an operator begins onboarding onto konflux

```
❯ git reset --hard && git clean -d -f && BOILERPLATE_GIT_REPO=git@github.com:jbpratt/boilerplate.git BOILERPLATE_GIT_CLONE="git clone -b konflux-swapover-2" make boilerplate-update
HEAD is now at c1c56e3 Merge pull request #397 from jbpratt/bump-boilerplate-x
...
executing /var/home/bpratt/git/openshift/osd-example-operator/boilerplate/openshift/golang-osd-operator/update PRE
executing /var/home/bpratt/git/openshift/osd-example-operator/boilerplate/openshift/golang-osd-operator/update POST
Copying .codecov.yml to your repository root.
Copying OWNERS_ALIASES to your repository root.
Copying dependabot.yml to .github/dependabot.yml
Copying Dockerfile.olm-registry to build/Dockerfile.olm-registry
Overwriting /var/home/bpratt/git/openshift/osd-example-operator/build/Dockerfile's initial FROM with quay.io/redhat-services-prod/boilerplate/image:image-v5.0.3
...
❯ git diff build/Dockerfile
diff --git a/build/Dockerfile b/build/Dockerfile
index fcc09cc..cc91529 100644
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/boilerplate:image-v5.0.3 AS builder
+FROM quay.io/redhat-services-prod/boilerplate/image:image-v5.0.3 AS builder

 WORKDIR /workspace
 # Copy the Go Modules manifests
...
```