### PR TITLE
Bump golangci-lint to v2.12.2 for Go 1.26 support

### DIFF
--- a/boilerplate/openshift/golang-lint/ensure.sh
+++ b/boilerplate/openshift/golang-lint/ensure.sh
@@ -8,7 +8,7 @@ fi
 REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh
 
-GOLANGCI_LINT_VERSION="2.7.2"
+GOLANGCI_LINT_VERSION="2.12.2"
 DEPENDENCY=${1:-}
 GOOS=$(go env GOOS)
 

--- a/boilerplate/openshift/golang-osd-operator/ensure.sh
+++ b/boilerplate/openshift/golang-osd-operator/ensure.sh
@@ -8,7 +8,7 @@ fi
 REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh
 
-GOLANGCI_LINT_VERSION="2.7.2"
+GOLANGCI_LINT_VERSION="2.12.2"
 OPM_VERSION="v1.60.0"
 GRPCURL_VERSION="1.7.0"
 DEPENDENCY=${1:-}

--- a/boilerplate/openshift/golang-osd-operator/olm_pko_migration.py
+++ b/boilerplate/openshift/golang-osd-operator/olm_pko_migration.py
@@ -11,7 +11,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import yaml
 
@@ -629,7 +629,7 @@ def write_pko_dockerfile():
             )
         )
 
-def extract_deployment_selector() -> str | None:
+def extract_deployment_selector() -> Optional[str]:
     """
     Extract the clusterDeploymentSelector from hack/olm-registry/olm-artifacts-template.yaml.
 

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,8 +1,8 @@
 FROM quay.io/konflux-ci/yq:latest AS yq
 FROM registry.access.redhat.com/ubi9:9.7-1778044007 AS builder
 
-ARG GOCILINT_VERSION="2.7.2"
-ARG GOCILINT_SHA256SUM="ce46a1f1d890e7b667259f70bb236297f5cf8791a9b6b98b41b283d93b5b6e88"
+ARG GOCILINT_VERSION="2.12.2"
+ARG GOCILINT_SHA256SUM="8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
 ARG GOCILINT_LOCATION=https://github.com/golangci/golangci-lint/releases/download/v${GOCILINT_VERSION}/golangci-lint-${GOCILINT_VERSION}-linux-amd64.tar.gz
 
 RUN curl -L -o golangci-lint.tar.gz ${GOCILINT_LOCATION} && \


### PR DESCRIPTION
## Summary

- Bumps golangci-lint from v2.7.2 to v2.12.2 in the container image and ensure.sh scripts
- Fixes Python 3.9 compatibility in olm_pko_migration.py (`str | None` → `Optional[str]`)

## Why

Kubernetes v0.36.1 and controller-runtime v0.24.1 declare `go 1.26.0` in their `go.mod`. golangci-lint v2.7.2 was built with Go 1.25 and refuses to lint code targeting Go 1.26, blocking all operators upgrading to these dependencies. Bumping to v2.12.2 (built with Go 1.26) unblocks them.

golangci-lint built with Go 1.26 is backward-compatible — operators still on Go 1.25 are unaffected.

## Changes

### golangci-lint bump (3 files)
- `config/Dockerfile`: version `2.7.2` → `2.12.2`, updated SHA256 checksum
- `boilerplate/openshift/golang-osd-operator/ensure.sh`: version `2.7.2` → `2.12.2`
- `boilerplate/openshift/golang-lint/ensure.sh`: version `2.7.2` → `2.12.2`

### Python 3.9 fix (1 file)
- `boilerplate/openshift/golang-osd-operator/olm_pko_migration.py`: `str | None` → `Optional[str]` (Python 3.10+ syntax not supported by Python 3.9 in the container image)

## Notes

- Both golangci-lint versions are within the v2 major line — golangci.yml config compatibility is maintained
- The `--new-from-rev` flag in `golang-osd-operator/standard.mk` limits lint to changed code, mitigating risk of new findings
- Follows the same pattern as the previous Go 1.25 bump

## Test plan

- [x] CI builds the Dockerfile successfully (validates download + SHA256 checksum)
- [ ] Boilerplate test suite passes (08-pko-migration was failing due to the Python fix included here)
- [ ] After release: `make container-lint` passes in pagerduty-operator with Go 1.26 go.mod

🤖 Created with assistance from Claude <claude@anthropic.com>