### PR TITLE
Bump golangci-lint to v2

### DIFF
--- a/boilerplate/openshift/golang-lint/ensure.sh
+++ b/boilerplate/openshift/golang-lint/ensure.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh
 
-GOLANGCI_LINT_VERSION="1.59.1"
+GOLANGCI_LINT_VERSION="2.0.2"
 DEPENDENCY=${1:-}
 GOOS=$(go env GOOS)
 
@@ -17,10 +17,8 @@ golangci-lint)
         exit
     else
         mkdir -p "${GOPATH}/bin"
-        echo "${PATH}" | grep -q "${GOPATH}/bin"
-        IN_PATH=$?
-        if [ $IN_PATH != 0 ]; then
-            echo "${GOPATH}/bin not in $$PATH"
+        if ! echo "${PATH}" | grep -q "${GOPATH}/bin"; then
+            echo "${GOPATH}/bin not in $PATH"
             exit 1
         fi
         DOWNLOAD_URL="https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-${GOOS}-amd64.tar.gz"

--- a/boilerplate/openshift/golang-lint/golangci.yml
+++ b/boilerplate/openshift/golang-lint/golangci.yml
@@ -1,33 +1,39 @@
-# options for analysis running
+version: "2"
 run:
-  # default concurrency is a available CPU number
   concurrency: 10
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  # We're using a somewhat resource-constrained container in the CI
-  # environment, so make this longish.
-  timeout: 10m
-
+linters:
+  default: none
+  enable:
+    - errcheck
+    - gosec
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - unused
+  settings:
+    misspell:
+      extra-words:
+        - typo: openshit
+          correction: OpenShift
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party/
+      - builtin/
+      - examples/
 issues:
-  # We want to make sure we get a full report every time. Setting these
-  # to zero disables the limit.
   max-issues-per-linter: 0
   max-same-issues: 0
-
-linters:
-  disable-all: true
-  enable:
-  - errcheck
-  - gosec
-  - gosimple
-  - govet
-  - ineffassign
-  - misspell
-  - staticcheck
-  - typecheck
-  - unused
-
-linters-settings:
-  misspell:
-    extra-words:
-      - typo: "openshit"
-        correction: "OpenShift"
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party/
+      - builtin/
+      - examples/

--- a/boilerplate/openshift/golang-osd-operator/ensure.sh
+++ b/boilerplate/openshift/golang-osd-operator/ensure.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh
 
-GOLANGCI_LINT_VERSION="1.59.1"
+GOLANGCI_LINT_VERSION="2.0.2"
 OPM_VERSION="v1.23.2"
 GRPCURL_VERSION="1.7.0"
 DEPENDENCY=${1:-}
@@ -19,10 +19,8 @@ golangci-lint)
         exit
     else
         mkdir -p "${GOPATH}/bin"
-        echo "${PATH}" | grep -q "${GOPATH}/bin"
-        IN_PATH=$?
-        if [ $IN_PATH != 0 ]; then
-            echo "${GOPATH}/bin not in $$PATH"
+        if ! echo "${PATH}" | grep -q "${GOPATH}/bin"; then
+            echo "${GOPATH}/bin not in $PATH"
             exit 1
         fi
         DOWNLOAD_URL="https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION}-${GOOS}-amd64.tar.gz"

--- a/boilerplate/openshift/golang-osd-operator/golangci.yml
+++ b/boilerplate/openshift/golang-osd-operator/golangci.yml
@@ -1,33 +1,39 @@
-# options for analysis running
+version: "2"
 run:
-  # default concurrency is a available CPU number
   concurrency: 10
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  # We're using a somewhat resource-constrained container in the CI
-  # environment, so make this longish.
-  timeout: 10m
-
+linters:
+  default: none
+  enable:
+    - errcheck
+    - gosec
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - unused
+  settings:
+    misspell:
+      extra-words:
+        - typo: openshit
+          correction: OpenShift
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party/
+      - builtin/
+      - examples/
 issues:
-  # We want to make sure we get a full report every time. Setting these
-  # to zero disables the limit.
   max-issues-per-linter: 0
   max-same-issues: 0
-
-linters:
-  disable-all: true
-  enable:
-  - errcheck
-  - gosec
-  - gosimple
-  - govet
-  - ineffassign
-  - misspell
-  - staticcheck
-  - typecheck
-  - unused
-
-linters-settings:
-  misspell:
-    extra-words:
-      - typo: "openshit"
-        correction: "OpenShift"
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party/
+      - builtin/
+      - examples/

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,8 +1,8 @@
 FROM quay.io/konflux-ci/yq:latest AS yq
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.23 AS builder
 
-ARG GOCILINT_VERSION="1.64.7"
-ARG GOCILINT_SHA256SUM="dada4095eab53f868f931840f04b99cb4be654e45f50d4d3b2832dc9ad3bede8"
+ARG GOCILINT_VERSION="2.0.2"
+ARG GOCILINT_SHA256SUM="89cc8a7810dc63b9a37900da03e37c3601caf46d42265d774e0f1a5d883d53e2"
 ARG GOCILINT_LOCATION=https://github.com/golangci/golangci-lint/releases/download/v${GOCILINT_VERSION}/golangci-lint-${GOCILINT_VERSION}-linux-amd64.tar.gz
 
 RUN curl -L -o golangci-lint.tar.gz ${GOCILINT_LOCATION} && \


### PR DESCRIPTION
This includes updates to move to `golangci-lint` v2. This was migrated and tested as such:

- Change the version in `ensure.sh`
- Run `golangci-lint migrate` manually to migrate the configuration file
- Update the `paths: []` arrays to use `$path/` (in my testing `examples/` was being linted still
- Update `osd-network-verfier` locally to use my local boilerplate
- Run `make lint`, see results below

This, once folks migrate, will require anyone using the `golang-lint` convention to fix any issues picked up, which I think is a fine outcome.

Once this merges, we will need to tag the commit as `image-v7.1.0` and then I can get a new one released via Konflux.

In the future, if we want to modify linters, folks can go ahead and propose that, but for the scope of this PR I left things as they were before.

# Local Validation
```
> export BOILERPLATE_GIT_REPO=~/git/openshift/boilerplate
> make boilerplate-update
....
Processing .gitattributes
Registering commit hash...
Registering image tag...
Done

> git diff | grep 2.0.2
+GOLANGCI_LINT_VERSION="2.0.2"

> make lint
boilerplate/openshift/golang-lint/ensure.sh golangci-lint
...
GOLANGCI_LINT_CACHE=/tmp/golangci-cache golangci-lint run -c boilerplate/openshift/golang-lint/golangci.yml ./...
../../../pkg/verifier/aws/entry_point.go:231:2: QF1007: could merge conditional assignment into variable declaration (staticcheck)
        ensurePrivate := false
        ^
1 issues:
* staticcheck: 1
make: *** [lint] Error 1

# Fix linting issues

> make lint
...
GOLANGCI_LINT_CACHE=/tmp/golangci-cache golangci-lint run -c boilerplate/openshift/golang-lint/golangci.yml ./...
0 issues.
test "" = "" || test ! -e "" || GOLANGCI_LINT_CACHE="/tmp/golangci-cache" golangci-lint run -c "" ./...
```