### PR TITLE
Bump ubi9.7 base to get go1.25.8

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/konflux-ci/yq:latest AS yq
-FROM registry.access.redhat.com/ubi9:9.7-1771346757 AS builder
+FROM registry.access.redhat.com/ubi9:9.7-1776833838 AS builder
 
 ARG GOCILINT_VERSION="2.7.2"
 ARG GOCILINT_SHA256SUM="ce46a1f1d890e7b667259f70bb236297f5cf8791a9b6b98b41b283d93b5b6e88"
@@ -28,7 +28,7 @@ RUN curl -L -o kubectl-package ${KUBECTL_PACKAGE_LOCATION} && \
     chmod +x kubectl-package && \
     mv kubectl-package /usr/local/bin
 
-FROM registry.access.redhat.com/ubi9:9.7-1771346757
+FROM registry.access.redhat.com/ubi9:9.7-1776833838
 
 RUN dnf -y install openssh-clients jq skopeo python3-pyyaml git go-toolset rsync && \
     dnf clean all && \

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/konflux-ci/yq:latest AS yq
-FROM registry.access.redhat.com/ubi9:9.7-1776833838 AS builder
+FROM registry.access.redhat.com/ubi9:9.7-1776834047 AS builder
 
 ARG GOCILINT_VERSION="2.7.2"
 ARG GOCILINT_SHA256SUM="ce46a1f1d890e7b667259f70bb236297f5cf8791a9b6b98b41b283d93b5b6e88"
@@ -28,7 +28,7 @@ RUN curl -L -o kubectl-package ${KUBECTL_PACKAGE_LOCATION} && \
     chmod +x kubectl-package && \
     mv kubectl-package /usr/local/bin
 
-FROM registry.access.redhat.com/ubi9:9.7-1776833838
+FROM registry.access.redhat.com/ubi9:9.7-1776834047
 
 RUN dnf -y install openssh-clients jq skopeo python3-pyyaml git go-toolset rsync && \
     dnf clean all && \


### PR DESCRIPTION
This specific bump gives us Go 1.25.5, which is needed for CVE remediation.

```
% podman run -it registry.access.redhat.com/ubi9:9.7-1776834047  /bin/bash
[ /]# yum install go-toolset -y
[ /]# go version
go version go1.25.8 (Red Hat 1.25.8-1.el9_7) linux/arm64
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker base image to a newer version, improving the underlying runtime environment and tools available in the build and runtime stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->