### PR TITLE
Ensure consumers FROM statements in Dockerfiles are using ubi9

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -92,10 +92,12 @@ for file in $DOCKERFILES; do
     ${SED?} -i "1s,.*,FROM $IMAGE_PULL_PATH AS builder," $file
   fi
 
-  # Update any UBI images to use a versioned tag of ubi8/ubi-minimal that is compatible with dependabot
+  # Update any UBI images to use a versioned tag of ubi9/ubi-minimal that is compatible with dependabot.
+  # WARNING: The ubi version _must_ match the one that Boilerplate's image is built with. Update this if you change the
+  # base ubi version.
+  UBI_IMAGE_NAME="registry.access.redhat.com/ubi9/ubi-minimal"
   for ubi_latest in $(grep -oE 'registry.access.redhat.com/ubi[7-9]/ubi.*?:.*' ${file}); do
-      ubi_base=$(echo "$ubi_latest" | "${SED?}" -n 's|registry.access.redhat.com/\(ubi[0-9]/ubi[^:]*\):.*|\1|p')
-      replacement_image=$(skopeo inspect --override-os linux --override-arch amd64 "docker://registry.access.redhat.com/${ubi_base}" --format "{{.Name}}:{{.Labels.version}}-{{.Labels.release}}")
+      replacement_image=$(skopeo inspect --override-os linux --override-arch amd64 docker://${UBI_IMAGE_NAME} --format "{{.Name}}:{{.Labels.version}}-{{.Labels.release}}")
       echo "Overwriting ${file}'s ${ubi_latest} image to ${replacement_image}"
       ${SED?} -i "s,${ubi_latest},${replacement_image}," ${file}
   done


### PR DESCRIPTION
In https://github.com/openshift/boilerplate/commit/6b3d4fabac7ea7744a674957ab0e80dad4d41ddd we updated this logic to iterate `FROM` directives in a consuming projects `Dockerfile` and update the UBI tag to the latest for a given major version (7,8,9 etc).

Now that we have update boilerplate to UBI9, in hindsight, this logic existed to _force_ consumers to use the same UBI version that boilerplate expects. If they don't, compiled binaries will fail to run.

This reverts the above commit, while also adding some context as to how this is load bearing for the future.