### PR TITLE
SDE-4270 load service account creds to osde2e job from tekton

### DIFF
--- a/boilerplate/openshift/golang-osd-operator-osde2e/test-harness-template.yml
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/test-harness-template.yml
@@ -10,11 +10,11 @@ parameters:
   - name: TEST_HARNESS_IMAGE
     required: true
   - name: OCM_CLIENT_ID
-    required: true
+    required: false
   - name: OCM_CLIENT_SECRET
-    required: true
+    required: false
   - name: OCM_TOKEN
-    required: true
+    required: false
   - name: OCM_CCS
     required: false
   - name: AWS_ACCESS_KEY_ID


### PR DESCRIPTION
https://issues.redhat.com/browse/SDE-4270

Follow up to:
https://github.com/openshift/osde2e/pull/2822/files

This change adds the OCM Client Credentials that OSDe2e will start using once offline tokens are deprecated.