### PR TITLE
Handle `GOCACHE` better in CI environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This work was inspired by, and partially cribbed from,
     - [Update](#update)
     - [Multiple Updates](#multiple-updates)
   - [Contributing](#contributing)
-    - [Environment setup](#environment-setup)
+    - [Testing Boilerplate Locally](#testing-boilerplate-locally)
     - [Tests](#tests)
     - [Build Images](#build-images)
       - [Making CI Efficient](#making-ci-efficient)
@@ -339,11 +339,10 @@ In your fork of this repository (not a consuming repository):
     - `LATEST_IMAGE_TAG`: The tag for the most recent build image
       produced by boilerplate.
 
-### Environment setup
+### Testing Boilerplate Locally
 To test your changes, you can use the `BOILERPLATE_GIT_REPO` environment
 variable and set it to your local clone in order to override the version of
 boilerplate used (Example: `export BOILERPLATE_GIT_REPO=~/git/boilerplate`).
-
 
 Default `update` behaviour consists of cloning the git repo, so ensure you have
 your changes locally committed for your testing.
@@ -352,6 +351,9 @@ command used for cloning the project. Example of usecases :
 - Add some flags to the git clone command
 - Replace `git clone` by a copy command such as `rsync` or `cp` in order to
 avoid having to regularly commit changes
+
+>**Note** The above process will result in `boilerplate/_data/last-boilerplate-commit` and `boilerplate/_data/backing-image-tag`
+> changing, and you may need to `git reset` them to continue testing.
 
 ### Tests
 Test cases are executed by running `make test`. This must be done on a

--- a/boilerplate/openshift/golang-codecov/standard.mk
+++ b/boilerplate/openshift/golang-codecov/standard.mk
@@ -4,14 +4,13 @@ GOARCH?=$(shell go env GOARCH)
 unexport GOFLAGS
 GOFLAGS_MOD ?=
 
-# In openshift ci (Prow), we need to set $HOME to a writable directory else tests will fail
-# because they don't have permissions to create /.local or /.cache directories
-# as $HOME is set to "/" by default.
-ifeq ($(HOME),/)
-export HOME=/tmp/home
-GOENV+=GOCACHE="${HOME}/.cache"
+# Optionally use alternate GOCACHE location if default is not writeable
+CACHE_WRITEABLE := $(shell test -w "${HOME}/.cache" && echo yes || echo no)
+ifeq ($(CACHE_WRITEABLE),no)
+tmpDir := $(shell mktemp -d)
+GOENV+=GOCACHE=${tmpDir}
+$(info Using custom GOCACHE of ${tmpDir})
 endif
-PWD=$(shell pwd)
 
 GOENV+=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS=${GOFLAGS_MOD}
 

--- a/boilerplate/openshift/golang-lint/standard.mk
+++ b/boilerplate/openshift/golang-lint/standard.mk
@@ -1,14 +1,13 @@
 # Defaults to -mod=vendor in the boilerplate image
 unexport GOFLAGS
 
-# In openshift ci (Prow), we need to set $HOME to a writable directory else tests will fail
-# because they don't have permissions to create /.local or /.cache directories
-# as $HOME is set to "/" by default.
-ifeq ($(HOME),/)
-export HOME=/tmp/home
-export GOCACHE="${HOME}/.cache"
+# Optionally use alternate GOCACHE location if default is not writeable
+CACHE_WRITEABLE := $(shell test -w "${HOME}/.cache" && echo yes || echo no)
+ifeq ($(CACHE_WRITEABLE),no)
+tmpDir := $(shell mktemp -d)
+GOENV+=GOCACHE=${tmpDir}
+$(info Using custom GOCACHE of ${tmpDir})
 endif
-PWD=$(shell pwd)
 
 # GOLANGCI_LINT_CACHE needs to be set to a directory which is writeable
 # Relevant issue - https://github.com/golangci/golangci-lint/issues/734
@@ -21,6 +20,6 @@ LINT_CONVENTION_DIR := boilerplate/openshift/golang-lint
 .PHONY: lint
 lint: 
 	${LINT_CONVENTION_DIR}/ensure.sh golangci-lint
-	GOLANGCI_LINT_CACHE=${GOLANGCI_LINT_CACHE} golangci-lint run -c ${LINT_CONVENTION_DIR}/golangci.yml ./...
-	test "${GOLANGCI_OPTIONAL_CONFIG}" = "" || test ! -e "${GOLANGCI_OPTIONAL_CONFIG}" || GOLANGCI_LINT_CACHE="${GOLANGCI_LINT_CACHE}" golangci-lint run -c "${GOLANGCI_OPTIONAL_CONFIG}" ./...
+	${GOENV} GOLANGCI_LINT_CACHE=${GOLANGCI_LINT_CACHE} golangci-lint run -c ${LINT_CONVENTION_DIR}/golangci.yml ./...
+	test "${GOLANGCI_OPTIONAL_CONFIG}" = "" || test ! -e "${GOLANGCI_OPTIONAL_CONFIG}" || ${GOENV} GOLANGCI_LINT_CACHE="${GOLANGCI_LINT_CACHE}" golangci-lint run -c "${GOLANGCI_OPTIONAL_CONFIG}" ./...
 

--- a/boilerplate/openshift/golang-osd-operator-osde2e/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/standard.mk
@@ -9,6 +9,14 @@ ifndef HARNESS_IMAGE_REPOSITORY
 $(error HARNESS_IMAGE_REPOSITORY is not set; check project.mk file)
 endif
 
+# Optionally use alternate GOCACHE location if default is not writeable
+CACHE_WRITEABLE := $(shell test -w "${HOME}/.cache" && echo yes || echo no)
+ifeq ($(CACHE_WRITEABLE),no)
+tmpDir := $(shell mktemp -d)
+GOENV+=GOCACHE=${tmpDir}
+$(info Using custom GOCACHE of ${tmpDir})
+endif
+
 # Use current commit as harness image tag
 CURRENT_COMMIT=$(shell git rev-parse --short=7 HEAD)
 HARNESS_IMAGE_TAG=$(CURRENT_COMMIT)

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -97,14 +97,13 @@ GOBIN?=$(shell go env GOBIN)
 unexport GOFLAGS
 GOFLAGS_MOD ?=
 
-# In openshift ci (Prow), we need to set $HOME to a writable directory else tests will fail
-# because they don't have permissions to create /.local or /.cache directories
-# as $HOME is set to "/" by default.
-ifeq ($(HOME),/)
-export HOME=/tmp/home
-GOENV+=GOCACHE="${HOME}/.cache"
+# Optionally use alternate GOCACHE location if default is not writeable
+CACHE_WRITEABLE := $(shell test -w "${HOME}/.cache" && echo yes || echo no)
+ifeq ($(CACHE_WRITEABLE),no)
+tmpDir := $(shell mktemp -d)
+GOENV+=GOCACHE=${tmpDir}
+$(info Using custom GOCACHE of ${tmpDir})
 endif
-PWD=$(shell pwd)
 
 GOENV+=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=1 GOFLAGS="${GOFLAGS_MOD}"
 GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"
@@ -190,8 +189,8 @@ docker-login:
 .PHONY: go-check
 go-check: ## Golang linting and other static analysis
 	${CONVENTION_DIR}/ensure.sh golangci-lint
-	GOLANGCI_LINT_CACHE=${GOLANGCI_LINT_CACHE} golangci-lint run -c ${CONVENTION_DIR}/golangci.yml ./...
-	test "${GOLANGCI_OPTIONAL_CONFIG}" = "" || test ! -e "${GOLANGCI_OPTIONAL_CONFIG}" || GOLANGCI_LINT_CACHE="${GOLANGCI_LINT_CACHE}" golangci-lint run -c "${GOLANGCI_OPTIONAL_CONFIG}" ./...
+	${GOENV} GOLANGCI_LINT_CACHE=${GOLANGCI_LINT_CACHE} golangci-lint run -c ${CONVENTION_DIR}/golangci.yml ./...
+	test "${GOLANGCI_OPTIONAL_CONFIG}" = "" || test ! -e "${GOLANGCI_OPTIONAL_CONFIG}" || ${GOENV} GOLANGCI_LINT_CACHE="${GOLANGCI_LINT_CACHE}" golangci-lint run -c "${GOLANGCI_OPTIONAL_CONFIG}" ./...
 
 .PHONY: go-generate
 go-generate:

--- a/boilerplate/openshift/osd-container-image/standard.mk
+++ b/boilerplate/openshift/osd-container-image/standard.mk
@@ -11,13 +11,13 @@ ifndef IMAGE_NAME
 $(error IMAGE_NAME is not set)
 endif
 
-# In openshift ci (Prow), we need to set $HOME to a writable directory else tests will fail
-# because they don't have permissions to create /.local or /.cache directories
-# as $HOME is set to "/" by default.
-ifeq ($(HOME),/)
-export HOME=/tmp/home
+# Optionally use alternate GOCACHE location if default is not writeable
+CACHE_WRITEABLE := $(shell test -w "${HOME}/.cache" && echo yes || echo no)
+ifeq ($(CACHE_WRITEABLE),no)
+tmpDir := $(shell mktemp -d)
+GOENV+=GOCACHE=${tmpDir}
+$(info Using custom GOCACHE of ${tmpDir})
 endif
-PWD=$(shell pwd)
 
 ### Accommodate docker or podman
 #


### PR DESCRIPTION
Our previous attempts to handle an unwritable `GOCACHE` weren't solving 100% of the cases, and leading to failures when I was attempting to update `osd-network-verifier`.

To ensure we always have a writeable `GOCACHE`, this PR modifies (and further extends) checks for `$HOME/.cache` not being writeable, and if so, creates a temporary directory and updates `GOCACHE` as such.

We then use this `GOCACHE` value via `GOENV` when we call `go` or `golangci-lint`.

Since Make is executing directives at _parse time_, just setting `GOCACHE=foo` early won't work on it's own, and callers have to explicitly check and use a custom tmp dir. I have done this for all the existing conventions, so users won't need to modify their per-repo `Makefile`s.

This will ensure that locally your `go env GOCACHE` value is still used, and in CI we always have a writeable tmp dir.

A sample PR can be found here utilizing these changes, showing passing CI. https://github.com/openshift/osd-network-verifier/pull/305