### PR TITLE
SREP-1170: Ensure `make pr-check` works on macOS and in Konflux

### DIFF
--- a/.tekton/boilerplate-master-pr-check.yaml
+++ b/.tekton/boilerplate-master-pr-check.yaml
@@ -54,7 +54,7 @@ spec:
         - name: fetchTags
           value: "true"
         - name: depth
-          value: "50"
+          value: "0"
       taskRef:
         params:
           - name: name

--- a/.tekton/boilerplate-master-pr-check.yaml
+++ b/.tekton/boilerplate-master-pr-check.yaml
@@ -55,6 +55,8 @@ spec:
           value: "true"
         - name: depth
           value: "0"
+        - name: verbose
+          value: "true"
       taskRef:
         params:
           - name: name

--- a/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
+++ b/boilerplate/openshift/golang-osd-operator/build-opm-catalog.sh
@@ -49,7 +49,7 @@ function check_required_environment() {
 
 function setup_temp_dir() {
     local temp_dir
-    temp_dir=$(mktemp -d --suffix "-$(basename "$0")")
+    temp_dir=$(mktemp -d -t "$(basename "$0").XXXXXX")
     [[ "$DELETE_TEMP_DIR" == "true" ]] && trap "rm -rf $temp_dir" EXIT
 
     echo "$temp_dir"

--- a/boilerplate/openshift/golang-osd-operator/rvmo-bundle.sh
+++ b/boilerplate/openshift/golang-osd-operator/rvmo-bundle.sh
@@ -8,7 +8,7 @@ RVMO_BRANCH=${CURRENT_BRANCH:-main}
 # You can override any branch detection by setting RELEASE_BRANCH
 BRANCH=${RELEASE_BRANCH:-$RVMO_BRANCH}
 DELETE_TEMP_DIR=${DELETE_TEMP_DIR:-true}
-TMPD=$(mktemp -d --suffix -rvmo-bundle)
+TMPD=$(mktemp -d -t rvmo-bundle.XXXXXX)
 [[ "${DELETE_TEMP_DIR}" == "true" ]] && trap 'rm -rf ${TMPD}' EXIT
 
 cd "${TMPD}"

--- a/test/case/convention/openshift/golang-osd-operator/05-build-olm-catalog
+++ b/test/case/convention/openshift/golang-osd-operator/05-build-olm-catalog
@@ -189,7 +189,7 @@ function test_add_current_version_to_bundle_versions_file() {
 }
 
 function main() {
-    TEMP_DIR=$(mktemp -d --suffix "-$(basename "$0")")
+    TEMP_DIR=$(mktemp -d -t "$(basename "$0").XXXXXX")
     [[ -z "${PRESERVE_TEMP_DIRS:-}" ]] && trap 'rm -rf $TEMP_DIR' EXIT
 
     local failed=0

--- a/test/driver
+++ b/test/driver
@@ -19,7 +19,7 @@ main() {
     cd "$HERE/case"
     local name_glob='*'
     [[ -n "$1" ]] && name_glob="$1"
-    cases=$(find . -type f -perm +111 -name "$name_glob" | sort)
+    cases=$(find . -type f -perm -111 -name "$name_glob" | sort)
     if [[ -z "$cases" ]]; then
         echo "No test cases found! Something is wrong!"
         exit 1

--- a/test/driver
+++ b/test/driver
@@ -19,7 +19,7 @@ main() {
     cd "$HERE/case"
     local name_glob='*'
     [[ -n "$1" ]] && name_glob="$1"
-    cases=$(find . -type f -perm /111 -name "$name_glob" | sort)
+    cases=$(find . -type f -perm +111 -name "$name_glob" | sort)
     if [[ -z "$cases" ]]; then
         echo "No test cases found! Something is wrong!"
         exit 1

--- a/test/driver
+++ b/test/driver
@@ -50,10 +50,10 @@ main() {
 
     hr
     colorprint ${GREEN} "PASS: ${#_PASS[@]}"
-    /bin/echo -n "  "
+    printf "  "
     colorprint ${GREEN} ${_PASS[@]} | ${SED?} 's/ /\n  /g'
     colorprint ${RED} "FAIL: ${#_FAIL[@]}"
-    /bin/echo -n "  "
+    printf "  "
     colorprint ${RED} ${_FAIL[@]} | ${SED?} 's/ /\n  /g'
     hr
     if [[ ${#_FAIL[@]} -ne 0 ]]; then

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -37,7 +37,7 @@ fi
 colorprint() {
   color=$1
   shift
-  /bin/echo -e "${color}$@${RESET}"
+  printf "${color}%s${RESET}\n" "$*"
 }
 
 err() {


### PR DESCRIPTION
The fixes below were made with the assistance of Cursor:

- `find` support for GNU and BSD
- `mktemp` support for GNU and BSD
- Color escape sequence fixes so terminal output shows the expected colors
- Ensure `tag-check.sh` works even when there is no `master` branch ref in the checkout, as is the case in Konflux.