### PR TITLE
Only return early for empty TESTTARGETS when required

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -127,11 +127,6 @@ ifeq ($(origin TESTTARGETS), undefined)
 TESTTARGETS := $(shell ${GOENV} go list -e ./... | grep -E -v "/(vendor)/" | grep -E -v "/(test/e2e)/")
 endif
 
-# If for any reason we've made it this far and TESTTARGETS is still empty, fail early.
-ifeq ($(TESTTARGETS),)
-$(error TESTTARGETS is empty)
-endif
-
 # ex, -v
 TESTOPTS :=
 
@@ -195,6 +190,12 @@ go-check: ## Golang linting and other static analysis
 
 .PHONY: go-generate
 go-generate:
+	# If for any reason we've made it this far and TESTTARGETS is still empty, fail early.
+	@if [ -z "$(TESTTARGETS)" ]; then \
+		echo "ERROR: TESTTARGETS is empty"; \
+		exit 1; \
+	fi
+
 	${GOENV} go generate $(TESTTARGETS)
 	# Don't forget to commit generated files
 
@@ -273,6 +274,12 @@ SHELL = /usr/bin/env bash -o pipefail
 
 .PHONY: go-test
 go-test: setup-envtest
+	# If for any reason we've made it this far and TESTTARGETS is still empty, fail early.
+	@if [ -z "$(TESTTARGETS)" ]; then \
+		echo "ERROR: TESTTARGETS is empty"; \
+		exit 1; \
+	fi
+
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test $(TESTOPTS) $(TESTTARGETS)
 
 .PHONY: python-venv


### PR DESCRIPTION
This updates a previous change that would fail early when `TESTTARGETS` was empty.

Instead of doing that during Makefile read time, do it inside the given recipes that rely upon it.

I have made this change locally to `aws-account-operator` and confirmed the logic passes.

```diff
diff --git a/boilerplate/openshift/golang-osd-operator/standard.mk b/boilerplate/openshift/golang-osd-operator/standard.mk
index 598cc501..5596aae7 100644
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -127,11 +127,6 @@ ifeq ($(origin TESTTARGETS), undefined)
 TESTTARGETS := $(shell ${GOENV} go list -e ./... | grep -E -v "/(vendor)/" | grep -E -v "/(test/e2e)/")
 endif

-# If for any reason we've made it this far and TESTTARGETS is still empty, fail early.
-ifeq ($(TESTTARGETS),)
-$(error TESTTARGETS is empty)
-endif
-
 # ex, -v
 TESTOPTS :=

@@ -273,6 +268,12 @@ SHELL = /usr/bin/env bash -o pipefail

 .PHONY: go-test
 go-test: setup-envtest
+       # If for any reason we've made it this far and TESTTARGETS is still empty, fail early.
+       @if [ -z "$(TESTTARGETS)" ]; then \
+               echo "ERROR: TESTTARGETS is empty"; \
+               exit 1; \
+       fi
+
        KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test $(TESTOPTS) $(TESTTARGETS)

 .PHONY: python-venv
```

```shell
> make go-test
cp: /var/lib/jenkins/.docker/config.json: No such file or directory
boilerplate/openshift/golang-osd-operator/standard.mk:115: Setting GOEXPERIMENT=boringcrypto - this generally causes builds to fail unless building inside the provided Dockerfile. If building locally consider calling 'go build .'
bash: setup-envtest: command not found
# If for any reason we've made it this far and TESTTARGETS is still empty, fail early.
KUBEBUILDER_ASSETS="" go test  github.com/openshift/aws-account-operator github.com/openshift/aws-account-operator/config github.com/openshift/aws-account-operator/controllers/account github.com/openshift/aws-account-operator/controllers/accountclaim github.com/openshift/aws-account-operator/controllers/accountclaim/mock github.com/openshift/aws-account-operator/controllers/accountpool github.com/openshift/aws-account-operator/controllers/awsfederatedaccountaccess github.com/openshift/aws-account-operator/controllers/awsfederatedrole github.com/openshift/aws-account-operator/controllers/validation github.com/openshift/aws-account-operator/pkg/awsclient github.com/openshift/aws-account-operator/pkg/awsclient/mock github.com/openshift/aws-account-operator/pkg/awsclient/sts github.com/openshift/aws-account-operator/pkg/localmetrics github.com/openshift/aws-account-operator/pkg/testutils github.com/openshift/aws-account-operator/pkg/totalaccountwatcher github.com/openshift/aws-account-operator/pkg/utils github.com/openshift/aws-account-operator/test/fixtures github.com/openshift/aws-account-operator/test/integration github.com/openshift/aws-account-operator/version
?       github.com/openshift/aws-account-operator       [no test files]
ok      github.com/openshift/aws-account-operator/config        (cached)
ok      github.com/openshift/aws-account-operator/controllers/account   (cached)
?       github.com/openshift/aws-account-operator/controllers/accountclaim/mock [no test files]
?       github.com/openshift/aws-account-operator/pkg/awsclient/mock    [no test files]
?       github.com/openshift/aws-account-operator/pkg/testutils [no test files]
ok      github.com/openshift/aws-account-operator/controllers/accountclaim      (cached)
ok      github.com/openshift/aws-account-operator/controllers/accountpool       (cached)
ok      github.com/openshift/aws-account-operator/controllers/awsfederatedaccountaccess (cached)
ok      github.com/openshift/aws-account-operator/controllers/awsfederatedrole  (cached)
ok      github.com/openshift/aws-account-operator/controllers/validation        (cached)
ok      github.com/openshift/aws-account-operator/pkg/awsclient (cached)
ok      github.com/openshift/aws-account-operator/pkg/awsclient/sts     (cached)
ok      github.com/openshift/aws-account-operator/pkg/localmetrics      (cached)
?       github.com/openshift/aws-account-operator/test/fixtures [no test files]
?       github.com/openshift/aws-account-operator/version       [no test files]
ok      github.com/openshift/aws-account-operator/pkg/totalaccountwatcher       (cached)
ok      github.com/openshift/aws-account-operator/pkg/utils     (cached)
ok      github.com/openshift/aws-account-operator/test/integration      (cached)
```