### PR TITLE
fix: add GOPATH to PATH

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -55,3 +55,4 @@ RUN dnf -y install openssh-clients jq skopeo python3-pyyaml && \
     rm -rf /var/cach/dnf
 
 COPY LICENSE /licenses/.
+ENV PATH $PATH:/go/bin


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/CFJD1NZFT/p1731341694284609?thread_ts=1731337912.626849&cid=CFJD1NZFT

path now matches the previous image

```
❯ podman run -it --rm quay.io/app-sre/boilerplate:image-v5.0.1 sh
sh-4.4# echo $PATH
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/go/bin

❯ podman run -it --rm 5ee1eb8423ad sh
sh-4.4# echo $PATH
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/go/bin
```