### PR TITLE
OSD-28159 - Enable OLM Skip Range

### DIFF
--- a/test/projects/file-generate/config/config.go
+++ b/test/projects/file-generate/config/config.go
@@ -15,6 +15,7 @@
 package config
 
 const (
-	OperatorName      string = "file-generate"
-	OperatorNamespace string = "file-generate"
+	OperatorName       string = "file-generate"
+	OperatorNamespace  string = "file-generate"
+	EnableOLMSkipRange        = "true"
 )


### PR DESCRIPTION
Configure boilerplate to generate an OLM bundle with a skip range pointing to the latest version. This will allow OLM to upgrade past broken replaces chains in which versions get abadoned without a path forward. The new OLM bundle will contain a single version, referencing the latest build with a skipRange to the version. Part of [OSD-28159](https://issues.redhat.com//browse/OSD-28159) ticket.