### PR TITLE
write out additional-labels.txt

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -32,6 +32,23 @@ if [[ -f ${REPO_ROOT}/.gitignore ]]; then
   ${SED?} -i "/Dockerfile.olm-registry/d" ${REPO_ROOT}/.gitignore
 fi
 
+OPERATOR_NAME=$(sed -n 's/.*OperatorName .*"\([^"]*\)".*/\1/p' "${REPO_ROOT}/config/config.go")
+
+if [[ ! -f ${REPO_ROOT}/config/metadata/additional-labels.txt ]]; then
+  mkdir -p ${REPO_ROOT}/config/metadata
+  cat >${REPO_ROOT}/config/metadata/additional-labels.txt <<EOF
+LABEL com.redhat.component="openshift-${OPERATOR_NAME}" \
+      io.k8s.description="..." \
+      description="..." \
+      distribution-scope="public" \
+      name="openshift/${OPERATOR_NAME}" \
+      url="https://github.com/openshift/${OPERATOR_NAME}" \
+      vendor="Red Hat, Inc." \
+      release="v0.0.0" \
+      version="v0.0.0"
+EOF
+fi
+
 IMAGE_PULL_PATH="quay.io/redhat-services-prod/openshift/boilerplate:${LATEST_IMAGE_TAG}"
 
 # Update Dockerfile builder image

--- a/pipelines/bundle-builder/pipeline.yaml
+++ b/pipelines/bundle-builder/pipeline.yaml
@@ -108,7 +108,7 @@ spec:
     description: Names of service accounts, outside of the operator's Deployment account, that have bindings to {Cluster}Roles that should be added to the CSV
     name: extra-service-accounts
     type: string
-  - default: ""
+  - default: "config/metadata/additional-labels.txt"
     description: A file containing additonal Dockerfile labels to append to the bundle Dockerfile
     name: additional-labels-file
     type: string

--- a/pipelines/bundle-builder/pipeline.yaml
+++ b/pipelines/bundle-builder/pipeline.yaml
@@ -177,7 +177,7 @@ spec:
     - name: package-name
       value: $(params.package-name)
     - name: version
-      value: $(params.major-version).$(params.minor-version).$(tasks.clone-repository.results.commit-timestamp)-$(tasks.clone-repository.results.short-commit)
+      value: $(params.major-version).$(params.minor-version).$(tasks.clone-repository.results.commit-timestamp)+g$(tasks.clone-repository.results.short-commit)
     - name: kustomize-dir
       value: $(params.kustomize-dir)
     - name: extra-service-accounts

--- a/pipelines/bundle-builder/pipeline.yaml
+++ b/pipelines/bundle-builder/pipeline.yaml
@@ -84,11 +84,11 @@ spec:
     description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
     name: build-args-file
     type: string
-  - default: "4"
+  - default: "0"
     description: Major version of the operator
     name: major-version
     type: string
-  - default: "16"
+  - default: "2"
     description: Minor version of the operator
     name: minor-version
     type: string


### PR DESCRIPTION
this is required by Konflux to pass validation. The labels get appended to the OLM bundle dockerfile. Teams will need to update the description field