### PR TITLE
Update lint to run on new changes only

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/golangci.yml
+++ b/boilerplate/openshift/golang-osd-operator/golangci.yml
@@ -59,6 +59,11 @@ linters:
 
 run:
   timeout: 5m
+  # Only check new code, not existing issues
+  # This uses git to compare against the base branch (typically master/main)
+  new: true
+  # Alternatively, you can specify a specific revision:
+  # new-from-rev: origin/master
 
 formatters:
   enable:


### PR DESCRIPTION
Ensuring changes from https://github.com/openshift/boilerplate/pull/716 does not affect old code