### PR TITLE
SREP-4484: Enable Codecov Enforcement

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/.codecov.yml
+++ b/boilerplate/openshift/golang-osd-operator/.codecov.yml
@@ -8,8 +8,14 @@ coverage:
   range: "20...100"
 
   status:
-    project: no
-    patch: no
+    project:
+      default:
+        target: 50%
+        threshold: 1%
+    patch:
+      default:
+        target: 50%
+        threshold: 1%
     changes: no
 
 parsers:

--- a/boilerplate/openshift/golang-osd-operator/.codecov.yml
+++ b/boilerplate/openshift/golang-osd-operator/.codecov.yml
@@ -14,8 +14,8 @@ coverage:
         threshold: 1%
     patch:
       default:
-        target: 60%
-        threshold: 5%
+        target: 50%
+        threshold: 1%
     changes: no
 
 parsers:

--- a/boilerplate/openshift/golang-osd-operator/.codecov.yml
+++ b/boilerplate/openshift/golang-osd-operator/.codecov.yml
@@ -10,12 +10,12 @@ coverage:
   status:
     project:
       default:
-        target: 50%
+        target: 35%
         threshold: 1%
     patch:
       default:
-        target: 50%
-        threshold: 1%
+        target: 60%
+        threshold: 5%
     changes: no
 
 parsers:


### PR DESCRIPTION
As a part of [SREP-4484](https://redhat.atlassian.net/browse/SREP-4484), Enable and configure codecov status checks with coverage thresholds

[SREP-4484]: https://redhat.atlassian.net/browse/SREP-4484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ