### PR TITLE
OSD-29557: Remove the `GOLANGCI_OPTIONAL_CONFIG` option, which is unused

### DIFF
--- a/boilerplate/openshift/golang-lint/README.md
+++ b/boilerplate/openshift/golang-lint/README.md
@@ -13,5 +13,3 @@
 - ensures the proper version of `golangci-lint` is installed, and
 - runs it against
 - a `golangci.yml` config.
-- a `GOLANGCI_OPTIONAL_CONFIG` config if it is defined and file exists
-

--- a/boilerplate/openshift/golang-lint/standard.mk
+++ b/boilerplate/openshift/golang-lint/standard.mk
@@ -12,7 +12,6 @@ endif
 # GOLANGCI_LINT_CACHE needs to be set to a directory which is writeable
 # Relevant issue - https://github.com/golangci/golangci-lint/issues/734
 GOLANGCI_LINT_CACHE ?= /tmp/golangci-cache
-GOLANGCI_OPTIONAL_CONFIG ?=
 
 LINT_CONVENTION_DIR := boilerplate/openshift/golang-lint
 
@@ -21,5 +20,3 @@ LINT_CONVENTION_DIR := boilerplate/openshift/golang-lint
 lint: 
 	${LINT_CONVENTION_DIR}/ensure.sh golangci-lint
 	${GOENV} GOLANGCI_LINT_CACHE=${GOLANGCI_LINT_CACHE} golangci-lint run -c ${LINT_CONVENTION_DIR}/golangci.yml ./...
-	test "${GOLANGCI_OPTIONAL_CONFIG}" = "" || test ! -e "${GOLANGCI_OPTIONAL_CONFIG}" || ${GOENV} GOLANGCI_LINT_CACHE="${GOLANGCI_LINT_CACHE}" golangci-lint run -c "${GOLANGCI_OPTIONAL_CONFIG}" ./...
-

--- a/boilerplate/openshift/golang-osd-operator/README.md
+++ b/boilerplate/openshift/golang-osd-operator/README.md
@@ -99,7 +99,6 @@ Consult [this doc](app-sre.md) for information on local execution/testing.
 - ensures the proper version of `golangci-lint` is installed, and
 - runs it against
 - a `golangci.yml` config.
-- a `GOLANGCI_OPTIONAL_CONFIG` config if it is defined and file exists
 
 ## Checks on generated code
 

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -120,8 +120,6 @@ endif
 # Relevant issue - https://github.com/golangci/golangci-lint/issues/734
 GOLANGCI_LINT_CACHE ?= /tmp/golangci-cache
 
-GOLANGCI_OPTIONAL_CONFIG ?=
-
 ifeq ($(origin TESTTARGETS), undefined)
 TESTTARGETS := $(shell ${GOENV} go list -e ./... | grep -E -v "/(vendor)/" | grep -E -v "/(test/e2e)/")
 endif
@@ -185,7 +183,6 @@ docker-login:
 go-check: ## Golang linting and other static analysis
 	${CONVENTION_DIR}/ensure.sh golangci-lint
 	${GOENV} GOLANGCI_LINT_CACHE=${GOLANGCI_LINT_CACHE} golangci-lint run -c ${CONVENTION_DIR}/golangci.yml ./...
-	test "${GOLANGCI_OPTIONAL_CONFIG}" = "" || test ! -e "${GOLANGCI_OPTIONAL_CONFIG}" || ${GOENV} GOLANGCI_LINT_CACHE="${GOLANGCI_LINT_CACHE}" golangci-lint run -c "${GOLANGCI_OPTIONAL_CONFIG}" ./...
 
 .PHONY: go-generate
 go-generate:


### PR DESCRIPTION
In https://github.com/openshift/boilerplate/pull/92 we added an option to be able to pass a custom golangci-lint configuration on a per repo basis. I believe the intent is to have it be _additive_, in that it would run a second `golangci-lint` invocation with your custom config. This would only work if you added a linter, as removing one in this file still meant the original invocation would have failed with the boilerplate-based config.

Additionally, the gate that was designed to prevent `golangci-lint` from running a second time, unless `GOLANGCI_OPTIONAL_CONFIG` is set, appears to not be working, so we are currently running linting twice on all our repos.

Lastly, after doing a quick search of GitHub, it appears we only have to repos with the configuration:
- https://github.com/openshift/osd-metrics-exporter/ configures it but the file was previously deleted, so no-ops
- https://github.com/openshift/osd-cluster-ready configures it, but the file just enables `gosec` that is part of our base config

For the above reasons, this PR proposes removing this feature to simplify linting versus fixing bugs with the existing, unused process. If approved, I will then go to the above two repos and remove the config.