### PR TITLE
SDCICD-1472 skip must-gather and destroy cluster steps in operator e2e suite

### DIFF
--- a/boilerplate/openshift/golang-osd-operator-osde2e/test-harness-template.yml
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/test-harness-template.yml
@@ -46,6 +46,8 @@ objects:
               args:
                 - test
                 - --only-health-check-nodes
+                - --skip-destroy-cluster
+                - --skip-must-gather
                 - --configs
                 - ${OSDE2E_CONFIGS}
               securityContext:


### PR DESCRIPTION
Aimed at making e2e jobs in PD pipelines  faster
- skip-destroy-cluster will skip uninstall logic in test. clusters will still be destroyed by ocm at their expiration 30 min after test
- must gather is not saved anywhere, so is useless in these jobs 
- changes will take effect only when boilerplate is updated on operator repos