### PR TITLE
Clean up job output when running `ensure.sh`

### DIFF
--- a/boilerplate/openshift/golang-lint/ensure.sh
+++ b/boilerplate/openshift/golang-lint/ensure.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-set -x
 set -eo pipefail
+
+if [ "$BOILERPLATE_SET_X" ]; then
+  set -x
+fi
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh

--- a/boilerplate/openshift/golang-osd-operator/ensure.sh
+++ b/boilerplate/openshift/golang-osd-operator/ensure.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-set -x
 set -eo pipefail
+
+if [ "$BOILERPLATE_SET_X" ]; then
+  set -x
+fi
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh


### PR DESCRIPTION
This script had `set -x` set which was making a ton of noise in jobs. Updated them to use the env var we have in case you ever want to see full shell output.