### PR TITLE
OSD-29370: Configure `HOME` for golang-lint and golang-codecov boilerplate conventions

### DIFF
--- a/boilerplate/openshift/golang-codecov/standard.mk
+++ b/boilerplate/openshift/golang-codecov/standard.mk
@@ -9,10 +9,11 @@ GOFLAGS_MOD ?=
 # as $HOME is set to "/" by default.
 ifeq ($(HOME),/)
 export HOME=/tmp/home
+GOENV+=GOCACHE="${HOME}/.cache"
 endif
 PWD=$(shell pwd)
 
-GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS=${GOFLAGS_MOD} GOCACHE="${PWD}/.cache"
+GOENV+=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS=${GOFLAGS_MOD}
 
 CODECOV_CONVENTION_DIR := boilerplate/openshift/golang-codecov
 

--- a/boilerplate/openshift/golang-codecov/standard.mk
+++ b/boilerplate/openshift/golang-codecov/standard.mk
@@ -4,6 +4,14 @@ GOARCH?=$(shell go env GOARCH)
 unexport GOFLAGS
 GOFLAGS_MOD ?=
 
+# In openshift ci (Prow), we need to set $HOME to a writable directory else tests will fail
+# because they don't have permissions to create /.local or /.cache directories
+# as $HOME is set to "/" by default.
+ifeq ($(HOME),/)
+export HOME=/tmp/home
+endif
+PWD=$(shell pwd)
+
 GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS=${GOFLAGS_MOD}
 
 CODECOV_CONVENTION_DIR := boilerplate/openshift/golang-codecov

--- a/boilerplate/openshift/golang-codecov/standard.mk
+++ b/boilerplate/openshift/golang-codecov/standard.mk
@@ -12,7 +12,7 @@ export HOME=/tmp/home
 endif
 PWD=$(shell pwd)
 
-GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS=${GOFLAGS_MOD}
+GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS=${GOFLAGS_MOD} GOCACHE="${PWD}/.cache"
 
 CODECOV_CONVENTION_DIR := boilerplate/openshift/golang-codecov
 

--- a/boilerplate/openshift/golang-lint/standard.mk
+++ b/boilerplate/openshift/golang-lint/standard.mk
@@ -1,6 +1,14 @@
 # Defaults to -mod=vendor in the boilerplate image
 unexport GOFLAGS
 
+# In openshift ci (Prow), we need to set $HOME to a writable directory else tests will fail
+# because they don't have permissions to create /.local or /.cache directories
+# as $HOME is set to "/" by default.
+ifeq ($(HOME),/)
+export HOME=/tmp/home
+endif
+PWD=$(shell pwd)
+
 # GOLANGCI_LINT_CACHE needs to be set to a directory which is writeable
 # Relevant issue - https://github.com/golangci/golangci-lint/issues/734
 GOLANGCI_LINT_CACHE ?= /tmp/golangci-cache

--- a/boilerplate/openshift/golang-lint/standard.mk
+++ b/boilerplate/openshift/golang-lint/standard.mk
@@ -9,6 +9,8 @@ export HOME=/tmp/home
 endif
 PWD=$(shell pwd)
 
+export GOCACHE="${PWD}/.cache"
+
 # GOLANGCI_LINT_CACHE needs to be set to a directory which is writeable
 # Relevant issue - https://github.com/golangci/golangci-lint/issues/734
 GOLANGCI_LINT_CACHE ?= /tmp/golangci-cache

--- a/boilerplate/openshift/golang-lint/standard.mk
+++ b/boilerplate/openshift/golang-lint/standard.mk
@@ -6,10 +6,9 @@ unexport GOFLAGS
 # as $HOME is set to "/" by default.
 ifeq ($(HOME),/)
 export HOME=/tmp/home
+export GOCACHE="${HOME}/.cache"
 endif
 PWD=$(shell pwd)
-
-export GOCACHE="${PWD}/.cache"
 
 # GOLANGCI_LINT_CACHE needs to be set to a directory which is writeable
 # Relevant issue - https://github.com/golangci/golangci-lint/issues/734

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -102,10 +102,11 @@ GOFLAGS_MOD ?=
 # as $HOME is set to "/" by default.
 ifeq ($(HOME),/)
 export HOME=/tmp/home
+GOENV+=GOCACHE="${HOME}/.cache"
 endif
 PWD=$(shell pwd)
 
-GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=1 GOFLAGS="${GOFLAGS_MOD}" GOCACHE="${PWD}/.cache"
+GOENV+=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=1 GOFLAGS="${GOFLAGS_MOD}"
 GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"
 
 ifeq (${FIPS_ENABLED}, true)

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -105,7 +105,7 @@ export HOME=/tmp/home
 endif
 PWD=$(shell pwd)
 
-GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=1 GOFLAGS="${GOFLAGS_MOD}"
+GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=1 GOFLAGS="${GOFLAGS_MOD}" GOCACHE="${PWD}/.cache"
 GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"
 
 ifeq (${FIPS_ENABLED}, true)


### PR DESCRIPTION
In https://github.com/openshift/boilerplate/commit/1e947d2b7daee575dbc0283c647b9945a8081c8f we added the below `HOME` override to ensure there is a place for `.cache` to be created with permissions in prow.

This is needed to allow `osd-network-verifier` to properly adopt boilerplate, and is currently failing running rehearsals due to permissions issues https://github.com/openshift/release/pull/63612. ONV does not use the operator convention, but does use these two which are missing the fix: `golang-lint`, and `golang-codecov`.

This also updates `GOENV` to explicitly use `GOCACHE` that is the `/tmp/home` directory we set as `pwd` earlier.

[Sample Failure](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/63612/rehearse-63612-pull-ci-openshift-osd-network-verifier-main-build/1909721074057089024)