### PR TITLE
Fixes dependabot config for new image pull path

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/dependabot.yml
+++ b/boilerplate/openshift/golang-osd-operator/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      - dependency-name: "app-sre/boilerplate"
+      - dependency-name: "redhat-services-prod/openshift/boilerplate"
         # don't upgrade boilerplate via these means
       - dependency-name: "openshift4/ose-operator-registry"
         # don't upgrade ose-operator-registry via these means


### PR DESCRIPTION
We do not want to use dependabot for boilerplate updates IIUC. 
When we switched to image pull path here https://github.com/openshift/boilerplate/pull/475, we did not update the dependabot.yml accordingly.
