### PR TITLE
Cleanup srep-functional-team-aurora alias

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
+++ b/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
@@ -6,7 +6,7 @@ aliases:
   srep-functional-team-aurora:
     - abyrne55
     - dakotalongRH
-    - lnguyen1401
+    - joshbranham
     - luis-falcon
     - reedcort
   srep-functional-team-fedramp:


### PR DESCRIPTION
Reflect team changes for the `srep-functional-team-aurora` `OWNERS_ALIASES` entry.