### PR TITLE
Add CPU and memory resources to osde2e e2e-template

### DIFF
--- a/boilerplate/openshift/golang-osd-e2e/e2e-template.yml
+++ b/boilerplate/openshift/golang-osd-e2e/e2e-template.yml
@@ -56,6 +56,13 @@ objects:
                 - --skip-must-gather
                 - --configs
                 - ${OSDE2E_CONFIGS}
+              resources:
+                requests:
+                  cpu: "300m"
+                  memory: "600Mi"
+                limits:
+                  cpu: "1"
+                  memory: "1200Mi"
               securityContext:
                 runAsNonRoot: true
                 allowPrivilegeEscalation: false
@@ -85,4 +92,4 @@ objects:
                 - name: USE_EXISTING_CLUSTER
                   value: ${USE_EXISTING_CLUSTER}
                 - name: CAD_PAGERDUTY_ROUTING_KEY
-                  value: ${CAD_PAGERDUTY_ROUTING_KEY}                 
+                  value: ${CAD_PAGERDUTY_ROUTING_KEY}


### PR DESCRIPTION
Adds resource requests and limits to the osde2e container in the e2e-template config to ensure proper resource allocation and prevent resource contention in test environments.

**Changes**
- CPU: Request 300m, Limit 1 core
- Memory: Request 600Mi, Limit 1200Mi

[SDCICD-1426](https://issues.redhat.com/browse/SDCICD-1426)

**Fix** the alert:
```
Alert[0]: deployment_validation_operator_unset_cpu_requirements Validation error for osde2e: Indicates when containers do not have CPU requests and limits set.

Annotations:

dashboard = https://grafana.app-sre.devshift.net/d/dashdotdb/dash-db?orgId=1&var-datasource=dashdotdb-rds&var-cluster=hivei01ue1&var-namespace=e2e-testing
html_url = https://gitlab.cee.redhat.com/service/app-interface/blob/master/resources/services/deployment-validation-operator/prometheusrules-unset_cpu_requirements.yaml.j2
runbook = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
Labels:

alertname = deployment_validation_operator_unset_cpu_requirements
app = osde2e
check_description = Indicates when containers do not have CPU requests and limits set.
check_remediation = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
cluster = hivei01ue1
environment = integration
exported_namespace = e2e-testing
jiralert = SDCICD
kind = Job
name = osde2e-certman-operator-37ef1a5-654uvor
prometheus = openshift-customer-monitoring/app-sre
service = deployment-validation-operator
severity = medium
Source: [Prometheus](https://prometheus.hivei01ue1.devshift.net/graph?g0.expr=group+by+%28check_description%2C+check_remediation%2C+exported_namespace%2C+kind%2C+name%29+%28avg_over_time%28deployment_validation_operator_unset_cpu_requirements%7Bexported_namespace%3D%22e2e-testing%22%2Cname%21~%22%28%5B0-9a-z%5D%7B63%7D%7C.%2A-catalog-%5B0-9a-z%5D%7B5%7D%29%22%2Cname%21~%22skupper-.%2A%22%7D%5B1h%5D%29%29+%3E+0&g0.tab=1)

Alert[1]: deployment_validation_operator_unset_cpu_requirements Validation error for osde2e: Indicates when containers do not have CPU requests and limits set.

Annotations:

dashboard = https://grafana.app-sre.devshift.net/d/dashdotdb/dash-db?orgId=1&var-datasource=dashdotdb-rds&var-cluster=hivei01ue1&var-namespace=e2e-testing
html_url = https://gitlab.cee.redhat.com/service/app-interface/blob/master/resources/services/deployment-validation-operator/prometheusrules-unset_cpu_requirements.yaml.j2
runbook = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
Labels:

alertname = deployment_validation_operator_unset_cpu_requirements
app = osde2e
check_description = Indicates when containers do not have CPU requests and limits set.
check_remediation = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
cluster = hivei01ue1
environment = integration
exported_namespace = e2e-testing
jiralert = SDCICD
kind = Job
name = osde2e-cloud-ingress-operator-9586e13-kr42uc2
prometheus = openshift-customer-monitoring/app-sre
service = deployment-validation-operator
severity = medium
Source: [Prometheus](https://prometheus.hivei01ue1.devshift.net/graph?g0.expr=group+by+%28check_description%2C+check_remediation%2C+exported_namespace%2C+kind%2C+name%29+%28avg_over_time%28deployment_validation_operator_unset_cpu_requirements%7Bexported_namespace%3D%22e2e-testing%22%2Cname%21~%22%28%5B0-9a-z%5D%7B63%7D%7C.%2A-catalog-%5B0-9a-z%5D%7B5%7D%29%22%2Cname%21~%22skupper-.%2A%22%7D%5B1h%5D%29%29+%3E+0&g0.tab=1)

Alert[2]: deployment_validation_operator_unset_cpu_requirements Validation error for osde2e: Indicates when containers do not have CPU requests and limits set.

Annotations:

dashboard = https://grafana.app-sre.devshift.net/d/dashdotdb/dash-db?orgId=1&var-datasource=dashdotdb-rds&var-cluster=hivei01ue1&var-namespace=e2e-testing
html_url = https://gitlab.cee.redhat.com/service/app-interface/blob/master/resources/services/deployment-validation-operator/prometheusrules-unset_cpu_requirements.yaml.j2
runbook = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
Labels:

alertname = deployment_validation_operator_unset_cpu_requirements
app = osde2e
check_description = Indicates when containers do not have CPU requests and limits set.
check_remediation = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
cluster = hivei01ue1
environment = integration
exported_namespace = e2e-testing
jiralert = SDCICD
kind = Job
name = osde2e-cloud-ingress-operator-9586e13-rssxasd
prometheus = openshift-customer-monitoring/app-sre
service = deployment-validation-operator
severity = medium
Source: [Prometheus](https://prometheus.hivei01ue1.devshift.net/graph?g0.expr=group+by+%28check_description%2C+check_remediation%2C+exported_namespace%2C+kind%2C+name%29+%28avg_over_time%28deployment_validation_operator_unset_cpu_requirements%7Bexported_namespace%3D%22e2e-testing%22%2Cname%21~%22%28%5B0-9a-z%5D%7B63%7D%7C.%2A-catalog-%5B0-9a-z%5D%7B5%7D%29%22%2Cname%21~%22skupper-.%2A%22%7D%5B1h%5D%29%29+%3E+0&g0.tab=1)

Alert[3]: deployment_validation_operator_unset_cpu_requirements Validation error for osde2e: Indicates when containers do not have CPU requests and limits set.

Annotations:

dashboard = https://grafana.app-sre.devshift.net/d/dashdotdb/dash-db?orgId=1&var-datasource=dashdotdb-rds&var-cluster=hivei01ue1&var-namespace=e2e-testing
html_url = https://gitlab.cee.redhat.com/service/app-interface/blob/master/resources/services/deployment-validation-operator/prometheusrules-unset_cpu_requirements.yaml.j2
runbook = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
Labels:

alertname = deployment_validation_operator_unset_cpu_requirements
app = osde2e
check_description = Indicates when containers do not have CPU requests and limits set.
check_remediation = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
cluster = hivei01ue1
environment = integration
exported_namespace = e2e-testing
jiralert = SDCICD
kind = Job
name = osde2e-configure-alertmanager-operator-7f3e820-pfdbh6x
prometheus = openshift-customer-monitoring/app-sre
service = deployment-validation-operator
severity = medium
Source: [Prometheus](https://prometheus.hivei01ue1.devshift.net/graph?g0.expr=group+by+%28check_description%2C+check_remediation%2C+exported_namespace%2C+kind%2C+name%29+%28avg_over_time%28deployment_validation_operator_unset_cpu_requirements%7Bexported_namespace%3D%22e2e-testing%22%2Cname%21~%22%28%5B0-9a-z%5D%7B63%7D%7C.%2A-catalog-%5B0-9a-z%5D%7B5%7D%29%22%2Cname%21~%22skupper-.%2A%22%7D%5B1h%5D%29%29+%3E+0&g0.tab=1)

Alert[4]: deployment_validation_operator_unset_cpu_requirements Validation error for osde2e: Indicates when containers do not have CPU requests and limits set.

Annotations:

dashboard = https://grafana.app-sre.devshift.net/d/dashdotdb/dash-db?orgId=1&var-datasource=dashdotdb-rds&var-cluster=hivei01ue1&var-namespace=e2e-testing
html_url = https://gitlab.cee.redhat.com/service/app-interface/blob/master/resources/services/deployment-validation-operator/prometheusrules-unset_cpu_requirements.yaml.j2
runbook = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
Labels:

alertname = deployment_validation_operator_unset_cpu_requirements
app = osde2e
check_description = Indicates when containers do not have CPU requests and limits set.
check_remediation = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
cluster = hivei01ue1
environment = integration
exported_namespace = e2e-testing
jiralert = SDCICD
kind = Job
name = osde2e-custom-domains-operator-02ac4c6-rkonuy4
prometheus = openshift-customer-monitoring/app-sre
service = deployment-validation-operator
severity = medium
Source: [Prometheus](https://prometheus.hivei01ue1.devshift.net/graph?g0.expr=group+by+%28check_description%2C+check_remediation%2C+exported_namespace%2C+kind%2C+name%29+%28avg_over_time%28deployment_validation_operator_unset_cpu_requirements%7Bexported_namespace%3D%22e2e-testing%22%2Cname%21~%22%28%5B0-9a-z%5D%7B63%7D%7C.%2A-catalog-%5B0-9a-z%5D%7B5%7D%29%22%2Cname%21~%22skupper-.%2A%22%7D%5B1h%5D%29%29+%3E+0&g0.tab=1)

Alert[5]: deployment_validation_operator_unset_cpu_requirements Validation error for osde2e: Indicates when containers do not have CPU requests and limits set.

Annotations:

dashboard = https://grafana.app-sre.devshift.net/d/dashdotdb/dash-db?orgId=1&var-datasource=dashdotdb-rds&var-cluster=hivei01ue1&var-namespace=e2e-testing
html_url = https://gitlab.cee.redhat.com/service/app-interface/blob/master/resources/services/deployment-validation-operator/prometheusrules-unset_cpu_requirements.yaml.j2
runbook = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
Labels:

alertname = deployment_validation_operator_unset_cpu_requirements
app = osde2e
check_description = Indicates when containers do not have CPU requests and limits set.
check_remediation = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
cluster = hivei01ue1
environment = integration
exported_namespace = e2e-testing
jiralert = SDCICD
kind = Job
name = osde2e-managed-node-metadata-operator-82b5e1e-14uc6rc
prometheus = openshift-customer-monitoring/app-sre
service = deployment-validation-operator
severity = medium
Source: [Prometheus](https://prometheus.hivei01ue1.devshift.net/graph?g0.expr=group+by+%28check_description%2C+check_remediation%2C+exported_namespace%2C+kind%2C+name%29+%28avg_over_time%28deployment_validation_operator_unset_cpu_requirements%7Bexported_namespace%3D%22e2e-testing%22%2Cname%21~%22%28%5B0-9a-z%5D%7B63%7D%7C.%2A-catalog-%5B0-9a-z%5D%7B5%7D%29%22%2Cname%21~%22skupper-.%2A%22%7D%5B1h%5D%29%29+%3E+0&g0.tab=1)

Alert[6]: deployment_validation_operator_unset_cpu_requirements Validation error for osde2e: Indicates when containers do not have CPU requests and limits set.

Annotations:

dashboard = https://grafana.app-sre.devshift.net/d/dashdotdb/dash-db?orgId=1&var-datasource=dashdotdb-rds&var-cluster=hivei01ue1&var-namespace=e2e-testing
html_url = https://gitlab.cee.redhat.com/service/app-interface/blob/master/resources/services/deployment-validation-operator/prometheusrules-unset_cpu_requirements.yaml.j2
runbook = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
Labels:

alertname = deployment_validation_operator_unset_cpu_requirements
app = osde2e
check_description = Indicates when containers do not have CPU requests and limits set.
check_remediation = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
cluster = hivei01ue1
environment = integration
exported_namespace = e2e-testing
jiralert = SDCICD
kind = Job
name = osde2e-managed-upgrade-operator-e922e64-ppjbw2s
prometheus = openshift-customer-monitoring/app-sre
service = deployment-validation-operator
severity = medium
Source: [Prometheus](https://prometheus.hivei01ue1.devshift.net/graph?g0.expr=group+by+%28check_description%2C+check_remediation%2C+exported_namespace%2C+kind%2C+name%29+%28avg_over_time%28deployment_validation_operator_unset_cpu_requirements%7Bexported_namespace%3D%22e2e-testing%22%2Cname%21~%22%28%5B0-9a-z%5D%7B63%7D%7C.%2A-catalog-%5B0-9a-z%5D%7B5%7D%29%22%2Cname%21~%22skupper-.%2A%22%7D%5B1h%5D%29%29+%3E+0&g0.tab=1)

Alert[7]: deployment_validation_operator_unset_cpu_requirements Validation error for osde2e: Indicates when containers do not have CPU requests and limits set.

Annotations:

dashboard = https://grafana.app-sre.devshift.net/d/dashdotdb/dash-db?orgId=1&var-datasource=dashdotdb-rds&var-cluster=hivei01ue1&var-namespace=e2e-testing
html_url = https://gitlab.cee.redhat.com/service/app-interface/blob/master/resources/services/deployment-validation-operator/prometheusrules-unset_cpu_requirements.yaml.j2
runbook = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
Labels:

alertname = deployment_validation_operator_unset_cpu_requirements
app = osde2e
check_description = Indicates when containers do not have CPU requests and limits set.
check_remediation = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
cluster = hivei01ue1
environment = integration
exported_namespace = e2e-testing
jiralert = SDCICD
kind = Job
name = osde2e-must-gather-operator-767d484-m1sagmf
prometheus = openshift-customer-monitoring/app-sre
service = deployment-validation-operator
severity = medium
Source: [Prometheus](https://prometheus.hivei01ue1.devshift.net/graph?g0.expr=group+by+%28check_description%2C+check_remediation%2C+exported_namespace%2C+kind%2C+name%29+%28avg_over_time%28deployment_validation_operator_unset_cpu_requirements%7Bexported_namespace%3D%22e2e-testing%22%2Cname%21~%22%28%5B0-9a-z%5D%7B63%7D%7C.%2A-catalog-%5B0-9a-z%5D%7B5%7D%29%22%2Cname%21~%22skupper-.%2A%22%7D%5B1h%5D%29%29+%3E+0&g0.tab=1)

Alert[8]: deployment_validation_operator_unset_cpu_requirements Validation error for osde2e: Indicates when containers do not have CPU requests and limits set.

Annotations:

dashboard = https://grafana.app-sre.devshift.net/d/dashdotdb/dash-db?orgId=1&var-datasource=dashdotdb-rds&var-cluster=hivei01ue1&var-namespace=e2e-testing
html_url = https://gitlab.cee.redhat.com/service/app-interface/blob/master/resources/services/deployment-validation-operator/prometheusrules-unset_cpu_requirements.yaml.j2
runbook = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
Labels:

alertname = deployment_validation_operator_unset_cpu_requirements
app = osde2e
check_description = Indicates when containers do not have CPU requests and limits set.
check_remediation = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
cluster = hivei01ue1
environment = integration
exported_namespace = e2e-testing
jiralert = SDCICD
kind = Job
name = osde2e-ocm-agent-de6d7ff-myhdt07
prometheus = openshift-customer-monitoring/app-sre
service = deployment-validation-operator
severity = medium
Source: [Prometheus](https://prometheus.hivei01ue1.devshift.net/graph?g0.expr=group+by+%28check_description%2C+check_remediation%2C+exported_namespace%2C+kind%2C+name%29+%28avg_over_time%28deployment_validation_operator_unset_cpu_requirements%7Bexported_namespace%3D%22e2e-testing%22%2Cname%21~%22%28%5B0-9a-z%5D%7B63%7D%7C.%2A-catalog-%5B0-9a-z%5D%7B5%7D%29%22%2Cname%21~%22skupper-.%2A%22%7D%5B1h%5D%29%29+%3E+0&g0.tab=1)

Alert[9]: deployment_validation_operator_unset_cpu_requirements Validation error for osde2e: Indicates when containers do not have CPU requests and limits set.

Annotations:

dashboard = https://grafana.app-sre.devshift.net/d/dashdotdb/dash-db?orgId=1&var-datasource=dashdotdb-rds&var-cluster=hivei01ue1&var-namespace=e2e-testing
html_url = https://gitlab.cee.redhat.com/service/app-interface/blob/master/resources/services/deployment-validation-operator/prometheusrules-unset_cpu_requirements.yaml.j2
runbook = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
Labels:

alertname = deployment_validation_operator_unset_cpu_requirements
app = osde2e
check_description = Indicates when containers do not have CPU requests and limits set.
check_remediation = Set CPU requests and limits for your container based on its requirements. Refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits for details.
cluster = hivei01ue1
environment = integration
exported_namespace = e2e-testing
jiralert = SDCICD
kind = Job
name = osde2e-ocm-agent-operator-61e569b-b27koor
prometheus = openshift-customer-monitoring/app-sre
service = deployment-validation-operator
severity = medium
```
