### PR TITLE
SREP-1170: Create Tekton Pipeline to run `pr-check` in Konflux

### DIFF
--- a/.tekton/boilerplate-master-pr-check.yaml
+++ b/.tekton/boilerplate-master-pr-check.yaml
@@ -1,0 +1,83 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: boilerplate-master-pr-check
+  labels:
+    build.appstudio.redhat.com/pipeline: boilerplate-master-pr-check
+spec:
+  params:
+    - description: Snapshot of the application
+      name: SNAPSHOT
+      default: '{"components": [{"name":"image", "containerImage": "quay.io/redhat-services-prod/openshift/boilerplate:latest", "source":{ "git":{"url": "https://github.com/openshift/boilerplate", "revision": "master"}}}]}'
+      type: string
+  workspaces:
+    - name: shared-workspace
+      description: A workspace to share data between tasks
+  tasks:
+    - name: parse-component-image-spec
+      description: Task parses the specific component image spec from the snapshot parameter
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+        results:
+          - name: COMPONENT_IMAGE
+            description: parsed component image spec
+          - name: COMPONENT_GIT_URL
+            description: parsed component git url
+          - name: COMPONENT_GIT_REVISION
+            description: parsed component git revision
+        steps:
+          - image: "registry.access.redhat.com/ubi8/ubi-minimal:latest@sha256:9746f7ac575b4427fc9635f8f575289870a8b30dabf77ee992ae4c2f1e121cce"
+            env:
+              - name: SNAPSHOT
+                value: $(params.SNAPSHOT)
+            script: |
+              microdnf -y install jq
+              COMPONENT_IMAGE=$(echo ${SNAPSHOT} | jq -r '.components[] | select(.name=="image") | .containerImage')
+              COMPONENT_GIT_URL=$(echo ${SNAPSHOT} | jq -r '.components[] | select(.name=="image") | .source.git.url')
+              COMPONENT_GIT_REVISION=$(echo ${SNAPSHOT} | jq -r '.components[] | select(.name=="image") | .source.git.revision')
+              echo -n "${COMPONENT_IMAGE}" | tee $(results.COMPONENT_IMAGE.path)
+              echo -n "${COMPONENT_GIT_URL}" | tee $(results.COMPONENT_GIT_URL.path)
+              echo -n "${COMPONENT_GIT_REVISION}" | tee $(results.COMPONENT_GIT_REVISION.path)
+    - name: clone-repository
+      description: Clone the repository
+      runAfter:
+        - parse-component-image-spec
+      params:
+        - name: url
+          value: $(tasks.parse-component-image-spec.results.COMPONENT_GIT_URL)
+        - name: revision
+          value: $(tasks.parse-component-image-spec.results.COMPONENT_GIT_REVISION)
+      taskRef:
+        params:
+          - name: name
+            value: git-clone
+          - name: bundle
+            value: quay.io/redhat-appstudio-tekton-catalog/task-git-clone:0.1@sha256:b99d377c3e28fad51009849f6ba3a1bc47d1dc4c46f470ea12ed7b1b444599d7
+          - name: kind
+            value: task
+        resolver: bundles
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+    - name: execute-boilerplate-pr-check
+      description: Run the boilerplate pr-check
+      runAfter:
+        - clone-repository
+      timeout: "1h"
+      params:
+        - name: COMPONENT_IMAGE
+          value: $(tasks.parse-component-image-spec.results.COMPONENT_IMAGE)
+      taskSpec:
+        params:
+          - name: COMPONENT_IMAGE
+        steps:
+          - image: $(params.COMPONENT_IMAGE)
+            command:
+              - make
+            args:
+              - pr-check
+            workingDir: $(workspaces.shared-workspace.path)

--- a/.tekton/boilerplate-master-pr-check.yaml
+++ b/.tekton/boilerplate-master-pr-check.yaml
@@ -80,4 +80,4 @@ spec:
               - make
             args:
               - pr-check
-            workingDir: $(workspaces.shared-workspace.path)
+            workingDir: "$(workspaces.shared-workspace.path)/source"

--- a/.tekton/image-pull-request.yaml
+++ b/.tekton/image-pull-request.yaml
@@ -12,7 +12,9 @@ metadata:
       target_branch == "master" &&
       (
         "config/***".pathChanged() ||
-        ".tekton/image-pull-request.yaml".pathChanged()
+        ".tekton/image-pull-request.yaml".pathChanged() ||
+        "boilerplate/***".pathChanged() ||
+        "test/***".pathChanged()
       )
   creationTimestamp:
   labels:

--- a/boilerplate/_lib/boilerplate-commit
+++ b/boilerplate/_lib/boilerplate-commit
@@ -56,13 +56,7 @@ elif grep -q '^ M boilerplate/_data/last-boilerplate-commit$' $git_status; then
   bp_compare_url="https://github.com/openshift/boilerplate/compare/$bp_commit_change"
   # Generate the commit history for this range. This will go in the commit message.
   (
-    if [[ -z "${BOILERPLATE_IN_CI}" ]]; then
-      git clone "${BOILERPLATE_GIT_REPO}" "${bp_clone}"
-    else
-      # HACK: We can't get around safe.directory in CI, so just leverage cp instead of git
-      cp -r /go/src/github.com/openshift/boilerplate/* "${bp_clone}"
-      cp -r /go/src/github.com/openshift/boilerplate/.git "${bp_clone}"
-    fi
+    git clone "${BOILERPLATE_GIT_REPO}" "${bp_clone}"
     cd "${bp_clone}"
     # Matches promote.sh
     git log --no-merges --pretty=format:'commit: %H%nauthor: %an%n%s%n%n%b%n%n' $bp_commit_change > $bp_log

--- a/boilerplate/update
+++ b/boilerplate/update
@@ -109,13 +109,8 @@ EOF
   fi
   BP_CLONE="$(mktemp -d)"
 
-  if [[ -z "${BOILERPLATE_IN_CI}" ]]; then
-    ${BOILERPLATE_GIT_CLONE} "${BOILERPLATE_GIT_REPO}" "${BP_CLONE}"
-  else
-    # HACK: We can't get around safe.directory in CI, so just leverage cp instead of git
-    cp -rf /go/src/github.com/openshift/boilerplate/* "${BP_CLONE}"
-    cp -rf /go/src/github.com/openshift/boilerplate/.git "${BP_CLONE}"
-  fi
+  ${BOILERPLATE_GIT_CLONE} "${BOILERPLATE_GIT_REPO}" "${BP_CLONE}"
+
   echo "Updating the update script."
   rsync -a "${BP_CLONE}/boilerplate/update" "$0"
   echo "Copying utilities"

--- a/test/case/convention/openshift/golang-osd-operator/01-generated-files-checker
+++ b/test/case/convention/openshift/golang-osd-operator/01-generated-files-checker
@@ -14,7 +14,7 @@ test_project="file-generate"
 # Attempt to boilerplate the test project with the openshift/golang-osd-operator convention
 bootstrap_project "${repo}" "${test_project}" openshift/golang-osd-operator
 cd "${repo}"
-BOILERPLATE_IN_CI=1 make boilerplate-update
+make boilerplate-update
 go mod download
 export GOPATH=$GOPATH:`pwd`
 

--- a/test/case/convention/openshift/golang-osd-operator/07-generate-crd-v1
+++ b/test/case/convention/openshift/golang-osd-operator/07-generate-crd-v1
@@ -14,7 +14,7 @@ test_project="file-generate"
 
 bootstrap_project $repo ${test_project} openshift/golang-osd-operator
 cd $repo
-BOILERPLATE_IN_CI=1 make boilerplate-update
+make boilerplate-update
 
 make op-generate
 

--- a/test/case/framework/01-bootstrap-update
+++ b/test/case/framework/01-bootstrap-update
@@ -13,7 +13,7 @@ bootstrap_repo $repo
 
 cd $repo
 
-BOILERPLATE_IN_CI=1 make boilerplate-update
+make boilerplate-update
 
 check_update $repo 01-no-convention
 
@@ -25,7 +25,7 @@ fi
 ./boilerplate/_lib/boilerplate-commit
 
 add_convention $repo test/test-base-convention
-BOILERPLATE_IN_CI=1 make boilerplate-update
+make boilerplate-update
 
 check_update $repo 01-with-convention
 

--- a/test/case/framework/02-nonexistent-convention
+++ b/test/case/framework/02-nonexistent-convention
@@ -18,7 +18,7 @@ cd $repo
 LOG=$LOG_DIR/${0##*/}.log
 
 # A little cheat so we can get the RC from `make`
-BOILERPLATE_IN_CI=1 make boilerplate-update >$LOG 2>&1
+make boilerplate-update >$LOG 2>&1
 rc=$?
 cat $LOG
 

--- a/test/case/framework/03-nexus-makefile-include
+++ b/test/case/framework/03-nexus-makefile-include
@@ -39,7 +39,7 @@ bootstrap_repo $repo
 cd $repo
 
 sub_hdr "Baseline"
-BOILERPLATE_IN_CI=1 make boilerplate-update
+make boilerplate-update
 check_update $repo
 
 sub_hdr "Include with no conventions"
@@ -58,7 +58,7 @@ diff $expected/nmi-header $NEXUS_MK
 
 sub_hdr "Convention with no includes"
 add_convention $repo test/nexus-makefile-include/no-includes
-BOILERPLATE_IN_CI=1 make boilerplate-update
+make boilerplate-update
 check_update $repo
 # Nexus Makefile include should have only the header
 diff $expected/nmi-header $NEXUS_MK
@@ -72,7 +72,7 @@ cd $repo
 sub_hdr "Convention with one include"
 convention=test/nexus-makefile-include/one-include
 add_convention $repo $convention
-BOILERPLATE_IN_CI=1 make boilerplate-update
+make boilerplate-update
 check_update $repo
 cat $expected/nmi-header > $exp_nmi
 /bin/echo "include boilerplate/$convention/one.mk" >> $exp_nmi
@@ -97,7 +97,7 @@ cd $repo
 sub_hdr "Convention with multiple includes"
 convention=test/nexus-makefile-include/multiple-includes
 add_convention $repo $convention
-BOILERPLATE_IN_CI=1 make boilerplate-update
+make boilerplate-update
 check_update $repo
 cat $expected/nmi-header > $exp_nmi
 # NOTE: These are added in lexical sort order!
@@ -120,7 +120,7 @@ sub_hdr "Multiple conventions"
 for c in no-includes one-include multiple-includes; do
     add_convention $repo test/nexus-makefile-include/$c
 done
-BOILERPLATE_IN_CI=1 make boilerplate-update
+make boilerplate-update
 check_update $repo
 cat $expected/nmi-header > $exp_nmi
 # NOTE: The *convention* order is honored, even though the *includes*

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -117,9 +117,9 @@ bootstrap_project() {
         for convention in $3 ; do
             add_convention . $convention
         done
-        BOILERPLATE_IN_CI=1 make boilerplate-update
+        make boilerplate-update
         ${SED?} -i '1s,^,include boilerplate/generated-includes.mk\n\n,' Makefile
-        BOILERPLATE_IN_CI=1 make boilerplate-commit
+        make boilerplate-commit
     )
 }
 
@@ -288,7 +288,7 @@ new_boilerplate_clone() {
     add_cleanup $clone
     # HACK: Set safe.directory using environment variables in CI because we can't modify the global config, e.g. with
     # git config --global --add safe.directory '/go/src/github.com/openshift/boilerplate/.git'
-    GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0='safe.directory' GIT_CONFIG_VALUE_0='/go/src/github.com/openshift/boilerplate/.git' git clone https://github.com/openshift/boilerplate.git $clone >&2
+    GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0='safe.directory' GIT_CONFIG_VALUE_0="${clone}/.git" git clone https://github.com/openshift/boilerplate.git "$clone" >&2
     if [ $# = 1 ] ; then
         pushd $clone > /dev/null
         git checkout $1


### PR DESCRIPTION
This does two things:

- Add a new pipeline that we can configure in Konflux to run an integration test (`make pr-check`) as we move this from prow to Konflux. This will be configured to run after an image is built for a PR.
- Remove all the hacks in the tests that were designed around shortcomings in the way `prow` ran the job before.

I ran this locally with this PipelineRun config

```
kind: PipelineRun
metadata:
  name: test-run
spec:
  pipelineRef:
    name: boilerplate-master-pr-check
  workspaces:
    - name: shared-workspace
      volumeClaimTemplate:
        spec:
          accessModes:
            - ReadWriteOnce
          resources:
            requests:
              storage: 1Gi
```

Two follow ups:

- Delete the prow config so it doesn't run `pr-check`
- Add the integration test config for Konflux