### PR TITLE
pipeline/catalog-builder: add missing bundle param

### DIFF
--- a/pipelines/catalog-builder/pipeline.yaml
+++ b/pipelines/catalog-builder/pipeline.yaml
@@ -301,6 +301,8 @@ spec:
       params:
       - name: name
         value: validate-fbc
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.1@sha256:f370a6cb7b854d81cf779f8afc00e053df3a7619af9cf45c54e31ced1a4c5034
       - name: kind
         value: task
       resolver: bundles


### PR DESCRIPTION
this was missing in the migration diff, forgot to add it

```
 Pipeline camo-hcm-tenant/ can't be Run; it contains Tasks that don't exist: Couldn't retrieve Task "resolver type bundles\nname = validate-fbc\n": error requesting remote resource: invalid resource request "camo-hcm-tenant/bundles-e5d1abeeef1ab876b4264b7d8ee2bfe7": parameter "bundle" required 
```