### PR TITLE
OSD-29374: Drop unsupported `strictfipsruntime` GOEXPERIMENT for Go 1.23

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -125,6 +125,12 @@ GOLANGCI_OPTIONAL_CONFIG ?=
 ifeq ($(origin TESTTARGETS), undefined)
 TESTTARGETS := $(shell ${GOENV} go list -e ./... | grep -E -v "/(vendor)/" | grep -E -v "/(test/e2e)/")
 endif
+
+# If for any reason we've made it this far and TESTTARGETS is still empty, fail early.
+ifeq ($(TESTTARGETS),)
+$(error TESTTARGETS is empty)
+endif
+
 # ex, -v
 TESTOPTS :=
 

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -111,8 +111,8 @@ GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPAT
 ifeq (${FIPS_ENABLED}, true)
 GOFLAGS_MOD+=-tags=fips_enabled
 GOFLAGS_MOD:=$(strip ${GOFLAGS_MOD})
-$(warning Setting GOEXPERIMENT=strictfipsruntime,boringcrypto - this generally causes builds to fail unless building inside the provided Dockerfile. If building locally consider calling 'go build .')
-GOENV+=GOEXPERIMENT=strictfipsruntime,boringcrypto
+$(warning Setting GOEXPERIMENT=boringcrypto - this generally causes builds to fail unless building inside the provided Dockerfile. If building locally consider calling 'go build .')
+GOENV+=GOEXPERIMENT=boringcrypto
 GOENV:=$(strip ${GOENV})
 endif
 


### PR DESCRIPTION
We noticed that it was not possible to run tests for 1.23 repos now, and after some digging, found that `TESTTARGETS` was failing to be set. This was a result of `GOEXPERIMENT` having `strictfipsruntime` set, which appears to no longer be supported.

We are, however, relying on `boringcrypto` for FIPS which is also not really "supported". This fixes `make test` by removing this flag. See the below references for more details.

- https://devblogs.microsoft.com/go/go-1-24-fips-update/
- https://github.com/golang/go/blob/release-branch.go1.23/src/crypto/internal/boring/README.md

I have made this change manually for `aws-account-operator` locally and it runs successfully now.

```
> make test
cp: /var/lib/jenkins/.docker/config.json: No such file or directory
boilerplate/openshift/golang-osd-operator/standard.mk:114: Setting GOEXPERIMENT=boringcrypto - this generally causes builds to fail unless building inside the provided Dockerfile. If building locally consider calling 'go build .'
KUBEBUILDER_ASSETS="/tmp/envtest/bin/k8s/1.23.5-darwin-arm64" go test  github.com/openshift/aws-account-operator github.com/openshift/aws-account-operator/config github.com/openshift/aws-account-operator/controllers/account github.com/openshift/aws-account-operator/controllers/accountclaim github.com/openshift/aws-account-operator/controllers/accountclaim/mock github.com/openshift/aws-account-operator/controllers/accountpool github.com/openshift/aws-account-operator/controllers/awsfederatedaccountaccess github.com/openshift/aws-account-operator/controllers/awsfederatedrole github.com/openshift/aws-account-operator/controllers/validation github.com/openshift/aws-account-operator/pkg/awsclient github.com/openshift/aws-account-operator/pkg/awsclient/mock github.com/openshift/aws-account-operator/pkg/awsclient/sts github.com/openshift/aws-account-operator/pkg/localmetrics github.com/openshift/aws-account-operator/pkg/testutils github.com/openshift/aws-account-operator/pkg/totalaccountwatcher github.com/openshift/aws-account-operator/pkg/utils github.com/openshift/aws-account-operator/test/fixtures github.com/openshift/aws-account-operator/test/integration github.com/openshift/aws-account-operator/version
?       github.com/openshift/aws-account-operator       [no test files]
ok      github.com/openshift/aws-account-operator/config        (cached)
ok      github.com/openshift/aws-account-operator/controllers/account   (cached)
?       github.com/openshift/aws-account-operator/controllers/accountclaim/mock [no test files]
ok      github.com/openshift/aws-account-operator/controllers/accountclaim      (cached)
ok      github.com/openshift/aws-account-operator/controllers/accountpool       (cached)
ok      github.com/openshift/aws-account-operator/controllers/awsfederatedaccountaccess (cached)
ok      github.com/openshift/aws-account-operator/controllers/awsfederatedrole  (cached)
ok      github.com/openshift/aws-account-operator/controllers/validation        (cached)
?       github.com/openshift/aws-account-operator/pkg/awsclient/mock    [no test files]
?       github.com/openshift/aws-account-operator/pkg/testutils [no test files]
?       github.com/openshift/aws-account-operator/test/fixtures [no test files]
?       github.com/openshift/aws-account-operator/version       [no test files]
ok      github.com/openshift/aws-account-operator/pkg/awsclient (cached)
ok      github.com/openshift/aws-account-operator/pkg/awsclient/sts     (cached)
ok      github.com/openshift/aws-account-operator/pkg/localmetrics      (cached)
ok      github.com/openshift/aws-account-operator/pkg/totalaccountwatcher       (cached)
ok      github.com/openshift/aws-account-operator/pkg/utils     (cached)
ok      github.com/openshift/aws-account-operator/test/integration      (cached)
```