### PR TITLE
Utilize custom `GOCACHE` for `op-generate` target

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -220,8 +220,8 @@ YQ = yq
 .PHONY: op-generate
 ## CRD v1beta1 is no longer supported.
 op-generate:
-	cd ./api; $(CONTROLLER_GEN) crd:crdVersions=v1,generateEmbeddedObjectMeta=true paths=./... output:dir=$(PWD)/deploy/crds
-	cd ./api; $(CONTROLLER_GEN) object paths=./...
+	cd ./api; ${GOENV} $(CONTROLLER_GEN) crd:crdVersions=v1,generateEmbeddedObjectMeta=true paths=./... output:dir=$(PWD)/deploy/crds
+	cd ./api; ${GOENV} $(CONTROLLER_GEN) object paths=./...
 
 .PHONY: openapi-generate
 openapi-generate:


### PR DESCRIPTION
In the `op-generate` target we call `controller-gen` which relies on the given modules modules to be installed. This suffers from the same issue where `GOCACHE` not being writeable is an issue.

This just plumbs `GOENV` through like we have done in previous PRs.

Tested this locally with the following diff on `aws-vpce-operator`, which was failing a BP bump in https://github.com/openshift/aws-vpce-operator/pull/295

```diff
diff --git a/boilerplate/openshift/golang-osd-operator/standard.mk b/boilerplate/openshift/golang-osd-operator/standard.mk
index 576a954..b1a2d82 100644
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -220,8 +220,8 @@ YQ = yq
 .PHONY: op-generate
 ## CRD v1beta1 is no longer supported.
 op-generate:
-       cd ./api; $(CONTROLLER_GEN) crd:crdVersions=v1,generateEmbeddedObjectMeta=true paths=./... output:dir=$(PWD)/deploy/crds
-       cd ./api; $(CONTROLLER_GEN) object paths=./...
+       cd ./api; ${GOENV} $(CONTROLLER_GEN) crd:crdVersions=v1,generateEmbeddedObjectMeta=true paths=./... output:dir=$(PWD)/deploy/crds
+       cd ./api; ${GOENV} $(CONTROLLER_GEN) object paths=./...

 .PHONY: openapi-generate
 openapi-generate:
```

Ran `make container-validate` which failed on me having the above diff from `boilerplate:master`, however then when running `make op-generate` manually in the container it now passes and uses the custom cache.