### PR TITLE
pipelines/catalog-builder: add deprecated-base-image-check task

### DIFF
--- a/pipelines/catalog-builder/pipeline.yaml
+++ b/pipelines/catalog-builder/pipeline.yaml
@@ -292,6 +292,28 @@ spec:
     workspaces:
     - name: source
       workspace: workspace
+  - name: deprecated-base-image-check
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-container.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-container.results.IMAGE_DIGEST)
+    runAfter:
+    - build-container
+    taskRef:
+      params:
+      - name: name
+        value: deprecated-image-check
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:5a1a165fa02270f0a947d8a2131ee9d8be0b8e9d34123828c2bef589e504ee84
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
   - name: fbc-validate
     params:
     - name: IMAGE_URL


### PR DESCRIPTION
this is required by the EC checks

```
✕ [Violation] tasks.required_tasks_found
  ImageRef: quay.io/redhat-user-workloads/oeo-cicada-tenant/osd-example-operator-main/osd-example-operator-main/catalog@sha256:70cbca46b46d21b4aecfb39a92cc80287ac776255c8f3b21f4ea9bd226b99a7f
  Reason: Required task "deprecated-image-check" is missing
  Title: All required tasks were included in the pipeline
  Description: Ensure that the set of required tasks are included in the PipelineRun attestation. To exclude this rule add
  "tasks.required_tasks_found:deprecated-image-check" to the `exclude` section of the policy configuration.
  Solution: Make sure all required tasks are in the build pipeline. The required task list is contained as
  xref:ec-cli:ROOT:configuration.adoc#_data_sources[data] under the key 'required-tasks'.
```