### PR TITLE
Add GOENV missing from go-test target

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -279,7 +279,7 @@ go-test: setup-envtest
 		exit 1; \
 	fi
 
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test $(TESTOPTS) $(TESTTARGETS)
+	${GOENV} KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test $(TESTOPTS) $(TESTTARGETS)
 
 .PHONY: python-venv
 python-venv:


### PR DESCRIPTION
Missed this one last `GOENV` prefix to ensure `go test` is using the `GOCACHE` value.

Tested locally for aws-vpce-operator:

```diff
diff --git a/boilerplate/openshift/golang-osd-operator/standard.mk b/boilerplate/openshift/golang-osd-operator/standard.mk
index 033ed7b..576a954 100644
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -279,7 +279,7 @@ go-test: setup-envtest
                exit 1; \
        fi

-       KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test $(TESTOPTS) $(TESTTARGETS)
+       ${GOENV} KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test $(TESTOPTS) $(TESTTARGETS)

 .PHONY: python-venv
 python-venv:
```

```shell
 make container-test
cp: /var/lib/jenkins/.docker/config.json: No such file or directory
boilerplate/openshift/golang-osd-operator/standard.mk:114: Setting GOEXPERIMENT=boringcrypto - this generally causes builds to fail unless building inside the provided Dockerfile. If building locally consider calling 'go build .'
cp: /var/lib/jenkins/.docker/config.json: No such file or directory
boilerplate/_lib/container-make test

==============================
Starting the container
==============================

==============================
Running: make test
==============================
cp: cannot stat '/var/lib/jenkins/.docker/config.json': No such file or directory
Using custom GOCACHE of /tmp/tmp.yQVqXgUKxt
boilerplate/openshift/golang-osd-operator/standard.mk:114: Setting GOEXPERIMENT=boringcrypto - this generally causes builds to fail unless building inside the provided Dockerfile. If building locally consider calling 'go build .'
Go compliance shim [18] [rhel-8-golang-1.23][openshift-golang-builder]: assessment: CGO_ENABLED=1
Go compliance shim [18] [rhel-8-golang-1.23][openshift-golang-builder]: assessment: dynamic linking
Go compliance shim [18] [rhel-8-golang-1.23][openshift-golang-builder]: skipping forced compliance due to broad exemption
Go compliance shim [18] [rhel-8-golang-1.23][openshift-golang-builder]: EXEMPT: 1


Go compliance shim [18] [rhel-8-golang-1.23][openshift-golang-builder]: final command line arguments: "env" "GOOS"

Go compliance shim [18] [rhel-8-golang-1.23][openshift-golang-builder]: invoking real go binary
Go compliance shim [18] [rhel-8-golang-1.23][openshift-golang-builder]: Exited with: 0
Go compliance shim [51] [rhel-8-golang-1.23][openshift-golang-builder]: assessment: CGO_ENABLED=1
Go compliance shim [51] [rhel-8-golang-1.23][openshift-golang-builder]: assessment: dynamic linking
Go compliance shim [51] [rhel-8-golang-1.23][openshift-golang-builder]: skipping forced compliance due to broad exemption
Go compliance shim [51] [rhel-8-golang-1.23][openshift-golang-builder]: EXEMPT: 1


Go compliance shim [51] [rhel-8-golang-1.23][openshift-golang-builder]: final command line arguments: "env" "GOARCH"

Go compliance shim [51] [rhel-8-golang-1.23][openshift-golang-builder]: invoking real go binary
Go compliance shim [51] [rhel-8-golang-1.23][openshift-golang-builder]: Exited with: 0
Using custom GOCACHE of /tmp/tmp.m9C6Q896Mj
cp: cannot stat '/var/lib/jenkins/.docker/config.json': No such file or directory
# If for any reason we've made it this far and TESTTARGETS is still empty, fail early.
GOCACHE=/tmp/tmp.yQVqXgUKxt GOOS=linux GOARCH=amd64 CGO_ENABLED=1 GOFLAGS="-tags=fips_enabled" GOEXPERIMENT=boringcrypto GOCACHE=/tmp/tmp.m9C6Q896Mj KUBEBUILDER_ASSETS="/tmp/envtest/bin/k8s/1.23.5-linux-amd64" go test  ./...
Go compliance shim [107] [rhel-8-golang-1.23][openshift-golang-builder]: assessment: CGO_ENABLED=1
Go compliance shim [107] [rhel-8-golang-1.23][openshift-golang-builder]: assessment: dynamic linking
Go compliance shim [107] [rhel-8-golang-1.23][openshift-golang-builder]: skipping forced compliance due to broad exemption
Go compliance shim [107] [rhel-8-golang-1.23][openshift-golang-builder]: EXEMPT: 1


Go compliance shim [107] [rhel-8-golang-1.23][openshift-golang-builder]: final command line arguments: "test" "./..."

Go compliance shim [107] [rhel-8-golang-1.23][openshift-golang-builder]: invoking real go binary
go: downloading github.com/aws/aws-sdk-go-v2 v1.26.1
....
go: downloading golang.org/x/text v0.22.0
?       github.com/openshift/aws-vpce-operator/api/v1alpha1     [no test files]
?       github.com/openshift/aws-vpce-operator/api/v1alpha2     [no test files]
?       github.com/openshift/aws-vpce-operator/config   [no test files]
?       github.com/openshift/aws-vpce-operator  [no test files]
ok      github.com/openshift/aws-vpce-operator/controllers/util 0.187s
?       github.com/openshift/aws-vpce-operator/controllers/vpcendpointacceptance        [no test files]
ok      github.com/openshift/aws-vpce-operator/controllers/vpcendpoint  0.224s
ok      github.com/openshift/aws-vpce-operator/controllers/vpcendpointtemplate  0.221s
ok      github.com/openshift/aws-vpce-operator/pkg/aws_client   0.226s
ok      github.com/openshift/aws-vpce-operator/pkg/dnses        0.234s
ok      github.com/openshift/aws-vpce-operator/pkg/hostedcontrolplanes  0.226s
?       github.com/openshift/aws-vpce-operator/pkg/testutil     [no test files]
ok      github.com/openshift/aws-vpce-operator/pkg/infrastructures      0.191s
ok      github.com/openshift/aws-vpce-operator/pkg/secrets      0.180s
ok      github.com/openshift/aws-vpce-operator/pkg/util 0.056s
Go compliance shim [107] [rhel-8-golang-1.23][openshift-golang-builder]: Exited with: 0

==============================
Cleaning up the container
==============================
```