### PR TITLE
SREP-860: Stop forcing `GOOS=linux` in `go-build` target

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -243,9 +243,7 @@ endif
 
 .PHONY: go-build
 go-build: ## Build binary
-	# Force GOOS=linux as we may want to build containers in other *nix-like systems (ie darwin).
-	# This is temporary until a better container build method is developed
-	${GOENV} GOOS=linux go build ${GOBUILDFLAGS} -o build/_output/bin/$(OPERATOR_NAME) .
+	${GOENV} go build ${GOBUILDFLAGS} -o build/_output/bin/$(OPERATOR_NAME) .
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23


### PR DESCRIPTION
~5 years ago this line was modified to enforce linux for building binaries.

This has the side effect of breaking `CGO` compilation on macOS. It can be fixed by configuring a cross-compiler that generates objects with Linux header files, however when building on your _local_ machine (outside docker) there is no need to force this to linux.

When the binary is built inside a container, the `GOOS` will be set to linux.

By changing this, you can now run `make go-build` for an operator like `managed-upgrade-operator`

```
> make go-build
boilerplate/openshift/golang-osd-operator/standard.mk:107: Setting GOEXPERIMENT=boringcrypto - this generally causes builds to fail unless building inside the provided Dockerfile. If building locally consider calling 'go build .'
boilerplate/openshift/golang-osd-operator/configure-fips.sh
Writing fips file at /Users/jbranham/git/openshift/managed-upgrade-operator/fips.go
GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 GOFLAGS="-tags=fips_enabled" GOEXPERIMENT=boringcrypto go build -gcflags="all=-trimpath=" -asmflags="all=-trimpath=" -o build/_output/bin/managed-upgrade-operator .

> make docker-build
boilerplate/openshift/golang-osd-operator/standard.mk:107: Setting GOEXPERIMENT=boringcrypto - this generally causes builds to fail unless building inside the provided Dockerfile. If building locally consider calling 'go build .'
/opt/homebrew/bin/podman build --pull -f build/Dockerfile -t quay.io/app-sre/managed-upgrade-operator:v0.1.1240-g1029385 .
[1/2] STEP 1/7: FROM quay.io/redhat-services-prod/openshift/boilerplate:image-v7.3.0 AS builder
Trying to pull quay.io/redhat-services-prod/openshift/boilerplate:image-v7.3.0...
Getting image source signatures
Copying blob sha256:c7965aa7086045a59bdb113a1fb8a19d7ccf7af4133e59af8ecefd39cda8e0b1
Copying blob sha256:0be72962dcb7cf38e093e93ddd810f2d7826046d28362c011f97c2a57cf80a7e
Copying blob sha256:17fa8acbe45e2766ea2d7fb8d4302966a9bda0bccd959aff967b7b6d35377d37
Copying config sha256:ebcc47e228a9cad0b96517ac4b8b6b4e8d028b8c348543b98538dd476d9122aa
Writing manifest to image destination
WARNING: image platform (linux/amd64) does not match the expected platform (linux/arm64)
[1/2] STEP 2/7: RUN mkdir -p /workdir
......
[2/2] STEP 7/8: USER ${USER_UID}
--> 439f4a6ed138
[2/2] STEP 8/8: LABEL io.openshift.managed.name="managed-upgrade-operator"       io.openshift.managed.description="Operator to manage upgrades for Openshift version 4 clusters"
[2/2] COMMIT quay.io/app-sre/managed-upgrade-operator:v0.1.1240-g1029385
--> bedfedd3b946
Successfully tagged quay.io/app-sre/managed-upgrade-operator:v0.1.1240-g1029385
bedfedd3b9464106f5aab5dabe26e8fcb172ee1c603eeb021e359054fc94f2ab
/opt/homebrew/bin/podman tag quay.io/app-sre/managed-upgrade-operator:v0.1.1240-g1029385 quay.io/app-sre/managed-upgrade-operator:latest
```