### PR TITLE
rename "harness" to appropriate names

### DIFF
--- a/boilerplate/openshift/golang-osd-operator-osde2e/README.md
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/README.md
@@ -3,8 +3,8 @@
 - [Conventions for Ginkgo based e2e tests](#conventions-for-ginkgo-based-e2e-tests)
     - [Consuming](#consuming)
     - [`make` targets and functions.](#make-targets-and-functions)
-        - [E2E Test Harness](#e2e-test-harness)
-            - [Local Testing](#e2e-harness-local-testing)
+        - [E2E Test](#e2e-test)
+            - [Local Testing](#e2e-local-testing)
 
 ## Consuming
 Currently, this convention is only intended for OSD operators. To adopt this convention, your `boilerplate/update.cfg` should include:
@@ -25,14 +25,14 @@ One of the primary purposes of these `make` targets is to allow you to
 standardize your prow and app-sre pipeline configurations using the
 following:
 
-### E2e Test Harness
+### E2e Test
 
-| `make` target      | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `e2e-harness-build`| Compiles ginkgo tests under test/e2e and creates the ginkgo binary.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `e2e-image-build-push` | Builds e2e test harness image and pushes to operator's quay repo. Image name is defaulted to <operator-image-name>-test-harness. Quay repository must be created beforehand.                                                                                                                                                                                                                                                                                                                        |
+| `make` target          | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `e2e-binary-build`     | Compiles ginkgo tests under test/e2e and creates the ginkgo binary.                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `e2e-image-build-push` | Builds e2e image and pushes to operator's quay repo. Image name is defaulted to <operator-image-name>-test-harness. Quay repository must be created beforehand.                                                                                                                                                                                                                                                                                                                        |
 
-#### E2E Harness Local Testing
+#### E2E Local Testing
 
 Please follow [this README](https://github.com/openshift/ops-sop/blob/master/v4/howto/osde2e/operator-test-harnesses.md#using-ginkgo) to run your e2e tests locally
 

--- a/boilerplate/openshift/golang-osd-operator-osde2e/e2e-image-build-push.sh
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/e2e-image-build-push.sh
@@ -11,8 +11,8 @@ dockerfile_path image_uri
 
     For example:
 
-# This is the test harness image
-./build/Dockerfile quay.io/app-sre/my-wizbang-operator-test-harness:latest
+# This is the e2e test image
+./build/Dockerfile quay.io/app-sre/my-wizbang-operator-e2e:latest
 
 
     The parameter is mandatory; if only building the catalog image,

--- a/boilerplate/openshift/golang-osd-operator-osde2e/project.mk
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/project.mk
@@ -1,9 +1,9 @@
 # Project specific values
 OPERATOR_NAME?=$(shell sed -n 's/.*OperatorName .*"\([^"]*\)".*/\1/p' config/config.go)
 
-HARNESS_IMAGE_REGISTRY?=quay.io
-HARNESS_IMAGE_REPOSITORY?=app-sre
-HARNESS_IMAGE_NAME?=$(OPERATOR_NAME)-test-harness
+E2E_IMAGE_REGISTRY?=quay.io
+E2E_IMAGE_REPOSITORY?=app-sre
+E2E_IMAGE_NAME?=$(OPERATOR_NAME)-e2e
 
  
 REGISTRY_USER?=$(QUAY_USER)

--- a/boilerplate/openshift/golang-osd-operator-osde2e/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/standard.mk
@@ -2,16 +2,16 @@
 ifndef OPERATOR_NAME
 $(error OPERATOR_NAME is not set; only operators should consume this convention; check project.mk file)
 endif
-ifndef HARNESS_IMAGE_REGISTRY
-$(error HARNESS_IMAGE_REGISTRY is not set; check project.mk file)
+ifndef E2E_IMAGE_REGISTRY
+$(error E2E_IMAGE_REGISTRY is not set; check project.mk file)
 endif
-ifndef HARNESS_IMAGE_REPOSITORY
-$(error HARNESS_IMAGE_REPOSITORY is not set; check project.mk file)
+ifndef E2E_IMAGE_REPOSITORY
+$(error E2E_IMAGE_REPOSITORY is not set; check project.mk file)
 endif
 
 # Use current commit as harness image tag
 CURRENT_COMMIT=$(shell git rev-parse --short=7 HEAD)
-HARNESS_IMAGE_TAG=$(CURRENT_COMMIT)
+E2E_IMAGE_TAG=$(CURRENT_COMMIT)
 
 ### Accommodate docker or podman
 #
@@ -65,16 +65,16 @@ container-engine-login:
 ######################
 
 # create binary
-.PHONY: e2e-harness-build
-e2e-harness-build: GOFLAGS_MOD=-mod=mod
-e2e-harness-build: GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS="${GOFLAGS_MOD}"
-e2e-harness-build:
+.PHONY: e2e-binary-build
+e2e-binary-build: GOFLAGS_MOD=-mod=mod
+e2e-binary-build: GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS="${GOFLAGS_MOD}"
+e2e-binary-build:
 	go mod tidy
-	go test ./test/e2e -v -c --tags=osde2e -o harness.test
+	go test ./test/e2e -v -c --tags=osde2e -o e2e.test
 
 # TODO: Push to a known image tag and commit id
 # push harness image
 .PHONY: e2e-image-build-push
 e2e-image-build-push:
-	${OSDE2E_CONVENTION_DIR}/e2e-image-build-push.sh "./test/e2e/Dockerfile $(IMAGE_REGISTRY)/$(HARNESS_IMAGE_REPOSITORY)/$(HARNESS_IMAGE_NAME):$(HARNESS_IMAGE_TAG)"
-	${OSDE2E_CONVENTION_DIR}/e2e-image-build-push.sh "./test/e2e/Dockerfile $(IMAGE_REGISTRY)/$(HARNESS_IMAGE_REPOSITORY)/$(HARNESS_IMAGE_NAME):latest"
+	${OSDE2E_CONVENTION_DIR}/e2e-image-build-push.sh "./test/e2e/Dockerfile $(IMAGE_REGISTRY)/$(E2E_IMAGE_REPOSITORY)/$(E2E_IMAGE_NAME):$(E2E_IMAGE_TAG)"
+	${OSDE2E_CONVENTION_DIR}/e2e-image-build-push.sh "./test/e2e/Dockerfile $(IMAGE_REGISTRY)/$(E2E_IMAGE_REPOSITORY)/$(E2E_IMAGE_NAME):latest"

--- a/boilerplate/openshift/golang-osd-operator-osde2e/test-harness-template.yml
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/test-harness-template.yml
@@ -6,7 +6,7 @@ metadata:
 parameters:
   - name: OSDE2E_CONFIGS
     required: true
-  - name: TEST_HARNESS_IMAGE
+  - name: TEST_IMAGE
     required: true
   - name: OCM_CLIENT_ID
     required: false
@@ -62,8 +62,8 @@ objects:
                 seccompProfile:
                   type: RuntimeDefault
               env:
-                - name: TEST_HARNESSES
-                  value: ${TEST_HARNESS_IMAGE}:${IMAGE_TAG}
+                - name: TEST_IMAGES
+                  value: ${TEST_IMAGE}:${IMAGE_TAG}
                 - name: OCM_CLIENT_ID
                   value: ${OCM_CLIENT_ID}
                 - name: OCM_CLIENT_SECRET

--- a/boilerplate/openshift/golang-osd-operator-osde2e/update
+++ b/boilerplate/openshift/golang-osd-operator-osde2e/update
@@ -92,7 +92,7 @@ tee "${E2E_SUITE_DIRECTORY}/README.md" <<EOF
 When updating your operator it's beneficial to add e2e tests for new functionality AND ensure existing functionality is not breaking using e2e tests. 
 To do this, following steps are recommended
 
-1. Run "make e2e-harness-build"  to make sure e2e tests build 
+1. Run "make e2e-binary-build"  to make sure e2e tests build 
 2. Deploy your new version of operator in a test cluster
 3. Run "go install github.com/onsi/ginkgo/ginkgo@latest"
 4. Get kubeadmin credentials from your cluster using 
@@ -104,4 +104,4 @@ ocm get /api/clusters_mgmt/v1/clusters/(cluster-id)/credentials | jq -r .kubecon
 DISABLE_JUNIT_REPORT=true KUBECONFIG=/(path-to)/kubeconfig  ./(path-to)/bin/ginkgo  --tags=osde2e -v test/e2e
 EOF
 
-sed -e "s/\${OPERATOR_NAME}/${OPERATOR_NAME}/" $(dirname $0)/test-harness-template.yml >"${E2E_SUITE_DIRECTORY}/test-harness-template.yml"
+sed -e "s/\${OPERATOR_NAME}/${OPERATOR_NAME}/" $(dirname $0)/e2e-template.yml >"${E2E_SUITE_DIRECTORY}/e2e-template.yml"

--- a/boilerplate/openshift/golang-osd-operator/prow-config
+++ b/boilerplate/openshift/golang-osd-operator/prow-config
@@ -66,7 +66,7 @@ resources:
 tests:
 - as: e2e-binary-build-success
   commands: |
-    make e2e-harness-build
+    make e2e-binary-build
   container:
     from: src
   run_if_changed: ^(test/e2e/\.*|go\.mod|go\.sum)$


### PR DESCRIPTION
[SDCICD-1593](https://issues.redhat.com//browse/SDCICD-1593)

- rename "e2e-harness-build" to "e2e-binary-build"
- rename "test-harness-template.yml" file to "e2e-template.yml"
- rename "-test-harness" for e2e docker images to "-e2e" suffix
- update all occurrences of HARNESS to appropriate replacement