### PR TITLE
SREP-4482: Update golangci-lint configuration with enhanced linters

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/golangci.yml
+++ b/boilerplate/openshift/golang-osd-operator/golangci.yml
@@ -1,39 +1,71 @@
 version: "2"
-run:
-  concurrency: 10
+
 linters:
-  default: none
   enable:
+    # Critical: Error Handling & Security
     - errcheck
-    - gosec
     - govet
-    - ineffassign
-    - misspell
     - staticcheck
+    - gosec
+    - bodyclose
+    - sqlclosecheck
+    - contextcheck
+    - noctx
+
+    # High: Error Prevention
+    - errorlint
+    - nilerr
+    - nilnil
+    - revive
+
+    # Medium: Code Quality
+    - ineffassign
+    - unconvert
+    - unparam
     - unused
+    - misspell
+
+    # Optional: Maintainability
+    - prealloc
+    - nolintlint
+    - gocyclo
+    - dupl
+    - exhaustive
+    - makezero
+    - containedctx
+
   settings:
+    revive:
+      rules:
+        - name: package-comments
+          disabled: true
+
+    errcheck:
+      check-type-assertions: true
+      check-blank: false
+      disable-default-exclusions: true
+
+    gocyclo:
+      min-complexity: 15
+
+    errorlint:
+      errorf: true
+      asserts: true
+      comparison: true
+
     misspell:
       extra-words:
         - typo: openshit
           correction: OpenShift
-  exclusions:
-    generated: lax
-    presets:
-      - comments
-      - common-false-positives
-      - legacy
-      - std-error-handling
-    paths:
-      - third_party/
-      - builtin/
-      - examples/
+
+run:
+  timeout: 5m
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-formatters:
-  exclusions:
-    generated: lax
-    paths:
-      - third_party/
-      - builtin/
-      - examples/


### PR DESCRIPTION
Based on the agreed golden standard for golangci.yml which can be used by all the agents & developers, enhance the golangci-lint configuration to include a more comprehensive set of linters organized by priority (Critical, High, Medium, Optional) with appropriate settings for error handling, security, and code quality checks.

Related to [SREP-4482](https://redhat.atlassian.net/browse/SREP-4482)

[SREP-4482]: https://redhat.atlassian.net/browse/SREP-4482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ