### PR TITLE
SDCICD-1414 update template prow-config to match new test/e2e directory path

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/prow-config
+++ b/boilerplate/openshift/golang-osd-operator/prow-config
@@ -69,7 +69,7 @@ tests:
     make e2e-harness-build
   container:
     from: src
-  run_if_changed: ^(osde2e/.*|go\.mod|go\.sum)$
+  run_if_changed: ^(test/e2e/\.*|go\.mod|go\.sum)$
 - as: coverage
   commands: |
     export CODECOV_TOKEN=\$(cat /tmp/secret/CODECOV_TOKEN)


### PR DESCRIPTION
This directory has been moved in https://issues.redhat.com/browse/SDCICD-1414

Template for prow pr check job should be updated for new operator scaffolding

Left out this one change in the first boilerplate update for this. 