### PR TITLE
SREP-935 - Update boilerplate to accept UBI 7-9

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -94,7 +94,8 @@ for file in $DOCKERFILES; do
 
   # Update any UBI images to use a versioned tag of ubi8/ubi-minimal that is compatible with dependabot
   for ubi_latest in $(grep -oE 'registry.access.redhat.com/ubi[7-9]/ubi.*?:.*' ${file}); do
-      replacement_image=$(skopeo inspect --override-os linux --override-arch amd64 docker://registry.access.redhat.com/ubi8/ubi-minimal --format "{{.Name}}:{{.Labels.version}}-{{.Labels.release}}")
+      ubi_base=$(echo "$ubi_latest" | "${SED?}" -n 's|registry.access.redhat.com/\(ubi[0-9]/ubi[^:]*\):.*|\1|p')
+      replacement_image=$(skopeo inspect --override-os linux --override-arch amd64 "docker://registry.access.redhat.com/${ubi_base}" --format "{{.Name}}:{{.Labels.version}}-{{.Labels.release}}")
       echo "Overwriting ${file}'s ${ubi_latest} image to ${replacement_image}"
       ${SED?} -i "s,${ubi_latest},${replacement_image}," ${file}
   done


### PR DESCRIPTION
Update boilerplate to accept UBI versions 7-9 and not override to 8.

https://issues.redhat.com/browse/SREP-935