### PR TITLE
Fix container-make leaving orphaned containers on interruption

### DIFF
--- a/boilerplate/_lib/container-make
+++ b/boilerplate/_lib/container-make
@@ -29,11 +29,13 @@ if [[ "${CONTAINER_ENGINE##*/}" == "podman" ]] && [[ $OSTYPE == *"linux"* ]]; th
 else
     CE_OPTS="${CE_OPTS} -v $REPO_ROOT:$CONTAINER_MOUNT"
 fi
-container_id=$($CONTAINER_ENGINE run -d ${CE_OPTS} $IMAGE_PULL_PATH sleep infinity)
+container_id=$($CONTAINER_ENGINE run --rm -d ${CE_OPTS} $IMAGE_PULL_PATH sleep infinity)
 
 if [[ $? -ne 0 ]] || [[ -z "$container_id" ]]; then
   err "Couldn't start detached container"
 fi
+
+trap "$CONTAINER_ENGINE stop $container_id >/dev/null 2>&1" EXIT
 
 # Now run our `make` command in it with the right UID and working directory
 args="exec -it -u $(id -u):0 -w $CONTAINER_MOUNT $container_id"
@@ -51,6 +53,9 @@ if [[ $rc -ne 0 ]]; then
     $CONTAINER_ENGINE $args /bin/bash
   fi
 fi
+
+# Disarm the interrupt trap -- normal cleanup handles it from here
+trap - EXIT
 
 # Finally, remove the container
 banner "Cleaning up the container"


### PR DESCRIPTION
## Summary
- Add `--rm` to the detached `podman run` so containers self-remove when stopped
- Add an `EXIT` trap to stop the container if the script is interrupted (Ctrl+C, terminal closed, etc.)
- Disarm the trap (`trap - EXIT`) before normal cleanup so the happy path uses the existing explicit `rm -f` without a redundant `stop` — the trap is purely an interrupt safety net
- Existing explicit cleanup kept for the normal path

Without this fix, interrupted `container-make` runs leave `sleep infinity` containers running indefinitely:

```
$ podman ps
CONTAINER ID  IMAGE                                                            COMMAND          CREATED       STATUS
7858c0c6ab01  quay.io/redhat-services-prod/openshift/boilerplate:image-v8.3.6  sleep infinity   2 weeks ago   Up 2 weeks
fc63b6ffb8c5  quay.io/redhat-services-prod/openshift/boilerplate:image-v8.3.6  sleep infinity   2 weeks ago   Up 2 weeks
a50c12d72004  quay.io/redhat-services-prod/openshift/boilerplate:image-v8.3.6  sleep infinity   12 days ago   Up 12 days
e62447ae9da8  quay.io/redhat-services-prod/openshift/boilerplate:image-v8.3.6  sleep infinity   12 days ago   Up 12 days
25bb61b66a00  quay.io/redhat-services-prod/openshift/boilerplate:image-v8.3.6  sleep infinity   12 days ago   Up 12 days
```

### How the cleanup layers work

| Exit path | What fires | Result |
|---|---|---|
| **Normal** (make succeeds or debug shell exits) | `trap - EXIT` disarms the trap → explicit `rm -f` runs | Container removed by `rm -f` |
| **Interrupted** (Ctrl+C, SIGTERM, terminal closed) | `EXIT` trap fires → `stop` + `--rm` auto-remove | Container stopped and removed by trap |

## Test plan
- [ ] Run `make container-test` in a consumer repo — verify container is removed after success
- [ ] Run `make container-test` and Ctrl+C mid-run — verify container is removed
- [ ] Run `make container-test` with a failing target, enter debug shell, exit — verify container is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)