### PR TITLE
Exit early if skopeo binary not found

### DIFF
--- a/boilerplate/_lib/common.sh
+++ b/boilerplate/_lib/common.sh
@@ -89,6 +89,11 @@ image_exists_in_repo() {
 
     local skopeo_stderr=$(mktemp)
 
+    if ! command -v skopeo &>/dev/null; then
+      echo "Failed to find the skopeo binary. If you are on Mac: brew install skopeo." >&2
+      exit 1
+    fi
+
     output=$(skopeo inspect docker://${image_uri} 2>$skopeo_stderr)
     rc=$?
     # So we can delete the temp file right away...


### PR DESCRIPTION
Recently a user was trying to update boilerplate for a repo and getting unexpected output. It turned out that they did not have `skopeo` installed (neither did I), and had to install it first. This makes that case a bit more obvious by printing a message.