### PR TITLE
pipelines/catalog-builder: drop SOURCE_ARTIFACT param

### DIFF
--- a/pipelines/catalog-builder/pipeline.yaml
+++ b/pipelines/catalog-builder/pipeline.yaml
@@ -336,8 +336,6 @@ spec:
       value: $(tasks.build-container.results.IMAGE_DIGEST)
     - name: image-url
       value: $(tasks.build-container.results.IMAGE_URL)
-    - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     runAfter:
     - build-container
     taskRef:


### PR DESCRIPTION
```
invalid result reference in pipeline task "fbc-fips-check": "SOURCE_ARTIFACT" is not a named result returned by pipeline task "prefetch-dependencies"
```