### PR TITLE
Remove srep-infra-cicd from golang-osd-operator update script [SDCICD-1761]

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -18,15 +18,25 @@ cp ${HERE}/.codecov.yml $REPO_ROOT
 echo "Copying OWNERS_ALIASES to your repository root."
 cp -L ${HERE}/OWNERS_ALIASES $REPO_ROOT
 
-# Add CICD owners to .tekton if exists
-if [[ -d "${REPO_ROOT}/.tekton/" ]]; then
-	echo "Adding Konflux subdirectory OWNERS file to .tekton/"
-	cat >"${REPO_ROOT}/.tekton/OWNERS" <<EOF
-reviewers:
-- srep-infra-cicd
-approvers:
-- srep-infra-cicd
-EOF
+# Clean up srep-infra-cicd from .tekton/OWNERS if it exists
+if [[ -f "${REPO_ROOT}/.tekton/OWNERS" ]]; then
+	echo "Checking .tekton/OWNERS for srep-infra-cicd cleanup..."
+
+	# Check if file contains srep-infra-cicd
+	if grep -q "srep-infra-cicd" "${REPO_ROOT}/.tekton/OWNERS"; then
+		# Count non-comment, non-blank lines excluding srep-infra-cicd
+		other_owners=$(grep -v "^#" "${REPO_ROOT}/.tekton/OWNERS" | grep -v "^$" | grep -v "reviewers:" | grep -v "approvers:" | grep -v "srep-infra-cicd" | wc -l)
+
+		if [[ "$other_owners" -eq 0 ]]; then
+			# Only srep-infra-cicd present, delete the file
+			echo "Removing .tekton/OWNERS (only contained srep-infra-cicd)"
+			rm "${REPO_ROOT}/.tekton/OWNERS"
+		else
+			# Other owners present, just remove srep-infra-cicd lines
+			echo "Removing srep-infra-cicd from .tekton/OWNERS (keeping other owners)"
+			sed -i '/srep-infra-cicd/d' "${REPO_ROOT}/.tekton/OWNERS"
+		fi
+	fi
 fi
 
 # Add dependabot configuration

--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -19,24 +19,17 @@ echo "Copying OWNERS_ALIASES to your repository root."
 cp -L ${HERE}/OWNERS_ALIASES $REPO_ROOT
 
 # Clean up srep-infra-cicd from .tekton/OWNERS if it exists
-if [[ -f "${REPO_ROOT}/.tekton/OWNERS" ]]; then
-	echo "Checking .tekton/OWNERS for srep-infra-cicd cleanup..."
+TEKTON_OWNERS="${REPO_ROOT}/.tekton/OWNERS"
+if [[ -f "${TEKTON_OWNERS}" ]] && grep -q "srep-infra-cicd" "${TEKTON_OWNERS}"; then
+	echo "Removing srep-infra-cicd from .tekton/OWNERS..."
+	${SED?} -i '/srep-infra-cicd/d' "${TEKTON_OWNERS}"
 
-	# Check if file contains srep-infra-cicd
-	if grep -q "srep-infra-cicd" "${REPO_ROOT}/.tekton/OWNERS"; then
-		# Count non-comment, non-blank lines excluding srep-infra-cicd
-		other_owners=$(grep -v "^#" "${REPO_ROOT}/.tekton/OWNERS" | grep -v "^$" | grep -v "reviewers:" | grep -v "approvers:" | grep -v "srep-infra-cicd" | wc -l)
-
-		if [[ "$other_owners" -eq 0 ]]; then
-			# Only srep-infra-cicd present, delete the file
-			echo "Removing .tekton/OWNERS (only contained srep-infra-cicd)"
-			rm "${REPO_ROOT}/.tekton/OWNERS"
-		else
-			# Other owners present, just remove srep-infra-cicd lines
-			echo "Removing srep-infra-cicd from .tekton/OWNERS (keeping other owners)"
-			sed -i '/srep-infra-cicd/d' "${REPO_ROOT}/.tekton/OWNERS"
-		fi
+	# If no owners remain (ignoring section headers, comments, and blank lines), remove the file
+	if ! grep -qE "^\\s*-\\s+\\S" "${TEKTON_OWNERS}"; then
+		echo "Removing .tekton/OWNERS (no owners remain after cleanup)"
+		rm "${TEKTON_OWNERS}"
 	fi
+fi
 fi
 
 # Add dependabot configuration


### PR DESCRIPTION
The srep-infra-cicd team migration is complete. Operator teams should now own their Konflux setup, so we no longer automatically add srep-infra-cicd to .tekton/OWNERS files during boilerplate updates.

This change updates the template code so future bp-update runs will intelligently remove our team from the OWNERS file if it exists.