### PR TITLE
update owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -16,5 +16,4 @@ approvers:
 maintainers:
 - srep-functional-leads
 - srep-team-leads
-- bdematte
 - joshbranham

--- a/OWNERS
+++ b/OWNERS
@@ -1,22 +1,20 @@
 reviewers:
-- jharrington22
-- dustman9000
-- 2uasimojo
-- bdematte
+- srep-functional-team-aurora
+- srep-functional-leads
+- srep-team-leads
 - xiaoyu74
 - mmazur
 - jbpratt
 - joshbranham
 approvers:
-- jharrington22
-- dustman9000
-- 2uasimojo
+- srep-functional-team-aurora
+- srep-functional-leads
+- srep-team-leads
 - bdematte
 - mmazur
 - joshbranham
-- srep-team-leads
 maintainers:
-- jharrington22
-- dustman9000
-- 2uasimojo
+- srep-functional-leads
+- srep-team-leads
 - bdematte
+- joshbranham


### PR DESCRIPTION
    Updates OWNERS to use OWNERS_ALIASES, add team aurora as reviewers,
    functional leads to approvers and maintainers, and Josh to maintainers.
    
    Signed-off-by: Chris Collins <collins.christopher@gmail.com>