### PR TITLE
Incremental fixes for running make test locally on macOS

### DIFF
--- a/test/case/convention/openshift/golang-osd-operator/05-build-olm-catalog
+++ b/test/case/convention/openshift/golang-osd-operator/05-build-olm-catalog
@@ -189,7 +189,7 @@ function test_add_current_version_to_bundle_versions_file() {
 }
 
 function main() {
-    TEMP_DIR=$(mktemp -d --suffix "-$(basename "$0")")
+    TEMP_DIR=$(mktemp -d -t "$(basename "$0")")
     [[ -z "${PRESERVE_TEMP_DIRS:-}" ]] && trap 'rm -rf $TEMP_DIR' EXIT
 
     local failed=0

--- a/test/driver
+++ b/test/driver
@@ -16,10 +16,10 @@ _PASS=()
 _FAIL=()
 
 main() {
-    cd "$HERE/case"
+    cd "$HERE/case" || exit
     local name_glob='*'
     [[ -n "$1" ]] && name_glob="$1"
-    cases=$(find . -type f -perm /111 -name "$name_glob" | sort)
+    cases=$(find . -type f -perm +111 -name "$name_glob" | sort)
     if [[ -z "$cases" ]]; then
         echo "No test cases found! Something is wrong!"
         exit 1

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -8,7 +8,7 @@ LATEST_IMAGE_TAG=image-v4.0.1
 REPO_ROOT=$(git rev-parse --show-toplevel)
 # Make all tests use this local clone by default.
 export BOILERPLATE_GIT_REPO=$REPO_ROOT
-export LOG_DIR=$(mktemp -d -t boilerplate-logs-XXXXXXXX)
+export LOG_DIR=$(mktemp -d -t boilerplate-logs)
 
 # Location of the convention config, relative to the repo root
 export UPDATE_CFG=boilerplate/update.cfg
@@ -37,7 +37,7 @@ fi
 colorprint() {
   color=$1
   shift
-  /bin/echo -e "${color}$@${RESET}"
+  printf "%b%b%b\n" "${color}" "$*" "${RESET}"
 }
 
 err() {


### PR DESCRIPTION
There are a handful of things broken about running tests locally (at least on macOS). This fixes a few of them in isolation to rule them out as I am working on getting https://github.com/openshift/boilerplate/pull/520 passing but can't run tests locally.