### PR TITLE
OSD-26236 leaver process member removal

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
+++ b/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
@@ -74,7 +74,6 @@ aliases:
     - Nikokolas3270
     - theautoroboto
     - bmeng
-    - mjlshen
     - sam-nguyen7
     - ravitri
     - mmazur


### PR DESCRIPTION
Removing michael shen from OWNER_ALIAS FILE as part of the leaver process