### PR TITLE
Fix incremental linting for enhanced golangci config

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/golangci.yml
+++ b/boilerplate/openshift/golang-osd-operator/golangci.yml
@@ -62,11 +62,9 @@ linters:
 
 run:
   timeout: 5m
-  # Only check new code, not existing issues
-  # This uses git to compare against the base branch (typically master/main)
-  new: true
-  # Alternatively, you can specify a specific revision:
-  # new-from-rev: origin/master
+  # Incremental linting (new-from-rev) is passed via the Makefile's
+  # go-check target. In CI it uses PULL_BASE_SHA (guaranteed to exist
+  # even in shallow clones); locally it falls back to origin/HEAD.
 
 formatters:
   enable:

--- a/boilerplate/openshift/golang-osd-operator/standard.mk
+++ b/boilerplate/openshift/golang-osd-operator/standard.mk
@@ -172,10 +172,19 @@ docker-login:
 	mkdir -p ${CONTAINER_ENGINE_CONFIG_DIR}
 	@${CONTAINER_ENGINE} login -u="${REGISTRY_USER}" -p="${REGISTRY_TOKEN}" quay.io
 
+# Only lint new/changed code. In Prow CI, PULL_BASE_SHA points to the
+# base commit and is guaranteed to exist in the checkout (even shallow
+# clones). Locally, fall back to the default branch ref.
+ifdef PULL_BASE_SHA
+LINT_NEW_FROM_REV := $(PULL_BASE_SHA)
+else
+LINT_NEW_FROM_REV := $(shell git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/||')
+endif
+
 .PHONY: go-check
 go-check: ## Golang linting and other static analysis
 	${CONVENTION_DIR}/ensure.sh golangci-lint
-	${GOENV} GOLANGCI_LINT_CACHE=${GOLANGCI_LINT_CACHE} golangci-lint run -c ${CONVENTION_DIR}/golangci.yml ./...
+	${GOENV} GOLANGCI_LINT_CACHE=${GOLANGCI_LINT_CACHE} golangci-lint run -c ${CONVENTION_DIR}/golangci.yml $(if $(LINT_NEW_FROM_REV),--new-from-rev=$(LINT_NEW_FROM_REV)) ./...
 
 .PHONY: go-generate
 go-generate:


### PR DESCRIPTION
The enhanced golangci-lint config added in d83e5ee uses `new: true` to only lint new code, but this silently falls back to linting everything in CI shallow clones where the required git history is unavailable (see golangci/golangci-lint#4180). This breaks `ci/prow/lint` across all consumer repos on boilerplate update.

Both `new: true` and `new-from-rev` in the YAML config have this same problem — they rely on git history that shallow clones don't provide, and golangci-lint silently falls back to linting the entire codebase.

**Fix:** Pass `--new-from-rev` via `standard.mk`'s `go-check` target using a ref that's guaranteed to exist:
- In Prow CI, use `PULL_BASE_SHA` (always present and valid, even in shallow clones)
- Locally, fall back to `origin/HEAD` via `git symbolic-ref`