### PR TITLE
Ensure the operator registry image uses consistent rhel versions

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/Dockerfile.olm-registry
+++ b/boilerplate/openshift/golang-osd-operator/Dockerfile.olm-registry
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/openshift4/ose-operator-registry:v4.14 AS builder
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19 AS builder
 ARG SAAS_OPERATOR_DIR
 COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive


### PR DESCRIPTION
We discovered that the previous UBI9 bumps didn't bump the base operator registry image, so we were using RHEL8 and then copying into RHEL9, which broke the catalog on FIPS clusters.