### PR TITLE
Add the home dir permission fix to osd-container-image as well

### DIFF
--- a/boilerplate/openshift/osd-container-image/standard.mk
+++ b/boilerplate/openshift/osd-container-image/standard.mk
@@ -11,6 +11,14 @@ ifndef IMAGE_NAME
 $(error IMAGE_NAME is not set)
 endif
 
+# In openshift ci (Prow), we need to set $HOME to a writable directory else tests will fail
+# because they don't have permissions to create /.local or /.cache directories
+# as $HOME is set to "/" by default.
+ifeq ($(HOME),/)
+export HOME=/tmp/home
+endif
+PWD=$(shell pwd)
+
 ### Accommodate docker or podman
 #
 # The docker/podman creds cache needs to be in a location unique to this


### PR DESCRIPTION
We need the same permission fix for the build cache as we did for golang-osd-operators.

https://github.com/openshift/boilerplate/blob/43c872a4c4e888fb2a7c304a1808be731132b3a9/boilerplate/openshift/golang-osd-operator/standard.mk#L100