### PR TITLE
Automate migrating FROM references in Dockerfile to ubi9

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -92,9 +92,18 @@ for file in $DOCKERFILES; do
     ${SED?} -i "1s,.*,FROM $IMAGE_PULL_PATH AS builder," $file
   fi
 
-  # Update any UBI images to use a versioned tag of ubi8/ubi-minimal that is compatible with dependabot
-  for ubi_latest in $(grep -oE 'registry.access.redhat.com/ubi[7-9]/ubi.*?:.*' ${file}); do
-      ubi_base=$(echo "$ubi_latest" | "${SED?}" -n 's|registry.access.redhat.com/\(ubi[0-9]/ubi[^:]*\):.*|\1|p')
+  # Update any UBI8 images to UBI9 first (before general UBI versioning)
+  for ubi8_image in $(grep -oE 'registry\.access\.redhat\.com/ubi8/ubi[^:]*:.*' ${file}); do
+      ubi8_base=$(echo "$ubi8_image" | "${SED?}" -n 's|registry\.access\.redhat\.com/\(ubi8/ubi[^:]*\):.*|\1|p')
+      ubi9_base=$(echo "$ubi8_base" | "${SED?}" 's|ubi8/|ubi9/|')
+      replacement_image=$(skopeo inspect --override-os linux --override-arch amd64 "docker://registry.access.redhat.com/${ubi9_base}" --format "{{.Name}}:{{.Labels.version}}-{{.Labels.release}}")
+      echo "Migrating ${file}'s ${ubi8_image} from UBI8 to UBI9: ${replacement_image}"
+      ${SED?} -i "s,${ubi8_image},${replacement_image}," ${file}
+  done
+
+  # Update any remaining UBI images to use a versioned tag (excluding UBI8 since we already migrated them)
+  for ubi_latest in $(grep -oE 'registry\.access\.redhat\.com/ubi[79]/ubi.*?:.*' ${file}); do
+      ubi_base=$(echo "$ubi_latest" | "${SED?}" -n 's|registry\.access\.redhat\.com/\(ubi[0-9]/ubi[^:]*\):.*|\1|p')
       replacement_image=$(skopeo inspect --override-os linux --override-arch amd64 "docker://registry.access.redhat.com/${ubi_base}" --format "{{.Name}}:{{.Labels.version}}-{{.Labels.release}}")
       echo "Overwriting ${file}'s ${ubi_latest} image to ${replacement_image}"
       ${SED?} -i "s,${ubi_latest},${replacement_image}," ${file}


### PR DESCRIPTION
With the switch to UBI9, any codebase that updates will have to ensure they are using ubi9 in their Dockerfiles. 

For example, since the first `FROM` in all operators is the boilerplate image (built with ubi9), if you use ubi8 in a later stage and `COPY --from builder`, binaries will fail to run due to things like GLIBC.

This just automates the migration for users.