### PR TITLE
pipelines/catalog-builder: drop prefetch-dependencies

### DIFF
--- a/pipelines/catalog-builder/pipeline.yaml
+++ b/pipelines/catalog-builder/pipeline.yaml
@@ -152,26 +152,6 @@ spec:
       workspace: workspace
     - name: basic-auth
       workspace: git-auth
-  - name: prefetch-dependencies
-    params:
-    - name: input
-      value: 'true'
-    runAfter:
-    - clone-repository
-    taskRef:
-      params:
-      - name: name
-        value: prefetch-dependencies
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.2@sha256:848f4d5e592d6c145ba3575f52b88d65be95ad6fbba108b24ff79d766cf5d45d
-      - name: kind
-        value: task
-      resolver: bundles
-    workspaces:
-    - name: source
-      workspace: workspace
-    - name: git-basic-auth
-      workspace: git-auth
   - name: opm-get-bundle-version
     runAfter:
     - prefetch-dependencies


### PR DESCRIPTION
it shouldn't be needed since we are building the bundle (maybe bundler though?)

```
Error: InvalidInput: 1 validation error for user input
packages -> 0
  Input tag 'true' found using 'type' does not match any of the expected tags: 'bundler', 'cargo', 'generic', 'gomod', 'npm', 'pip', 'rpm', 'yarn'
```