### PR TITLE
SREP-1227: Run `make pr-check` in a container via `make container-pr-check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 ALLOW_DIRTY_CHECKOUT?=false
-SKIP_IMAGE_TAG_CHECK?=false
 IMG?=boilerplate
 CONTAINER_ENGINE?=$(shell command -v podman 2>/dev/null || echo "docker")
 CHECKOUT=$(shell pwd)
@@ -14,14 +13,14 @@ isclean: ## Validate the local checkout is clean. Use ALLOW_DIRTY_CHECKOUT=true 
 
 .PHONY: test
 test: export GO_COMPLIANCE_INFO = 0
-test: isclean ## Runs tests under the /case directory
+test: ## Runs tests under the /case directory
 	test/driver $(CASE_GLOB)
 
 .PHONY: pr-check
 pr-check: test
 
 .PHONY: container-pr-check
-container-pr-check: build-image-deep
+container-pr-check: build-image-deep # Builds the boilerplate image from your local checkout, mounts boilerplate, then runs 'make pr-check' as it would run in Konflux.
 	$(CONTAINER_ENGINE) run --rm -it -v ${CHECKOUT}:/boilerplate:Z localhost/boilerplate:latest cd boilerplate && make pr-check
 
 .PHONY: subscriber-report

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ ALLOW_DIRTY_CHECKOUT?=false
 SKIP_IMAGE_TAG_CHECK?=false
 IMG?=boilerplate
 CONTAINER_ENGINE?=$(shell command -v podman 2>/dev/null || echo "docker")
+CHECKOUT=$(shell pwd)
 
 # Tests rely on this starting off unset. (And if it is set, it's usually
 # not for the reasons we care about.)
@@ -18,6 +19,10 @@ test: isclean ## Runs tests under the /case directory
 
 .PHONY: pr-check
 pr-check: test
+
+.PHONY: container-pr-check
+container-pr-check: build-image-deep
+	$(CONTAINER_ENGINE) run --rm -it -v ${CHECKOUT}:/boilerplate:Z localhost/boilerplate:latest cd boilerplate && make pr-check
 
 .PHONY: subscriber-report
 subscriber-report: ## Discover onboarding and prow status of subscribed consumers

--- a/README.md
+++ b/README.md
@@ -360,6 +360,10 @@ Test cases are executed by running `make test`. This must be done on a
 clean git repository; otherwise the tests will not be using your
 uncommitted changes.
 
+You can also run the tests within the context of the docker image this project creates.
+To do this, run `make container-pr-check`, which will build the `config/Dockerfile` image, then
+run `make pr-check` in that context.
+
 Add new test cases by creating executable files in the [test/case](test/case)
 subdirectory. These are discovered and executed in lexicographic order by
 `make test`. Your test case should exit zero to indicate success; nonzero to


### PR DESCRIPTION
Add a new make target that builds the container image then runs `make pr-check` inside it. This resolves issues with local dependencies being different versions than the ones used in CI, which can cause diffs in generated output for the tests.