### PR TITLE
Add readme to e2e scaffolding; Update osde2e convention readme

### DIFF
--- a/boilerplate/openshift/golang-osd-operator-osde2e/README.md
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/README.md
@@ -15,8 +15,7 @@ openshift/golang-osd-operator-osde2e
 
 ## `make` targets and functions.
 
-**Note:** Your repository's main `Makefile` needs to be edited to include the
-"nexus makefile include":
+**Note:** Your repository's main `Makefile` needs to be edited to include:
 
 ```
 include boilerplate/generated-includes.mk
@@ -30,11 +29,10 @@ following:
 
 | `make` target      | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `e2e-harness-generate` | Generate scaffolding for an end to end test harness. The `test/e2e` directory is created where the tests and test runner reside. The harness has access to cloud client and harness passthrough secrets within the test job cluster. Add your operator  related ginkgo e2e tests under the `test/e2e/<operator-name>_tests.go` file. See [this README](https://github.com/openshift/osde2e-example-test-harness/blob/main/README.md#locally-running-this-example) for more details on test harness. |
 | `e2e-harness-build`| Compiles ginkgo tests under test/e2e and creates the ginkgo binary.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `e2e-image-build-push` | Builds e2e test harness image and pushes to operator's quay repo. Image name is defaulted to <operator-image-name>-test-harness. Quay repository must be created beforehand.                                                                                                                                                                                                                                                                                                                        |
 
 #### E2E Harness Local Testing
 
-Please follow [this README](https://github.com/openshift/osde2e-example-test-harness/blob/main/README.md#locally-running-this-example) to run your e2e tests locally
+Please follow [this README](https://github.com/openshift/ops-sop/blob/master/v4/howto/osde2e/operator-test-harnesses.md#using-ginkgo) to run your e2e tests locally
 

--- a/boilerplate/openshift/golang-osd-operator-osde2e/update
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/update
@@ -87,4 +87,21 @@ func Test${OPERATOR_NAME_CAMEL_CASE}(t *testing.T) {
 }
 EOF
 
+tee "${E2E_SUITE_DIRECTORY}/README.md" <<EOF
+## Locally running e2e test suite
+When updating your operator it's beneficial to add e2e tests for new functionality AND ensure existing functionality is not breaking using e2e tests. 
+To do this, following steps are recommended
+
+1. Run "make e2e-harness-build"  to make sure e2e tests build 
+2. Deploy your new version of operator in a test cluster
+3. Run "go install github.com/onsi/ginkgo/ginkgo@latest"
+4. Get kubeadmin credentials from your cluster using 
+
+ocm get /api/clusters_mgmt/v1/clusters/(cluster-id)/credentials | jq -r .kubeconfig > /(path-to)/kubeconfig
+
+5. Run test suite using 
+ 
+DISABLE_JUNIT_REPORT=true KUBECONFIG=/(path-to)/kubeconfig  ./(path-to)/bin/ginkgo  --tags=osde2e -v test/e2e
+EOF
+
 sed -e "s/\${OPERATOR_NAME}/${OPERATOR_NAME}/" $(dirname $0)/test-harness-template.yml >"${E2E_SUITE_DIRECTORY}/test-harness-template.yml"


### PR DESCRIPTION
1. Add readme to e2e scaffolding with steps on running tests locally 
2. Update osde2e convention readme - remove deprecated target, change sop link 