### PR TITLE
[OSD-26766] removes leading g before comparing short_hash to DEPLOYED_HASH

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
+++ b/boilerplate/openshift/golang-osd-operator/csv-generate/csv-generate.sh
@@ -169,7 +169,11 @@ if [[ -z "$SKIP_SAAS_FILE_CHECKS" ]]; then
 
             if [[ "$delete" == false ]]; then
                 short_hash=$(echo "$version" | cut -d- -f2)
-
+                
+                # before comparing the short_hash to the deployment hash, remove the leading g added in https://issues.redhat.com/browse/OSD-13681
+                # short_hash should be 7 char long without the leading g. 
+                [ ${#short_hash} -gt 7 ] && short_hash=${short_hash:1:7}
+                
                 if [[ "$DEPLOYED_HASH" == "${short_hash}"* ]]; then
                     delete=true
                 fi


### PR DESCRIPTION
Since https://github.com/openshift/boilerplate/pull/373, we added a leading `g` character in the short_hash of our operators' bundle name.
Unfortunately, this short hash is used to cleanup non-promoted commits on the production channel.
As a result, any operator promotion will be achieved by incrementing through every commit. This means that a bad commit will require a OLM dance to unblock the upgrade.


This PR removes the leading character (g) when the length of short_hash is greater than 7. 
from boilerplate/openshift/golang-osd-operator/standard.mk, short_hash are currently 8 character long (g + 7 first chars of the commit hash)