### PR TITLE
Auto-install kubectl-package via ensure.sh

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/ensure.sh
+++ b/boilerplate/openshift/golang-osd-operator/ensure.sh
@@ -31,6 +31,23 @@ golangci-lint)
     fi
     ;;
 
+kubectl-package)
+    KUBECTL_PACKAGE_VERSION="v1.18.6"
+    GOPATH=$(go env GOPATH)
+    if which kubectl-package ; then
+        exit
+    else
+        mkdir -p "${GOPATH}/bin"
+        if ! echo "${PATH}" | grep -q "${GOPATH}/bin"; then
+            echo "${GOPATH}/bin not in $PATH"
+            exit 1
+        fi
+        DOWNLOAD_URL="https://github.com/package-operator/package-operator/releases/download/${KUBECTL_PACKAGE_VERSION}/kubectl-package_${GOOS}_amd64"
+        curl -sfL "${DOWNLOAD_URL}" -o "${GOPATH}/bin/kubectl-package"
+        chmod +x "${GOPATH}/bin/kubectl-package"
+    fi
+    ;;
+
 opm)
     mkdir -p .opm/bin
     cd .opm/bin

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -315,12 +315,7 @@ prow-config:
 .PHONY: validate-pko-fixtures
 validate-pko-fixtures:
 	@if [ -d deploy_pko ] && grep -q '^test:' deploy_pko/manifest.yaml 2>/dev/null; then \
-		if ! command -v kubectl-package >/dev/null 2>&1; then \
-			echo "ERROR: kubectl-package is not installed." >&2; \
-			echo "Install it from: https://github.com/package-operator/package-operator/releases" >&2; \
-			echo "Example: curl -L -o /usr/local/bin/kubectl-package https://github.com/package-operator/package-operator/releases/download/v1.18.6/kubectl-package_linux_amd64 && chmod +x /usr/local/bin/kubectl-package" >&2; \
-			exit 1; \
-		fi; \
+		${CONVENTION_DIR}/ensure.sh kubectl-package; \
 		echo "Validating PKO package fixtures..."; \
 		kubectl-package validate deploy_pko/ || \
 			(echo "ERROR: PKO fixture validation failed. Rendered templates do not match committed fixtures." >&2; \
@@ -357,12 +352,7 @@ validate-pko-fixtures:
 .PHONY: generate-pko-fixtures
 generate-pko-fixtures:
 	@if [ -d deploy_pko ] && grep -q '^test:' deploy_pko/manifest.yaml 2>/dev/null; then \
-		if ! command -v kubectl-package >/dev/null 2>&1; then \
-			echo "ERROR: kubectl-package is not installed." >&2; \
-			echo "Install it from: https://github.com/package-operator/package-operator/releases" >&2; \
-			echo "Example: curl -L -o /usr/local/bin/kubectl-package https://github.com/package-operator/package-operator/releases/download/v1.18.6/kubectl-package_linux_amd64 && chmod +x /usr/local/bin/kubectl-package" >&2; \
-			exit 1; \
-		fi; \
+		${CONVENTION_DIR}/ensure.sh kubectl-package; \
 		echo "Regenerating PKO test fixtures..."; \
 		rm -rf deploy_pko/.test-fixtures; \
 		kubectl-package validate deploy_pko/ && \


### PR DESCRIPTION
## Summary
- Add `kubectl-package` case to `ensure.sh` following the `golangci-lint` pattern
- Replace manual error blocks in `validate-pko-fixtures` and `generate-pko-fixtures` with `ensure.sh kubectl-package` calls
- Unblocks Prow CI on boilerplate image tags that predate `kubectl-package` inclusion

## Context
PR #709 added `kubectl-package` to the boilerplate container image and wired `validate-pko-fixtures` into `make validate`. However, Prow CI still uses `image-v8.3.4` (tagged before #709), so repos consuming the new make targets fail with `ERROR: kubectl-package is not installed`. Auto-installing via `ensure.sh` removes the dependency on the container image version.

## Test plan
- [ ] Prow `validate` target passes on a repo with PKO test fixtures (e.g., deadmanssnitch-operator)
- [ ] `make validate-pko-fixtures` still works when `kubectl-package` is already on `$PATH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)