### PR TITLE
OSD-28963: Preserve consumer dependabot.yml by appending boilerplate

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -31,8 +31,29 @@ fi
 
 # Add dependabot configuration
 mkdir -p $REPO_ROOT/.github
-echo "Copying dependabot.yml to .github/dependabot.yml"
-cp ${HERE}/dependabot.yml ${REPO_ROOT}/.github/dependabot.yml
+TARGET_FILE="${REPO_ROOT}/.github/dependabot.yml"
+BOILERPLATE_FILE="${HERE}/dependabot.yml"
+
+if [[ -f "$TARGET_FILE" ]]; then
+  if grep -q '# BEGIN boilerplate-managed' "$TARGET_FILE"; then
+    echo "Boilerplate-managed section already present in dependabot.yml, skipping append."
+  elif diff -q "$TARGET_FILE" "$BOILERPLATE_FILE" >/dev/null; then
+    echo "Wrapping existing dependabot.yml (which matches boilerplate) with boilerplate-managed markers..."
+    mv "$TARGET_FILE" "${TARGET_FILE}.bak"
+    {
+      echo "# BEGIN boilerplate-managed"
+      cat "${TARGET_FILE}.bak"
+      echo "# END boilerplate-managed"
+    } > "$TARGET_FILE"
+    rm -f "${TARGET_FILE}.bak"
+  else
+    echo "[WARNING] dependabot.yml exists and differs from boilerplate template but has no boilerplate-managed markers."
+    echo "[WARNING] Please review manually to avoid config duplication."
+  fi
+else
+  echo "Copying boilerplate-managed dependabot.yml"
+  cp "$BOILERPLATE_FILE" "$TARGET_FILE"
+fi
 
 # Add olm-registry Dockerfile
 mkdir -p $REPO_ROOT/build


### PR DESCRIPTION
This patch updates the `update` script under `boilerplate/openshift/golang-osd-operator` to prevent overwriting an existing `.github/dependabot.yml` in consumer repositories.

### What it does:
- If `.github/dependabot.yml` already exists in the consumer repo:
  - It checks whether a boilerplate-managed section (marked by `# BEGIN boilerplate-managed`) is present.
  - If not present, it appends the boilerplate-managed block to the file.
  - If already present, it skips to avoid duplication.
- If the file does not exist, it copies the full boilerplate-managed `dependabot.yml`.

This allows consumer repositories to maintain their own custom Dependabot configuration while still receiving boilerplate-defined updates in a non-destructive way.

Fixes: [OSD-28963](https://issues.redhat.com/browse/OSD-28963)