### PR TITLE
Only copy `/var/lib/jenkins/.docker/config.json` if it exists

### DIFF
--- a/boilerplate/openshift/golang-osd-operator-osde2e/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/standard.mk
@@ -19,6 +19,7 @@ HARNESS_IMAGE_TAG=$(CURRENT_COMMIT)
 # invocation; otherwise it could collide across jenkins jobs. We'll use
 # a .docker folder relative to pwd (the repo root).
 CONTAINER_ENGINE_CONFIG_DIR = .docker
+JENKINS_DOCKER_CONFIG_FILE = /var/lib/jenkins/.docker/config.json
 export REGISTRY_AUTH_FILE = ${CONTAINER_ENGINE_CONFIG_DIR}/config.json
 
 # If this configuration file doesn't exist, podman will error out. So
@@ -27,7 +28,7 @@ ifeq (,$(wildcard $(REGISTRY_AUTH_FILE)))
 $(shell mkdir -p $(CONTAINER_ENGINE_CONFIG_DIR))
 # Copy the node container auth file so that we get access to the registries the
 # parent node has access to
-$(shell cp /var/lib/jenkins/.docker/config.json $(REGISTRY_AUTH_FILE))
+$(shell if test -f $(JENKINS_DOCKER_CONFIG_FILE); then cp $(JENKINS_DOCKER_CONFIG_FILE) $(REGISTRY_AUTH_FILE); fi)
 endif
 
 # ==> Docker uses --config=PATH *before* (any) subcommand; so we'll glue

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -21,6 +21,7 @@ endif
 # invocation; otherwise it could collide across jenkins jobs. We'll use
 # a .docker folder relative to pwd (the repo root).
 CONTAINER_ENGINE_CONFIG_DIR = .docker
+JENKINS_DOCKER_CONFIG_FILE = /var/lib/jenkins/.docker/config.json
 export REGISTRY_AUTH_FILE = ${CONTAINER_ENGINE_CONFIG_DIR}/config.json
 
 # If this configuration file doesn't exist, podman will error out. So
@@ -29,7 +30,7 @@ ifeq (,$(wildcard $(REGISTRY_AUTH_FILE)))
 $(shell mkdir -p $(CONTAINER_ENGINE_CONFIG_DIR))
 # Copy the node container auth file so that we get access to the registries the
 # parent node has access to
-$(shell cp /var/lib/jenkins/.docker/config.json $(REGISTRY_AUTH_FILE))
+$(shell if test -f $(JENKINS_DOCKER_CONFIG_FILE); then cp $(JENKINS_DOCKER_CONFIG_FILE) $(REGISTRY_AUTH_FILE); fi)
 endif
 
 # ==> Docker uses --config=PATH *before* (any) subcommand; so we'll glue


### PR DESCRIPTION
Whenever you run the make targets locally, you can see a few common errors, one of which is
```
 make boilerplate-update
cp: /var/lib/jenkins/.docker/config.json: No such file or directory
```

This cp really only is used in CI, and local users will not have that auth file. This guards against the file not existing and therefore scrubs more noisy output.