### PR TITLE
Revert golangci-lint bump to v2.7.2

### DIFF
--- a/boilerplate/openshift/golang-lint/ensure.sh
+++ b/boilerplate/openshift/golang-lint/ensure.sh
@@ -8,7 +8,7 @@ fi
 REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh
 
-GOLANGCI_LINT_VERSION="2.12.2"
+GOLANGCI_LINT_VERSION="2.7.2"
 DEPENDENCY=${1:-}
 GOOS=$(go env GOOS)
 

--- a/boilerplate/openshift/golang-osd-operator/ensure.sh
+++ b/boilerplate/openshift/golang-osd-operator/ensure.sh
@@ -8,7 +8,7 @@ fi
 REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh
 
-GOLANGCI_LINT_VERSION="2.12.2"
+GOLANGCI_LINT_VERSION="2.7.2"
 OPM_VERSION="v1.60.0"
 GRPCURL_VERSION="1.7.0"
 DEPENDENCY=${1:-}

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,8 +1,8 @@
 FROM quay.io/konflux-ci/yq:latest AS yq
 FROM registry.access.redhat.com/ubi9:9.7-1778044007 AS builder
 
-ARG GOCILINT_VERSION="2.12.2"
-ARG GOCILINT_SHA256SUM="8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
+ARG GOCILINT_VERSION="2.7.2"
+ARG GOCILINT_SHA256SUM="ce46a1f1d890e7b667259f70bb236297f5cf8791a9b6b98b41b283d93b5b6e88"
 ARG GOCILINT_LOCATION=https://github.com/golangci/golangci-lint/releases/download/v${GOCILINT_VERSION}/golangci-lint-${GOCILINT_VERSION}-linux-amd64.tar.gz
 
 RUN curl -L -o golangci-lint.tar.gz ${GOCILINT_LOCATION} && \


### PR DESCRIPTION
## Summary

- Reverts golangci-lint from v2.12.2 back to v2.7.2
- The Python 3.9 compatibility fix from PR #743 is intentionally preserved

## Why

The Go 1.26 upgrade is no longer needed — downstream operators are bumping down the kube components version instead. Reverting the golangci-lint bump to avoid shipping an unnecessary change.

This partially reverts 43f0781 (PR #743).

## Changes

- `config/Dockerfile`: version `2.12.2` → `2.7.2`, restored original SHA256 checksum
- `boilerplate/openshift/golang-osd-operator/ensure.sh`: version `2.12.2` → `2.7.2`
- `boilerplate/openshift/golang-lint/ensure.sh`: version `2.12.2` → `2.7.2`

## What is NOT reverted

- `boilerplate/openshift/golang-osd-operator/olm_pko_migration.py`: The `Optional[str]` fix for Python 3.9 compatibility is kept — that was a genuine bug fix independent of the golangci-lint bump.

🤖 Created with assistance from Claude <claude@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration with new version pins and corresponding security verification checksums for the code linting tool used in the build pipeline. This change maintains build integrity, ensures consistent tooling across deployment environments, and refreshes security verification standards throughout the container image build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->