### PR TITLE
ROSA-745: Batch MintMaker gomod updates (UTC schedule)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,7 @@
     "enabled": true,
     "packageRules": [
       {
+        "description": "Tekton patch/minor with lgtm/approved for tide automerge after required checks pass",
         "matchUpdateTypes": [
           "minor",
           "patch",
@@ -32,17 +33,23 @@
   "gomod": {
     "packageRules": [
       {
+        "description": "One gomod PR per repo, UTC 02:00-04:59 Mon-Fri; lgtm/approved for tide after required checks pass",
         "matchUpdateTypes": [
           "minor",
           "patch",
           "pin",
           "digest"
         ],
+        "groupName": "gomod dependencies",
+        "schedule": ["* 2-4 * * 1-5"],
+        "automergeSchedule": ["* 2-4 * * 1-5"],
         "automerge": true,
         "addLabels": ["lgtm", "approved"]
       }
     ]
   },
+  "timezone": "UTC",
+  "updateNotScheduled": false,
   "dependencyDashboard": true,
   "semanticCommits": "enabled",
   "rebaseLabel": "needs-rebase"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,7 +33,7 @@
   "gomod": {
     "packageRules": [
       {
-        "description": "TEST: Thu UTC 06:00-07:59 (~11:30-13:29 IST). Follow-up restores 02:00-04:59 Mon-Fri.",
+        "description": "Pilot: Thu 06:00-06:59 UTC (~11:30 AM-12:29 PM IST). Follow-up restores 02:00-04:59 UTC Mon-Fri.",
         "matchUpdateTypes": [
           "minor",
           "patch",
@@ -41,8 +41,8 @@
           "digest"
         ],
         "groupName": "gomod dependencies",
-        "schedule": ["* 6-7 * * 4"],
-        "automergeSchedule": ["* 6-7 * * 4"],
+        "schedule": ["* 6-6 * * 4"],
+        "automergeSchedule": ["* 6-6 * * 4"],
         "automerge": true,
         "addLabels": ["lgtm", "approved"]
       }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,7 +33,7 @@
   "gomod": {
     "packageRules": [
       {
-        "description": "One gomod PR per repo, UTC 02:00-04:59 Mon-Fri; lgtm/approved for tide after required checks pass",
+        "description": "TEST: Thu UTC 06:00-07:59 (~11:30-13:29 IST). Follow-up restores 02:00-04:59 Mon-Fri.",
         "matchUpdateTypes": [
           "minor",
           "patch",
@@ -41,8 +41,8 @@
           "digest"
         ],
         "groupName": "gomod dependencies",
-        "schedule": ["* 2-4 * * 1-5"],
-        "automergeSchedule": ["* 2-4 * * 1-5"],
+        "schedule": ["* 6-7 * * 4"],
+        "automergeSchedule": ["* 6-7 * * 4"],
         "automerge": true,
         "addLabels": ["lgtm", "approved"]
       }


### PR DESCRIPTION
## Summary

Batch MintMaker gomod updates to reduce staging redeploy churn from many small dependency PRs:

- **One grouped gomod PR** per repo (`gomod dependencies`)
- **UTC 02:00–04:59, Mon–Fri** for when updates are opened
- **`lgtm` / `approved`** for tide automerge after **required** Prow checks pass (no new GitHub Action)

Operators that `extends` boilerplate `renovate.json` pick this up after merge.

## Test plan

- [ ] Pilot operator: grouped gomod PR during the UTC window (see companion test PR)
- [ ] Tide merges only when required `ci/prow/*` (and Konflux if required) are green