### PR TITLE
update subscriber propose update command to work

### DIFF
--- a/boilerplate/_lib/subscriber-propose-update
+++ b/boilerplate/_lib/subscriber-propose-update
@@ -25,7 +25,7 @@ Quirks and Limitations:
 - Is still slightly interactive, because 'gh pr create' likes to ask
   questions about your origin and upstream.
 EOF
-    exit -1
+    exit 1
 }
 
 source $REPO_ROOT/boilerplate/_lib/subscriber.sh
@@ -35,7 +35,7 @@ source $REPO_ROOT/boilerplate/_lib/subscriber.sh
 
 TMPD=$(mktemp -d)
 echo $TMPD;
-#trap "rm -fr $TMPD" EXIT
+trap "rm -fr $TMPD" EXIT
 
 run_step() {
     local title=$1

--- a/boilerplate/_lib/subscriber-propose-update
+++ b/boilerplate/_lib/subscriber-propose-update
@@ -34,16 +34,54 @@ source $REPO_ROOT/boilerplate/_lib/subscriber.sh
 [[ $# -eq 0 ]] && usage
 
 TMPD=$(mktemp -d)
-trap "rm -fr $TMPD" EXIT
+echo $TMPD;
+#trap "rm -fr $TMPD" EXIT
+
+run_step() {
+    local title=$1
+    local log_file="$TMPD/$title.log"
+    log_file=$(tr '[:upper:]' '[:lower:]' <<< "$log_file")
+    log_file=$(tr ' ' '-' <<< "$log_file")
+    shift
+
+    if [[ $1 != "--" ]]; then
+        echo "ERR: expected '--' but got '$1'"
+        exit 1
+    fi
+    shift
+    echo -n "$title...  "
+
+    if ! "$@" > "$log_file" 2>&1; then
+        echo " FAILED"
+        echo "!!!"
+        echo "!!! Boilerplate update failed for $subscriber"
+        echo "!!!"
+        echo ""
+        cat "$log_file"
+        exit 1
+    fi
+    echo " DONE"
+}
+
+sync_main() {
+    local main_branch=$1
+    shift
+
+    git pull upstream $main_branch
+    git push origin $main_branch
+}
+
+git_clean_and_push() {
+    local branch=$1
+    shift
+
+    git push --delete origin $branch || true
+    git push -u origin $branch
+}
 
 propose_update() {
     local subscriber=$1
     local proj=${subscriber#*/}
-
-    if [[ -z "$DRY_RUN" ]]; then
-        echo "DRY RUN: Would propose update for $subscriber"
-        return 0
-    fi
 
     (
         # Clone my fork of the subscriber repo
@@ -51,29 +89,45 @@ propose_update() {
         # This
         # - uses the existing fork if one exists
         # - sets 'origin' and 'upstream' remotes
-        gh repo fork $subscriber --clone=true --remote=true
+        # only clones the default branch to save disk space and time
+
+        run_step "Creating fork" -- gh repo fork $subscriber --clone=true --default-branch-only
         cd $proj
 
-        # Current branch is 'master' or 'main'
-        cur_branch=$(current_branch .)
-        # Make sure our origin is synced with upstream, so our update
-        # commit is based off of the latest code.
-        # WARNING: This changes your fork!
-        git pull upstream $cur_branch
-        git push origin $cur_branch
+        # Current branch is 'master' or 'main' or 'trunk'
+        main_branch=$(current_branch .)
+        run_step "Syncing Fork" -- sync_main $main_branch
+        # run_step "Pushing fork" -- git push origin $main_branch
 
-        # Create the update commit
-        make boilerplate-update
-        make boilerplate-commit
+        # Create the update commit - only cat logs if something goes wrong.
+        run_step "Updating boilerplate" -- make boilerplate-update
+        run_step "Committing boilerplate update" -- make boilerplate-commit
 
-        # And create the PR
-        # TODO: This is interactive. How do we tell gh "Yes, please use
-        # upstream as upstream and origin as origin?"
-        gh pr create -f
+        boilerplate_branch=$(git rev-parse --abbrev-ref HEAD)
+        # By pushing to the origin boilerplate branch explicitly before opening a PR,
+        # we make don't get prompted for the branch to push to.
+        # If we still find that it's giving us an interactive prompt, we can otherwise
+        # use `gh api` to create the PR programmatically.
+        if [[ "$boilerplate_branch" == "$main_branch" ]]; then
+            echo "CRITICAL ERROR: boilerplate branch '$boilerplate_branch' is the same as main branch '$main_branch'"
+            echo "If you see this, something has gone terribly wrong"
+            echo "Skipping"
+            exit 20
+        fi
+        run_step "pushing update" -- git_clean_and_push $boilerplate_branch
+
+        gh pr create --repo $subscriber -f $DRY_RUN_FLAG
     )
 }
 
 bp_master=$(git rev-parse master)
+
+DRY_RUN_FLAG=""
+if [[ -z "$DRY_RUN" ]]; then
+    echo "DRY RUN: ENABLED"
+    DRY_RUN_FLAG="--dry-run"
+fi
+
 
 for subscriber in $(subscriber_args "$@"); do
 
@@ -89,14 +143,45 @@ for subscriber in $(subscriber_args "$@"); do
         continue
     fi
 
-    # Is there already a PR proposed for this level?
-    existing_pr=$(gh pr list --repo $subscriber | grep -P ":boilerplate-\S+-$bp_master\s")
+    # Is there already a PR proposed for this commit?
+    pr_list=$(gh pr list --repo $subscriber --json headRefName,url,number | jq -r '. | map(select(.headRefName | startswith("boilerplate-update--")))')
+    existing_pr=$(jq -r ".[] | select(.headRefName == \"boilerplate-update--$bp_master\")" <<< "$pr_list")
     if [[ -n "$existing_pr" ]]; then
-        echo "Subscriber '$subscriber' already has an open PR:"
-        echo "https://github.com/$subscriber/pull/$existing_pr"
+        echo "Subscriber '$subscriber' already has an open PR for this boilerplate commit:"
+        jq -r .url <<< "$existing_pr"
         continue
     fi
 
     # Pull the trigger
-    propose_update "$subscriber"
+    if ! propose_update "$subscriber"; then
+        echo "Error: failed to propose update for '$subscriber'"
+        continue
+    fi
+
+    new_pr="XXXX"
+    # Get the new PR URL
+    # only run if not dry-run - otherwise the new_pr var will be empty
+    if [[ -n $DRY_RUN ]]; then
+        new_pr=$(gh pr list --repo $subscriber --json headRefName,number | jq -r ".[] | select(.headRefName == \"boilerplate-update--$bp_master\") | .number")
+        if [[ -z "$new_pr" ]]; then
+            echo "error: unable to find new PR for boilerplate update '$bp_master' on subscriber '$subscriber'"
+            continue
+        fi
+    fi
+
+    # Add comments to existing PRs to say they're superseded by this new one
+    if [[ -n "$pr_list" ]]; then
+        prs=$(jq -r '. | map(.number) | @tsv' <<< "$pr_list")
+        echo "Closing old PRs: $prs"
+        for pr in $prs; do
+            if [[ -z $DRY_RUN ]]; then
+                echo "Dry run - would close $pr with comment:"
+                echo "  \"Superseded by #$new_pr.\""
+                continue
+            fi
+
+            gh pr close --repo $subscriber --comment "Superseded by #$new_pr." $pr
+        done
+    fi
+
 done

--- a/hack/find-subscribers.sh
+++ b/hack/find-subscribers.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Finds all repos in the openshift GitHub org that have a top-level
+# boilerplate/ directory, reads their update.cfg to determine which
+# conventions they subscribe to, and outputs subscribers.yaml format.
+#
+# Requires: gh (GitHub CLI), authenticated
+#
+# Usage: ./find-subscribers.sh > subscribers.yaml
+
+set -euo pipefail
+
+echo "# List of repositories in openshift org with a boilerplate/ directory."
+echo "# Generated on $(date +%Y-%m-%d)."
+echo ""
+echo "subscribers:"
+
+# Page through all non-fork, non-archived repos in the org
+gh repo list openshift --no-archived --source --limit 9999 --json name --jq '.[].name' | sort | while read -r repo; do
+  # Check if a top-level boilerplate/ directory exists on the default branch
+  if ! gh api "repos/openshift/${repo}/contents/boilerplate" --silent 2>/dev/null; then
+    continue
+  fi
+
+  echo "  Found: openshift/${repo}" >&2
+
+  # Fetch update.cfg to determine which conventions this repo subscribes to
+  conventions=()
+  cfg=$(gh api "repos/openshift/${repo}/contents/boilerplate/update.cfg" --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)
+
+  if [[ -n "$cfg" ]]; then
+    while read -r line; do
+      # Strip comments and whitespace
+      line="${line%%#*}"
+      line="$(echo "$line" | xargs 2>/dev/null || true)"
+      [[ -n "$line" ]] && conventions+=("$line")
+    done <<< "$cfg"
+  fi
+
+  # If we couldn't read update.cfg or it was empty, mark as unknown
+  if [[ ${#conventions[@]} -eq 0 ]]; then
+    conventions=("unknown")
+  fi
+
+  echo "  - name: openshift/${repo}"
+  echo "    conventions:"
+  for conv in "${conventions[@]}"; do
+    echo "      - name: ${conv}"
+    echo "        status: manual"
+  done
+  echo ""
+done

--- a/subscribers.yaml
+++ b/subscribers.yaml
@@ -31,27 +31,57 @@
 #                       convention and/or boilerplate framework merge.
 
 subscribers:
-  #- name: app-sre/deployment-validation-operator
-  #  conventions:
-  #    - name: openshift/golang-osd-operator
-  #      status: manual
+  - name: openshift/addon-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: manual
 
   - name: openshift/aws-account-operator
     conventions:
       - name: openshift/golang-osd-operator
         status: manual
 
+  - name: openshift/aws-efs-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: manual
+
+  - name: openshift/aws-vpce-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: manual
+      - name: openshift/golang-osd-e2e
+        status: manual
+
   - name: openshift/certman-operator
     conventions:
       - name: openshift/golang-osd-operator
+        status: manual
+      - name: openshift/golang-osd-e2e
         status: manual
 
   - name: openshift/cloud-ingress-operator
     conventions:
       - name: openshift/golang-osd-operator
         status: manual
+      - name: openshift/golang-osd-e2e
+        status: manual
+
+  - name: openshift/configuration-anomaly-detection
+    conventions:
+      - name: openshift/osd-container-image
+        status: manual
+      - name: openshift/golang-osd-e2e
+        status: manual
 
   - name: openshift/configure-alertmanager-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: manual
+      - name: openshift/golang-osd-e2e
+        status: manual
+
+  - name: openshift/configure-goalert-operator
     conventions:
       - name: openshift/golang-osd-operator
         status: manual
@@ -59,6 +89,8 @@ subscribers:
   - name: openshift/custom-domains-operator
     conventions:
       - name: openshift/golang-osd-operator
+        status: manual
+      - name: openshift/golang-osd-e2e
         status: manual
 
   - name: openshift/deadmanssnitch-operator
@@ -71,9 +103,23 @@ subscribers:
       - name: openshift/golang-osd-operator
         status: manual
 
+  - name: openshift/managed-cluster-validating-webhooks
+    conventions:
+      - name: openshift/golang-osd-e2e
+        status: manual
+
+  - name: openshift/managed-node-metadata-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: manual
+      - name: openshift/golang-osd-e2e
+        status: manual
+
   - name: openshift/managed-upgrade-operator
     conventions:
       - name: openshift/golang-osd-operator
+        status: manual
+      - name: openshift/golang-osd-e2e
         status: manual
 
   - name: openshift/managed-velero-operator
@@ -86,9 +132,49 @@ subscribers:
       - name: openshift/golang-osd-operator
         status: manual
 
+  - name: openshift/ocm-agent
+    conventions:
+      - name: openshift/golang-osd-e2e
+        status: manual
+
+  - name: openshift/ocm-agent-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: manual
+      - name: openshift/golang-osd-e2e
+        status: manual
+
+  - name: openshift/operator-custom-metrics
+    conventions:
+      - name: openshift/golang-lint
+        status: manual
+
+  - name: openshift/osd-cluster-ready
+    conventions:
+      - name: openshift/osd-container-image
+        status: manual
+      - name: openshift/golang-lint
+        status: manual
+
+  - name: openshift/osd-example-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: manual
+      - name: openshift/golang-osd-e2e
+        status: manual
+
   - name: openshift/osd-metrics-exporter
     conventions:
       - name: openshift/golang-osd-operator
+        status: manual
+      - name: openshift/golang-osd-e2e
+        status: manual
+
+  - name: openshift/osd-network-verifier
+    conventions:
+      - name: openshift/golang-lint
+        status: manual
+      - name: openshift/golang-codecov
         status: manual
 
   - name: openshift/pagerduty-operator
@@ -100,13 +186,31 @@ subscribers:
     conventions:
       - name: openshift/golang-osd-operator
         status: manual
+      - name: openshift/golang-osd-e2e
+        status: manual
 
   - name: openshift/route-monitor-operator
     conventions:
       - name: openshift/golang-osd-operator
         status: manual
+      - name: openshift/golang-osd-e2e
+        status: manual
+
+  - name: openshift/splunk-forwarder-images
+    conventions:
+      - name: openshift/osd-container-image
+        status: manual
 
   - name: openshift/splunk-forwarder-operator
     conventions:
       - name: openshift/golang-osd-operator
+        status: manual
+      - name: openshift/golang-osd-e2e
+        status: manual
+
+  - name: openshift/splunk-token-operator
+    conventions:
+      - name: openshift/golang-osd-operator
+        status: manual
+      - name: openshift/golang-osd-e2e
         status: manual

--- a/subscribers.yaml
+++ b/subscribers.yaml
@@ -4,10 +4,6 @@
 # Note:
 # - This file is currently maintained by hand (not by tooling). It's
 #   YAML so it can used by tooling in the future.
-# - At the time of this writing, there is only one convention:
-#   openshift/golang-osd-operator.
-# - At the time of this writing, the subscribers[].conventions[].status
-#   "automated" isn't a thing yet.
 #
 # Pseudo-schema:
 #   subscribers: List of dicts, each representing the state of a

--- a/subscribers.yaml
+++ b/subscribers.yaml
@@ -31,17 +31,12 @@
 #                       convention and/or boilerplate framework merge.
 
 subscribers:
-  - name: app-sre/deployment-validation-operator
-    conventions:
-      - name: openshift/golang-osd-operator
-        status: manual
+  #- name: app-sre/deployment-validation-operator
+  #  conventions:
+  #    - name: openshift/golang-osd-operator
+  #      status: manual
 
   - name: openshift/aws-account-operator
-    conventions:
-      - name: openshift/golang-osd-operator
-        status: manual
-
-  - name: openshift/aws-efs-operator
     conventions:
       - name: openshift/golang-osd-operator
         status: manual
@@ -54,11 +49,6 @@ subscribers:
   - name: openshift/cloud-ingress-operator
     conventions:
       - name: openshift/golang-osd-operator
-        status: manual
-
-  - name: openshift/compliance-audit-router
-    conventions:
-      - name: openshift/osd-container-image
         status: manual
 
   - name: openshift/configure-alertmanager-operator


### PR DESCRIPTION
Makes some tweaks to the `subscriber propose update` command to get it to work.

* removes grep dependency, going with jq instead so it can work cross platform (gnu grep vs bsd grep issue)
* Logs all steps out to files within the tmp dir that's created instead of polluting the screen when everything is okay
* Ensures git branch on your fork doesn't already exist, deletes it if it does before pushing
** Further validates that you're not working off of whatever the default branch is before deleting anything
* removes outdated subscribers
* Closes open Boilerplate PRs that are outdated, commenting that they've been superseded by the new one.

Example Output now:

```
==============================
Processing openshift/route-monitor-operator
==============================
Subscriber 'openshift/route-monitor-operator' already has an open PR for this boilerplate commit:
https://github.com/openshift/route-monitor-operator/pull/563

==============================
Processing openshift/compliance-audit-router
==============================
Creating fork...   DONE
Syncing Fork...   DONE
Updating boilerplate...   DONE
Committing boilerplate update...   DONE
pushing update...   DONE

Creating pull request for iamkirkbater:boilerplate-update--8fb7c801f68dc7e06e8d2ae138c2a98f0b234b56 into main in openshift/compliance-audit-router

pull request create failed: GraphQL: Repository was archived so is read-only (createPullRequest)
Error: failed to propose update for 'openshift/compliance-audit-router'

==============================
Processing openshift/cloud-ingress-operator
==============================
Creating fork...   DONE
Syncing Fork...   DONE
Updating boilerplate...   DONE
Committing boilerplate update...   DONE
pushing update...   DONE

Creating pull request for iamkirkbater:boilerplate-update--8fb7c801f68dc7e06e8d2ae138c2a98f0b234b56 into master in openshift/cloud-ingress-operator

https://github.com/openshift/cloud-ingress-operator/pull/487
Closing old PRs: 486
✓ Closed pull request openshift/cloud-ingress-operator#486 (Boilerplate: Update to adf5de77e6238d9697351b1030ec7f4c3e793bac)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a repository discovery script to identify projects using boilerplate configurations and their convention subscriptions.

* **Chores**
  * Updated subscriber registry with nine new OpenShift projects and extended existing entries with additional conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->