### PR TITLE
[ROSAENG-692] Added a fix that was blocking my work on a repo that uses boilerplate.

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/fips.go.tmplt
+++ b/boilerplate/openshift/golang-osd-operator/fips.go.tmplt
@@ -12,5 +12,5 @@ import (
 )
 
 func init() {
-	fmt.Println("***** Starting with FIPS crypto enabled *****")
+	_, _ = fmt.Println("***** Starting with FIPS crypto enabled *****")
 }


### PR DESCRIPTION
The new golangci-lint config now flags all functions that silently ignore errors.