### PR TITLE
SREP-1170: Configure IntegrationTest to support `workspace`

### DIFF
--- a/.tekton/boilerplate-master-pr-check-pipelinerun.yaml
+++ b/.tekton/boilerplate-master-pr-check-pipelinerun.yaml
@@ -1,0 +1,23 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: boilerplate-master-pr-check-pipelinerun-
+spec:
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: https://github.com/openshift/boilerplate
+      - name: revision
+        value: master
+      - name: pathInRepo
+        value: .tekton/boilerplate-master-pr-check.yaml
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/.tekton/boilerplate-master-pr-check.yaml
+++ b/.tekton/boilerplate-master-pr-check.yaml
@@ -51,6 +51,10 @@ spec:
           value: $(tasks.parse-component-image-spec.results.COMPONENT_GIT_URL)
         - name: revision
           value: $(tasks.parse-component-image-spec.results.COMPONENT_GIT_REVISION)
+        - name: fetchTags
+          value: "true"
+        - name: depth
+          value: "50"
       taskRef:
         params:
           - name: name


### PR DESCRIPTION
As part of migrating to Konflux to run our `pr-check` test, I discovered we needed to configure things differently in order to use a `workspace` to share the git clone.

This defines a `PipelineRun` template in-repo, which is then targeted by a `IntegrationTestScenario` in the Konflux cluster.

The test still has some issues with Git, but this progresses things so it is running.

Sample:
```
apiVersion: appstudio.redhat.com/v1beta2
kind: IntegrationTestScenario
metadata:
  labels:
    test.appstudio.openshift.io/optional: "true"
  name: boilerplate-master-pr-check
  namespace: boilerplate-cicada-tenant
spec:
  application: boilerplate-master
  contexts:
    - description: execute the integration test in all cases - this would be the default
        state
      name: application
  resolverRef:
    params:
      - name: url
        value: https://github.com/openshift/boilerplate
      - name: revision
        value: master
      - name: pathInRepo
        value: .tekton/boilerplate-master-pr-check-pipelinerun.yaml
    resolver: git
    resourceKind: pipelinerun

```