### PR TITLE
Revert ROSA-745 boilerplate dependency automation changes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,6 @@
     "enabled": true,
     "packageRules": [
       {
-        "description": "Tekton patch/minor with lgtm/approved for tide automerge after required checks pass",
         "matchUpdateTypes": [
           "minor",
           "patch",
@@ -33,23 +32,17 @@
   "gomod": {
     "packageRules": [
       {
-        "description": "Pilot: Thu 06:00-06:59 UTC (~11:30 AM-12:29 PM IST). Follow-up restores 02:00-04:59 UTC Mon-Fri.",
         "matchUpdateTypes": [
           "minor",
           "patch",
           "pin",
           "digest"
         ],
-        "groupName": "gomod dependencies",
-        "schedule": ["* 6-6 * * 4"],
-        "automergeSchedule": ["* 6-6 * * 4"],
         "automerge": true,
         "addLabels": ["lgtm", "approved"]
       }
     ]
   },
-  "timezone": "UTC",
-  "updateNotScheduled": false,
   "dependencyDashboard": true,
   "semanticCommits": "enabled",
   "rebaseLabel": "needs-rebase"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,8 +7,7 @@
     "group:allDigest"
   ],
   "enabledManagers": [
-    "tekton",
-    "gomod"
+    "tekton"
   ],
   "tekton": {
     "includePaths": [
@@ -16,20 +15,6 @@
       ".tekton/**"
     ],
     "enabled": true,
-    "packageRules": [
-      {
-        "matchUpdateTypes": [
-          "minor",
-          "patch",
-          "pin",
-          "digest"
-        ],
-        "automerge": true,
-        "addLabels": ["lgtm", "approved"]
-      }
-    ]
-  },
-  "gomod": {
     "packageRules": [
       {
         "matchUpdateTypes": [

--- a/boilerplate/openshift/golang-osd-operator/dependabot.yml
+++ b/boilerplate/openshift/golang-osd-operator/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     labels:
       - "area/dependency"
       - "ok-to-test"
-      - "lgtm"
-      - "approved"
     schedule:
       interval: "weekly"
     ignore:


### PR DESCRIPTION
## Summary

Revert both [ROSA-745](https://redhat.atlassian.net/browse/ROSA-745) boilerplate rollouts and return to original behavior:

- Revert `dd0c851` (PR #746)
- Revert `b9feed9` (PR #741)

This rolls back the MintMaker gomod batching/schedule and the earlier boilerplate dependency automation adjustments introduced by those two PRs.

## Test plan

- [ ] Confirm `.github/renovate.json` matches pre-#741/#746 baseline
- [ ] Confirm `boilerplate/openshift/golang-osd-operator/dependabot.yml` matches pre-#741 baseline
- [ ] Verify dependency PR behavior returns to the original state

[ROSA-745]: https://redhat.atlassian.net/browse/ROSA-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management configuration to restrict automatic merging to specific package managers, removing support for Go module auto-merge behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->