### PR TITLE
fix: add .tekton to includePaths

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,8 @@
   ],
   "tekton": {
     "includePaths": [
-      "pipelines/**"
+      "pipelines/**",
+      ".tekton/**"
     ]
   },
   "dependencyDashboard": true,


### PR DESCRIPTION
this seems to be overidden from the extended renovate config and only working on the pipelines/ directory