### PR TITLE
Add the home dir permission fix to golang-osd-operator

### DIFF
--- a/boilerplate/openshift/golang-osd-operator-osde2e/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/standard.mk
@@ -9,6 +9,14 @@ ifndef HARNESS_IMAGE_REPOSITORY
 $(error HARNESS_IMAGE_REPOSITORY is not set; check project.mk file)
 endif
 
+# In openshift ci (Prow), we need to set $HOME to a writable directory else tests will fail
+# because they don't have permissions to create /.local or /.cache directories
+# as $HOME is set to "/" by default.
+ifeq ($(HOME),/)
+export HOME=/tmp/home
+endif
+PWD=$(shell pwd)
+
 # Use current commit as harness image tag
 CURRENT_COMMIT=$(shell git rev-parse --short=7 HEAD)
 HARNESS_IMAGE_TAG=$(CURRENT_COMMIT)

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -15,6 +15,14 @@ ifndef VERSION_MINOR
 $(error VERSION_MINOR is not set; check project.mk file)
 endif
 
+# In openshift ci (Prow), we need to set $HOME to a writable directory else tests will fail
+# because they don't have permissions to create /.local or /.cache directories
+# as $HOME is set to "/" by default.
+ifeq ($(HOME),/)
+export HOME=/tmp/home
+endif
+PWD=$(shell pwd)
+
 ### Accommodate docker or podman
 #
 # The docker/podman creds cache needs to be in a location unique to this


### PR DESCRIPTION
Issue with MUO build:
_failed to initialize build cache at /.cache/go-build: mkdir /.cache: permission denied_

This was fixed earlier #491 
However, MUO uses golang-osd-operator.
