### PR TITLE
Update UBI9 base image to 9.7-1778044007 for Go 1.25.9

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/konflux-ci/yq:latest AS yq
-FROM registry.access.redhat.com/ubi9:9.7-1776834047 AS builder
+FROM registry.access.redhat.com/ubi9:9.7-1778044007 AS builder
 
 ARG GOCILINT_VERSION="2.7.2"
 ARG GOCILINT_SHA256SUM="ce46a1f1d890e7b667259f70bb236297f5cf8791a9b6b98b41b283d93b5b6e88"
@@ -28,7 +28,7 @@ RUN curl -L -o kubectl-package ${KUBECTL_PACKAGE_LOCATION} && \
     chmod +x kubectl-package && \
     mv kubectl-package /usr/local/bin
 
-FROM registry.access.redhat.com/ubi9:9.7-1776834047
+FROM registry.access.redhat.com/ubi9:9.7-1778044007
 
 RUN dnf -y install openssh-clients jq skopeo python3-pyyaml git go-toolset rsync && \
     dnf clean all && \


### PR DESCRIPTION
## Summary
Updates UBI9 base image from `9.7-1776834047` to `9.7-1778044007` to get Go 1.25.9 support in the boilerplate builder image.

## Motivation
Downstream projects (aws-account-operator, others) need Go 1.25.9 to fix critical stdlib security vulnerabilities:
- CVE-2026-27143 (Critical)
- CVE-2026-25679 (High) 
- CVE-2026-27140 (High)
- CVE-2026-27144 (High)
- CVE-2026-32280 (High)
- CVE-2026-32281 (High)
- CVE-2026-32283 (High)
- CVE-2026-27142 (Medium)
- CVE-2026-32282 (Medium)
- CVE-2026-32288 (Medium)
- CVE-2026-32289 (Medium)
- CVE-2026-27139 (Low)

Part of May 2026 security vulnerability mitigation effort (target: 2026-05-22).

## Changes
- Updated `config/Dockerfile` builder stage: `registry.access.redhat.com/ubi9:9.7-1778044007`
- Updated `config/Dockerfile` final stage: `registry.access.redhat.com/ubi9:9.7-1778044007`

## Verification
Build output confirms new image includes:
- `go-toolset-1.25.9-1.el9_7.x86_64.rpm`
- `golang-1.25.9-1.el9_7.x86_64.rpm`
- `golang-bin-1.25.9-1.el9_7.x86_64.rpm`

Related: openshift/aws-account-operator#979