### PR TITLE
Fix usage of `PWD` for `op-generate` target in `goland-osd-operator`

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -209,7 +209,7 @@ YQ = yq
 .PHONY: op-generate
 ## CRD v1beta1 is no longer supported.
 op-generate:
-	cd ./api; ${GOENV} $(CONTROLLER_GEN) crd:crdVersions=v1,generateEmbeddedObjectMeta=true paths=./... output:dir=$(PWD)/deploy/crds
+	cd ./api; ${GOENV} $(CONTROLLER_GEN) crd:crdVersions=v1,generateEmbeddedObjectMeta=true paths=./... output:dir=$(shell pwd)/deploy/crds
 	cd ./api; ${GOENV} $(CONTROLLER_GEN) object paths=./...
 
 .PHONY: openapi-generate


### PR DESCRIPTION
The `make op-generate` target was relying on `PWD` being set to know where the writeable local checkout was.

That was mistakingly removed in https://github.com/openshift/boilerplate/commit/3bd17ad71e5b6f8268a1ef499128f78ec99f675c

Adding back in essentially the same, although using `$(shell pwd)` explicilty when needed versus setting the var for the whole Makefile.

# Diff Tested
```diff
diff --git a/boilerplate/openshift/golang-osd-operator/standard.mk b/boilerplate/openshift/golang-osd-operator/standard.mk
index ee2e3484..73ab1974 100644
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -209,7 +209,7 @@ YQ = yq
 .PHONY: op-generate
 ## CRD v1beta1 is no longer supported.
 op-generate:
-       cd ./api; ${GOENV} $(CONTROLLER_GEN) crd:crdVersions=v1,generateEmbeddedObjectMeta=true paths=./... output:dir=$(PWD)/deploy/crds
+       cd ./api; ${GOENV} $(CONTROLLER_GEN) crd:crdVersions=v1,generateEmbeddedObjectMeta=true paths=./... output:dir=$(shell pwd)/deploy/crds
        cd ./api; ${GOENV} $(CONTROLLER_GEN) object paths=./...

 .PHONY: openapi-generate
```

# Before
```
Go compliance shim [83] [rhel-8-golang-1.23][openshift-golang-builder]: Exited with: 0
cd ./api; GOOS=linux GOARCH=amd64 CGO_ENABLED=1 GOFLAGS="-tags=fips_enabled" GOEXPERIMENT=boringcrypto controller-gen crd:crdVersions=v1,generateEmbeddedObjectMeta=true paths=./... output:dir=/deploy/crds
mkdir /deploy: permission denied
Error: not all generators ran successfully
```
# After
```
Go compliance shim [80] [rhel-8-golang-1.23][openshift-golang-builder]: Exited with: 0
cd ./api; GOOS=linux GOARCH=amd64 CGO_ENABLED=1 GOFLAGS="-tags=fips_enabled" GOEXPERIMENT=boringcrypto controller-gen crd:crdVersions=v1,generateEmbeddedObjectMeta=true paths=./... output:dir=/go/src/github.com/openshift/aws-account-operator/deploy/crds
cd ./api; GOOS=linux GOARCH=amd64 CGO_ENABLED=1 GOFLAGS="-tags=fips_enabled" GOEXPERIMENT=boringcrypto controller-gen object paths=./...
```