### PR TITLE
.tekton: increase memory for preflight

### DIFF
--- a/.tekton/image-pull-request.yaml
+++ b/.tekton/image-pull-request.yaml
@@ -40,6 +40,10 @@ spec:
       computeResources:
         limits:
           memory: 4Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        limits:
+          memory: 4Gi
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/image-push.yaml
+++ b/.tekton/image-push.yaml
@@ -37,6 +37,10 @@ spec:
       computeResources:
         limits:
           memory: 4Gi
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      computeResources:
+        limits:
+          memory: 4Gi
   pipelineSpec:
     finally:
     - name: show-sbom


### PR DESCRIPTION
the team recommended increasing it as it seemed to have insufficient resources, causing log output to be missing

https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1742201155433009