### PR TITLE
Fix IMAGE_PULL_PATH

### DIFF
--- a/boilerplate/_lib/common.sh
+++ b/boilerplate/_lib/common.sh
@@ -183,6 +183,8 @@ if [ -z "$BOILERPLATE_GIT_REPO" ]; then
   export BOILERPLATE_GIT_REPO=https://github.com/openshift/boilerplate.git
 fi
 
+# Base image repo url
+IMAGE_REPO=quay.io/redhat-services-prod/openshift
 # The namespace of the ImageStream by which prow will import the image.
 IMAGE_NAMESPACE=openshift
 IMAGE_NAME=boilerplate
@@ -199,4 +201,4 @@ if [[ -z "$LATEST_IMAGE_TAG" ]]; then
     fi
 fi
 # The public image location
-IMAGE_PULL_PATH=${IMAGE_PULL_PATH:-quay.io/app-sre/$IMAGE_NAME:$LATEST_IMAGE_TAG}
+IMAGE_PULL_PATH=${IMAGE_PULL_PATH:-$IMAGE_REPO/$IMAGE_NAME:$LATEST_IMAGE_TAG}


### PR DESCRIPTION
The path to boilerplate backing image has changed from the app-sre repo to redhat-services-prod. This updates the default value so commands like container-generate, etc. will work properly. 

```
$ make container-generate
boilerplate/openshift/golang-osd-operator/standard.mk:114: Setting GOEXPERIMENT=strictfipsruntime,boringcrypto - this generally causes builds to fail unless building inside the provided Dockerfile. If building locally consider calling 'go build .'
go: unknown GOEXPERIMENT strictfipsruntime
boilerplate/_lib/container-make generate

==============================
Starting the container
==============================
Trying to pull quay.io/app-sre/boilerplate:image-v6.0.1...
Error: initializing source docker://quay.io/app-sre/boilerplate:image-v6.0.1: reading manifest image-v6.0.1 in quay.io/app-sre/boilerplate: manifest unknown
==ERROR== Couldn't start detached container
make: *** [container-generate] Error 1
```