### PR TITLE
ROSA-745: MintMaker gomod batch + automerge via boilerplate renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,8 @@
     "group:allDigest"
   ],
   "enabledManagers": [
-    "tekton"
+    "tekton",
+    "gomod"
   ],
   "tekton": {
     "includePaths": [
@@ -17,17 +18,68 @@
     "enabled": true,
     "packageRules": [
       {
+        "description": "Tekton patch/minor; batch and automerge Mon-Fri 02:00-04:59 UTC (requires Prow + Konflux via branch protection)",
         "matchUpdateTypes": [
           "minor",
           "patch",
           "pin",
           "digest"
         ],
+        "schedule": ["* 2-4 * * 1-5"],
+        "automergeSchedule": ["* 2-4 * * 1-5"],
         "automerge": true,
         "addLabels": ["lgtm", "approved"]
+      },
+      {
+        "description": "Tekton major — open PR for manual /lgtm; never automerge",
+        "matchUpdateTypes": [
+          "major"
+        ],
+        "automerge": false,
+        "schedule": ["* 2-4 * * 1-5"],
+        "addLabels": [
+          "major-update",
+          "manual-review-required",
+          "area/dependency",
+          "ok-to-test"
+        ]
       }
     ]
   },
+  "gomod": {
+    "packageRules": [
+      {
+        "description": "Grouped gomod minor/patch; batch and automerge Mon-Fri 02:00-04:59 UTC (requires Prow + Konflux via branch protection)",
+        "matchUpdateTypes": [
+          "minor",
+          "patch",
+          "pin",
+          "digest"
+        ],
+        "groupName": "gomod dependencies",
+        "schedule": ["* 2-4 * * 1-5"],
+        "automergeSchedule": ["* 2-4 * * 1-5"],
+        "automerge": true,
+        "addLabels": ["lgtm", "approved"]
+      },
+      {
+        "description": "Gomod major — MintMaker opens PR; manual /lgtm after CI (no lgtm/approved here)",
+        "matchUpdateTypes": [
+          "major"
+        ],
+        "automerge": false,
+        "schedule": ["* 2-4 * * 1-5"],
+        "addLabels": [
+          "major-update",
+          "manual-review-required",
+          "area/dependency",
+          "ok-to-test"
+        ]
+      }
+    ]
+  },
+  "timezone": "UTC",
+  "updateNotScheduled": false,
   "dependencyDashboard": true,
   "semanticCommits": "enabled",
   "rebaseLabel": "needs-rebase"

--- a/boilerplate/openshift/golang-osd-operator/dependabot.yml
+++ b/boilerplate/openshift/golang-osd-operator/dependabot.yml
@@ -5,8 +5,13 @@ updates:
     labels:
       - "area/dependency"
       - "ok-to-test"
+      - "lgtm"
+      - "approved"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "03:00"
+      timezone: "UTC"
     ignore:
       - dependency-name: "redhat-services-prod/openshift/boilerplate"
         # don't upgrade boilerplate via these means


### PR DESCRIPTION
### Summary

Re-introduces [ROSA-745](https://redhat.atlassian.net/browse/ROSA-745) MintMaker gomod batching + tide automerge via shared boilerplate config, after revert #747.

- Enable **gomod** in `.github/renovate.json` with **grouped** minor/patch updates and **production** UTC schedule (`02:00–04:59`, Mon–Fri).
- Pre-apply **`lgtm`** / **`approved`** on **patch/minor/digest** gomod + Tekton rules so tide automerges when required checks pass.
- **Major** gomod/Tekton updates: MintMaker **opens PRs** with `major-update` / `manual-review-required` / `ok-to-test` — **no** `lgtm`/`approved`, **no** automerge (manual `/lgtm` after CI).
- **Dependabot** docker template: **`lgtm`** / **`approved`** + `ok-to-test` + `area/dependency`; **weekly Mon 03:00 UTC** (aligned with MintMaker batch window).

### Who opens what

| Ecosystem | Bot | Safe updates (automerge after CI) | Major / manual |
|-----------|-----|-----------------------------------|----------------|
| **Go modules** | **MintMaker** (Renovate) | Grouped batch, Mon–Fri 02:00–04:59 UTC | PR opened; manual `/lgtm` |
| **Tekton** | **MintMaker** (Renovate) | Same UTC window | Major: manual `/lgtm` |
| **Docker `/build`** | **Dependabot** | Weekly Mon 03:00 UTC + pre-labels | N/A (digest/tag bumps) |

Do **not** add gomod to Dependabot where MintMaker runs — avoids duplicate PRs. Gomod majors are MintMaker’s job (e.g. module line v4→v5).

### Lessons from #741 / #746 rollback (#747)

| Issue (why we reverted) | Fix in this PR |
|-------------------------|----------------|
| **#746** used a narrow **Thu 06:00 UTC pilot** window | **Mon–Fri 02:00–04:59 UTC** production window from day one |
| **#741** had no **groupName** → stream of individual gomod PRs | `"groupName": "gomod dependencies"` (patch/minor only) |
| Missing **`timezone`** / **`updateNotScheduled`** | `"timezone": "UTC"`, `"updateNotScheduled": false` |
| Automerge without clear **CI gate** expectation | Rule descriptions note merge requires **Prow + Konflux** via branch protection (DPP ticket) |
| Push for per-repo **GHA auto-merge** workflows | **Out of scope** — tide + labels only (per platform review) |

### Out of scope

- Per-operator GitHub Action auto-merge workflows.
- `dependency-pr-automerge.yml` or boilerplate update-script workflow install.
- Dependabot **gomod** (MintMaker covers gomod including majors).

### Prerequisites before fleet impact

- [ ] DPP applies required **`ci/prow/*`** + primary **Konflux `*-on-pull-request`** per repo (see [ROSA-745](https://redhat.atlassian.net/browse/ROSA-745) DPP handoff).
- [ ] Operators run `boilerplate-update` to pick up `dependabot.yml` label + schedule changes.

### Test plan (after merge)

- [ ] One grouped **patch/minor** gomod PR automerges after required Prow + Konflux green.
- [ ] A **major** MintMaker PR appears with `major-update` labels and **does not** merge without human `/lgtm`.
- [ ] Dependabot docker PR opens with **`lgtm`/`approved`** and automerges after required CI green.

### Related

- Supersedes reverted #741, #746; follow-up to revert #747
- Jira: [ROSA-745](https://issues.redhat.com/browse/ROSA-745) / [ROSAENG-751](https://redhat.atlassian.net/browse/ROSAENG-751)


[ROSA-745]: https://redhat.atlassian.net/browse/ROSA-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSA-745]: https://redhat.atlassian.net/browse/ROSA-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency updates for Go modules and Tekton with scheduled maintenance windows (Mon–Fri 02:00–04:59 UTC).
  * Enabled auto-merge for grouped minor/patch updates and disabled auto-merge for major updates, which now require manual review.
  * Applied review and area labels to updates for clearer triage.
  * Set repository timezone to UTC and enforced scheduled-only update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->