### PR TITLE
Add geowa4 to OWNERS approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,6 +7,7 @@ aliases:
     - AlexSmithGH
     - dakotalongRH
     - eth1030
+    - geowa4
     - joshbranham
     - luis-falcon
     - reedcort


### PR DESCRIPTION
## Summary
- Add geowa4 to the approvers list in OWNERS so they can approve PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated team ownership configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->