### PR TITLE
Minor fixes for pre-commit hooks and Lint

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/golangci.yml
+++ b/boilerplate/openshift/golang-osd-operator/golangci.yml
@@ -2,7 +2,7 @@ version: "2"
 
 linters:
   enable:
-    # Critical: Error Handling & Security
+    # Error Handling & Security
     - errcheck
     - govet
     - staticcheck
@@ -12,24 +12,23 @@ linters:
     - contextcheck
     - noctx
 
-    # High: Error Prevention
+    # Error Prevention
     - errorlint
     - nilerr
     - nilnil
     - revive
 
-    # Medium: Code Quality
+    # Code Quality
     - ineffassign
     - unconvert
     - unparam
     - unused
     - misspell
 
-    # Optional: Maintainability
+    # Maintainability
     - prealloc
     - nolintlint
     - gocyclo
-    - dupl
     - exhaustive
     - makezero
     - containedctx

--- a/boilerplate/openshift/golang-osd-operator/pre-commit-config.yaml
+++ b/boilerplate/openshift/golang-osd-operator/pre-commit-config.yaml
@@ -115,7 +115,8 @@ repos:
         name: go mod tidy
         language: system
         entry: bash -c 'T=$(command -v timeout || command -v gtimeout || echo); ${T:+$T 60s} go mod tidy && git diff --exit-code go.mod go.sum'
-        files: go\.(mod|sum)$
+        files: '(\.go$|go\.(mod|sum)$)'
+        exclude: '^vendor/'
         pass_filenames: false
 
       # -----------------------------------------------------------------------


### PR DESCRIPTION
1. Updates Pre-Commit hook based on the comment https://github.com/openshift/ocm-agent-operator/pull/251#discussion_r3186952228
2. Removes `dupl` from linters since test cases uses the dupl and it is acceptable for test cases