### PR TITLE
pipelines/catalog-builder: runafter clone-repo

### DIFF
--- a/pipelines/catalog-builder/pipeline.yaml
+++ b/pipelines/catalog-builder/pipeline.yaml
@@ -154,7 +154,7 @@ spec:
       workspace: git-auth
   - name: opm-get-bundle-version
     runAfter:
-    - prefetch-dependencies
+    - clone-repository
     params:
     - name: bundle-image
       value: $(params.operator-bundle-image)


### PR DESCRIPTION
prefetch-dependencies task was dropped and this was missed