### PR TITLE
SREP-4417: Add Containerfile.prow to golang-osd-e2e convention

### DIFF
--- a/boilerplate/openshift/golang-osd-e2e/update
+++ b/boilerplate/openshift/golang-osd-e2e/update
@@ -39,6 +39,24 @@ COPY --from=builder ./e2e.test e2e.test
 ENTRYPOINT [ "/e2e.test" ]
 EOF
 
+if [ ! -f "${E2E_SUITE_DIRECTORY}/Containerfile.prow" ]; then
+	echo "creating ${E2E_SUITE_DIRECTORY}/Containerfile.prow"
+	tee "${E2E_SUITE_DIRECTORY}/Containerfile.prow" <<EOF
+FROM ${E2E_SUITE_BUILDER_IMAGE} AS builder
+
+WORKDIR /build
+ENV GOFLAGS=""
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go test ./test/e2e -v -c --tags=osde2e -o /e2e.test
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+COPY --from=builder /e2e.test /usr/local/bin/e2e.test
+EOF
+fi
+
 if [ ! -f "${E2E_SUITE_DIRECTORY}/${OPERATOR_UNDERSCORE_NAME}_tests.go" ]; then
 	echo "syncing ${E2E_SUITE_DIRECTORY}/${OPERATOR_UNDERSCORE_NAME}_tests.go"
 	tee "${E2E_SUITE_DIRECTORY}/${OPERATOR_UNDERSCORE_NAME}_tests.go" <<EOF


### PR DESCRIPTION
## Summary

- Add `Containerfile.prow` generation to the `golang-osd-e2e` convention
- Uses the same builder image as the existing `Dockerfile` but targets `rosa-aws-cli` as the runtime base
- Gives the e2e binary access to `rosa`, `ocm`, `oc`, and `aws` CLIs needed for Prow-based operator e2e testing

## Context

This supports the operator e2e Prow migration ([SREP-4417](https://redhat.atlassian.net/browse/SREP-4417)) where focused tests move from Tekton/SAPM to Prow for unified Sippy visibility. The `Containerfile.prow` is used by ci-operator to build the e2e test image that runs in the `rosa-operator-e2e` Prow workflow.

All boilerplate consumers subscribed to `golang-osd-e2e` will get `test/e2e/Containerfile.prow` on their next `make boilerplate-update`.

## Related

- Enhancement: https://github.com/openshift-online/rosa-enhancements/pull/51
- Release PR: https://github.com/openshift/release/pull/77989
- Jira: https://redhat.atlassian.net/browse/SREP-4417

## Test plan

- [ ] Run `make boilerplate-update` in a consumer repo (e.g., route-monitor-operator) and verify `test/e2e/Containerfile.prow` is generated
- [ ] Build the image with `podman build -f test/e2e/Containerfile.prow .` and verify the e2e binary is at `/usr/local/bin/e2e.test`
