### PR TITLE
Remove myself from OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,7 +4,6 @@
 # =============================================================================
 aliases:
   srep-functional-team-aurora:
-    - abyrne55
     - AlexSmithGH
     - dakotalongRH
     - eth1030
@@ -73,7 +72,6 @@ aliases:
     - yiqinzhang
     - varunraokadaparthi
   srep-functional-leads:
-    - abyrne55
     - clcollins
     - bergmannf
     - theautoroboto


### PR DESCRIPTION
Removed 'abyrne55' from srep-functional-team-aurora and srep-functional-leads aliases.

Cheers, y'all!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated team ownership configuration by modifying alias group memberships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->