### PR TITLE
.tekton/image*: remove JAVA_COMMUNITY_DEPENDENCIES

### DIFF
--- a/.tekton/image-pull-request.yaml
+++ b/.tekton/image-pull-request.yaml
@@ -147,9 +147,6 @@ spec:
     - description: ""
       name: CHAINS-GIT_COMMIT
       value: $(tasks.clone-repository.results.commit)
-    - description: ""
-      name: JAVA_COMMUNITY_DEPENDENCIES
-      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
     - name: init
       params:

--- a/.tekton/image-push.yaml
+++ b/.tekton/image-push.yaml
@@ -144,9 +144,6 @@ spec:
     - description: ""
       name: CHAINS-GIT_COMMIT
       value: $(tasks.clone-repository.results.commit)
-    - description: ""
-      name: JAVA_COMMUNITY_DEPENDENCIES
-      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
     tasks:
     - name: init
       params:


### PR DESCRIPTION
this is a deprecated and unused parameter that is causing new builds to fail