### PR TITLE
Remove srep-infra-cicd from OWNERS files [SDCICD-1761]

### DIFF
--- a/.tekton/OWNERS
+++ b/.tekton/OWNERS
@@ -1,6 +1,12 @@
 reviewers:
+- srep-functional-team-aurora
+- srep-functional-leads
+- srep-team-leads
+- xiaoyu74
 - joshbranham
-- srep-infra-cicd
 approvers:
+- srep-functional-team-aurora
+- srep-functional-leads
+- srep-team-leads
+- bdematte
 - joshbranham
-- srep-infra-cicd


### PR DESCRIPTION
The srep-infra-cicd migration is now complete. This PR removes the team as owners from this repository.

Related: Similar cleanup across OpenShift managed services repositories.