### PR TITLE
Drop no longer needed .ci-operator.yaml config

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,0 @@
-build_root_image:
-  namespace: ocp
-  name: builder
-  tag: rhel-8-golang-1.23-openshift-4.19


### PR DESCRIPTION
We are no longer doing presubmits via prow so drop this config