### PR TITLE
feat(renovate): set prow compatible rebaseLabel

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,5 +29,6 @@
     ]
   },
   "dependencyDashboard": true,
-  "semanticCommits": "enabled"
+  "semanticCommits": "enabled",
+  "rebaseLabel": "needs-rebase"
 }


### PR DESCRIPTION
Prow automatically applies this label when a PR can't be merged due to a
conflict, this teaches MintMaker/Renovate about that for when to rebase
a PR.

https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1758031732746159?thread_ts=1755650191.179509&cid=C04PZ7H0VA8

Signed-off-by: Brady Pratt <bpratt@redhat.com>
