### PR TITLE
Add init container to e2e template for SAPM image gate

### DIFF
--- a/boilerplate/openshift/golang-osd-e2e/e2e-template.yml
+++ b/boilerplate/openshift/golang-osd-e2e/e2e-template.yml
@@ -52,6 +52,24 @@ objects:
               secret:
                 secretName: osde2e-gcp-credentials
                 optional: true
+          initContainers:
+            - name: test-image-gate
+              image: ${TEST_IMAGE}:${IMAGE_TAG}
+              command: ["true"]
+              resources:
+                requests:
+                  cpu: "10m"
+                  memory: "16Mi"
+                limits:
+                  cpu: "10m"
+                  memory: "16Mi"
+              securityContext:
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: [ "ALL" ]
+                seccompProfile:
+                  type: RuntimeDefault
           containers:
             - name: osde2e
               image: quay.io/redhat-services-prod/osde2e-cicada-tenant/osde2e:latest


### PR DESCRIPTION
## Summary

Adds an init container to the osde2e focused test Job template that references the test image (`${TEST_IMAGE}:${IMAGE_TAG}`). This makes the image visible to qontract-reconcile's `_collect_images` scanner, which validates all container images exist before deploying.

## Problem

The test image reference is embedded in a YAML string inside the `TEST_SUITES_YAML` env var. The `_collect_images` scanner only checks `spec.template.spec.containers[].image` and `initContainers[].image`, so it never finds the test image.

When SAPM auto-promotes the e2e saas file after a PKO deploy, the e2e Job deploys before the Konflux release pipeline finishes pushing the test image to the production registry, causing `manifest unknown` errors.

## Fix

The init container runs `true` and exits immediately. Its only purpose is to surface the test image reference as a proper container image field so the SAPM image check blocks deployment until the image exists.

Benefits all operators using the `golang-osd-e2e` boilerplate convention.