### PR TITLE
ROSA-745 Extend Renovate automerge rules to gomod (MintMaker)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,8 @@
     "group:allDigest"
   ],
   "enabledManagers": [
-    "tekton"
+    "tekton",
+    "gomod"
   ],
   "tekton": {
     "includePaths": [
@@ -15,6 +16,20 @@
       ".tekton/**"
     ],
     "enabled": true,
+    "packageRules": [
+      {
+        "matchUpdateTypes": [
+          "minor",
+          "patch",
+          "pin",
+          "digest"
+        ],
+        "automerge": true,
+        "addLabels": ["lgtm", "approved"]
+      }
+    ]
+  },
+  "gomod": {
     "packageRules": [
       {
         "matchUpdateTypes": [

--- a/boilerplate/openshift/golang-osd-operator/dependabot.yml
+++ b/boilerplate/openshift/golang-osd-operator/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     labels:
       - "area/dependency"
       - "ok-to-test"
+      - "lgtm"
+      - "approved"
     schedule:
       interval: "weekly"
     ignore:


### PR DESCRIPTION
## Summary

**MintMaker (Renovate)** — extend boilerplate `.github/renovate.json`:

- Enable **gomod** with the same rules as **Tekton**: `automerge` + **`lgtm` / `approved`** for patch / minor / pin / digest
- Operators that `extends` boilerplate inherit on the next MintMaker run

**Dependabot (kept)** — update `golang-osd-operator/dependabot.yml` template:

- Keep **docker** updates for `/build` (unchanged ecosystem)
- Add **`lgtm`** and **`approved`** to PR labels (with existing `area/dependency`, `ok-to-test`) so Dependabot applies them when opening PRs
- Repos receive label changes on **`make boilerplate-update`**

## Note on Dependabot and `/ok-to-test`

Dependabot applies configured labels automatically; openshift may still require **`/ok-to-test`** on some PRs depending on org bot policy. This PR does not remove Dependabot.

## Test plan

- [ ] MintMaker **gomod** PR: `lgtm` + `approved`, merges after CI
- [ ] Tekton behavior unchanged
- [ ] After boilerplate-update, new **Dependabot** docker PR includes `lgtm` + `approved`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to enable automated handling of Go module dependencies. The configuration now includes automatic merging rules for minor, patch, pin, and digest updates, with appropriate approval labels applied to maintain code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->