### PR TITLE
Bump UBI9 image to 9.8

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/konflux-ci/yq:latest AS yq
-FROM registry.access.redhat.com/ubi9:9.7-1778044007 AS builder
+FROM registry.access.redhat.com/ubi9:9.8-1781496985 AS builder
 
 ARG GOCILINT_VERSION="2.7.2"
 ARG GOCILINT_SHA256SUM="ce46a1f1d890e7b667259f70bb236297f5cf8791a9b6b98b41b283d93b5b6e88"
@@ -28,7 +28,7 @@ RUN curl -L -o kubectl-package ${KUBECTL_PACKAGE_LOCATION} && \
     chmod +x kubectl-package && \
     mv kubectl-package /usr/local/bin
 
-FROM registry.access.redhat.com/ubi9:9.7-1778044007
+FROM registry.access.redhat.com/ubi9:9.8-1781496985
 
 RUN dnf -y install openssh-clients jq skopeo python3-pyyaml git go-toolset rsync && \
     dnf clean all && \

--- a/pipelines/docker-build-oci-ta/pipeline.yaml
+++ b/pipelines/docker-build-oci-ta/pipeline.yaml
@@ -344,7 +344,7 @@ spec:
           - name: name
             value: sast-snyk-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:ba08e3b2dac65b0938ee312a9d6956770b98d99916100c2f9869f0090db3ad68
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:bc1328059d7d91d8fc3b7bf066a54bb0bb2442df2df890020c4f2bfed49d79a9
           - name: kind
             value: task
         resolver: bundles


### PR DESCRIPTION
This specific bump gives us Go 1.26.3, which is needed for CVE remediation.

Built locally:
```
 podman run localhost/boilerplate:latest go version
go version go1.26.3 (Red Hat 1.26.3-1.el9_8) linux/arm64
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the base container image to a newer Red Hat UBI9 patch level.
  * Refreshed the referenced SAST/Snyk Tekton bundle digest used by the OCI build pipeline task.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->