### PR TITLE
pipelines/catalog-builder: fix runAfter

### DIFF
--- a/pipelines/catalog-builder/pipeline.yaml
+++ b/pipelines/catalog-builder/pipeline.yaml
@@ -296,7 +296,7 @@ spec:
     - name: IMAGE_DIGEST
       value: $(tasks.build-container.results.IMAGE_DIGEST)
     runAfter:
-    - build-image-index
+    - build-container
     taskRef:
       params:
       - name: name


### PR DESCRIPTION
```
invalid value: couldn't add link between validate-fbc and
build-image-index: task validate-fbc depends on build-image-index but
build-image-index wasn't present in Pipeline: spec.tasks
```