### PR TITLE
Re-enable std-error-handling exclusion for golang-osd-operator lint

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/golangci.yml
+++ b/boilerplate/openshift/golang-osd-operator/golangci.yml
@@ -42,7 +42,10 @@ linters:
     errcheck:
       check-type-assertions: true
       check-blank: false
-      disable-default-exclusions: true
+
+  exclusions:
+    presets:
+      - std-error-handling
 
     gocyclo:
       min-complexity: 15


### PR DESCRIPTION
Recent updates to the `golang-osd-operator`'s golangci config removed the std-error-handling exclusion preset, causing errcheck to flag unchecked return values from standard library functions like `fmt.Printf` and `fmt.Println`. 

The golang-lint convention already includes this preset. Also removes disable-default-exclusions which was redundant with the explicit preset.

🤖 Generated with Claude Code (https://claude.ai/claude-code) 