### PR TITLE
SREP-1552: Use latest 9.6 UBI tag, add support for GOTOOLCHAIN=auto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ subscriber-report: ## Discover onboarding and prow status of subscribed consumer
 
 .PHONY: build-image-deep
 build-image-deep: ## Builds the image from scratch, like appsre does. May require ALLOW_DIRTY_CHECKOUT=true if testing
-	$(CONTAINER_ENGINE) build -t $(IMG):latest -f config/Dockerfile .
+	$(CONTAINER_ENGINE) build --no-cache -t $(IMG):latest -f config/Dockerfile .
 
 .DEFAULT_GOAL := help
 .PHONY: help

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/konflux-ci/yq:latest AS yq
-FROM registry.redhat.io/ubi9:9.6-1751445649 AS builder
+FROM registry.redhat.io/ubi9:9.6 AS builder
 
 ARG GOCILINT_VERSION="2.0.2"
 ARG GOCILINT_SHA256SUM="89cc8a7810dc63b9a37900da03e37c3601caf46d42265d774e0f1a5d883d53e2"
@@ -19,7 +19,7 @@ RUN curl -L -o gh.tar.gz ${GH_LOCATION} && \
     tar xzf gh.tar.gz gh_${GH_VERSION}_linux_amd64/bin/gh && \
     mv gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin
 
-FROM registry.redhat.io/ubi9:9.6-1751445649
+FROM registry.redhat.io/ubi9:9.6
 
 RUN dnf -y install openssh-clients jq skopeo python3-pyyaml git go-toolset rsync && \
     dnf clean all && \
@@ -64,3 +64,6 @@ COPY LICENSE .
 # By setting a XDG_CACHE_HOME value we ensure GOCACHE works without having to customize/set it at
 # runtime. See https://pkg.go.dev/os#UserCacheDir
 ENV XDG_CACHE_HOME=/tmp
+
+# Allow consumers to set a 'toolchain' Go version in their go.mod
+ENV GOTOOLCHAIN=auto


### PR DESCRIPTION
As CVE remediation is a common pattern that requires boilerplate changes, enact a few things to make it a bit easier.

- Use the latest sha of the `9.6` UBI tag instead of a specific release. This way whenever we rebuild the image, we will get updated packages etc from the repo.
- Use `--no-cache` locally, since the Make target already implied that was the case (to ensure `dnf install` re-runs)
- Set `GOTOOLCHAIN=auto` to override the default of `local`. This means a project can define a `toolchain go1.yy.zz` value in `go.mod` and the BP image will honor that when building the operator.

Sample from `aws-account-operator`
```diff
diff --git a/build/Dockerfile b/build/Dockerfile
index a9422ad1..186e73e5 100644
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/redhat-services-prod/openshift/boilerplate:image-v8.0.0 AS builder
+FROM localhost/boilerplate AS builder

 ENV OPERATOR_PATH=/go/src/github.com/openshift/aws-account-operator
 ENV GO111MODULE=on
diff --git a/go.mod b/go.mod
index 0a7bedfb..e17237a3 100644
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/openshift/aws-account-operator

 go 1.24.4

+toolchain go1.24.5
+
 require (
        github.com/avast/retry-go v2.6.1+incompatible
        github.com/aws/aws-sdk-go v1.51.7
```

And generated image with `1.24.5` instead of `1.24.4` that comes with boilerplate
```
 ALLOW_DIRTY_CHECKOUT=true make docker-build
boilerplate/openshift/golang-osd-operator/standard.mk:107: Setting GOEXPERIMENT=boringcrypto - this generally causes builds to fail unless building inside the provided Dockerfile. If building locally consider calling 'go build .'
/opt/homebrew/bin/podman build --pull -f ./build/Dockerfile -t quay.io/app-sre/aws-account-operator:v0.1.1799-g005e36e .
[1/2] STEP 1/8: FROM localhost/boilerplate AS builder
[1/2] STEP 2/8: ENV OPERATOR_PATH=/go/src/github.com/openshift/aws-account-operator
--> efb0f821db22
[1/2] STEP 3/8: ENV GO111MODULE=on
--> 89d468eb831c
[1/2] STEP 4/8: ENV GOFLAGS=""
--> 972375bdc461
[1/2] STEP 5/8: ARG FIPS_ENABLED=true
--> a80f40778f65
[1/2] STEP 6/8: COPY . ${OPERATOR_PATH}
--> 2f75b49c3f19
[1/2] STEP 7/8: WORKDIR ${OPERATOR_PATH}
--> aec5e40fb1a6
[1/2] STEP 8/8: RUN make go-build FIPS_ENABLED=${FIPS_ENABLED}
boilerplate/openshift/golang-osd-operator/standard.mk:107: Setting GOEXPERIMENT=boringcrypto - this generally causes builds to fail unless building inside the provided Dockerfile. If building locally consider calling 'go build .'
go: downloading go1.24.5 (linux/arm64)
.....

 podman run --rm -it quay.io/app-sre/aws-account-operator:latest
[root@251dc3d2d9a0 ~]# aws-account-operator
***** Starting with FIPS crypto enabled *****
{"level":"info","ts":1755031891.5823777,"logger":"setup","msg":"Operator Version: 0.0.1"}
{"level":"info","ts":1755031891.5824037,"logger":"setup","msg":"Operator-sdk Version: 1.21"}
{"level":"info","ts":1755031891.5824087,"logger":"setup","msg":"Go Version: go1.24.5 X:boringcrypto"}
{"level":"info","ts":1755031891.5824125,"logger":"setup","msg":"Go OS/Arch: linux/arm64"}
{"level":"error","ts":1755031891.5825138,"logger":"controller-runtime.client.config","msg":"unable to get kubeconfig","error":"invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable","errorCauses":[{"error":"no configuration has been provided, try setting KUBERNETES_MASTER environment variable"}],"stacktrace":"sigs.k8s.io/controller-runtime/pkg/client/config.GetConfigOrDie\n\tpkg/mod/sigs.k8s.io/controller-runtime@v0.12.1/pkg/client/config/config.go:153\nmain.main\n\tsrc/github.com/openshift/aws-account-operator/main.go:101\nruntime.main\n\tpkg/mod/golang.org/toolchain@v0.0.1-go1.24.5.linux-arm64/src/runtime/proc.go:283"}
[root@251dc3d2d9a0 ~]# exit
exit
```
