### PR TITLE
[OSD-30016] bump controller-gen version to v0.16.4

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -23,7 +23,7 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.23
 ENV GOFLAGS="-mod=mod"
 
 ARG KUSTOMIZE_VERSION="v5.6.0" \
-    CONTROLLER_GEN_VERSION="v0.15.0" \
+    CONTROLLER_GEN_VERSION="v0.16.4" \
     OPENAPI_GEN_VERSION="v0.29.15" \
     ENVTEST_VERSION="release-0.18" \
     GOVULNCHECK_VERSION="v1.1.4" \

--- a/test/projects/file-generate/deploy/crds/mygroup.operators.coreos.com_testkinds.yaml
+++ b/test/projects/file-generate/deploy/crds/mygroup.operators.coreos.com_testkinds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: testkinds.mygroup.operators.coreos.com
 spec:
   group: mygroup.operators.coreos.com

--- a/test/projects/file-generate/expected/mygroup.operators.coreos.com_testkinds.yaml
+++ b/test/projects/file-generate/expected/mygroup.operators.coreos.com_testkinds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: testkinds.mygroup.operators.coreos.com
 spec:
   group: mygroup.operators.coreos.com


### PR DESCRIPTION
- controller-gen version bump to `v1.16.4` for operator's dep bump as below: 

```
k8s.io/api v0.31.1
k8s.io/apimachinery v0.31.1
sigs.k8s.io/controller-runtime v0.19.0 
```