### PR TITLE
Build golangci-lint from source to match image Go version

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,15 +1,6 @@
 FROM quay.io/konflux-ci/yq:latest AS yq
 FROM registry.access.redhat.com/ubi9:9.8-1781496985 AS builder
 
-ARG GOCILINT_VERSION="2.7.2"
-ARG GOCILINT_SHA256SUM="ce46a1f1d890e7b667259f70bb236297f5cf8791a9b6b98b41b283d93b5b6e88"
-ARG GOCILINT_LOCATION=https://github.com/golangci/golangci-lint/releases/download/v${GOCILINT_VERSION}/golangci-lint-${GOCILINT_VERSION}-linux-amd64.tar.gz
-
-RUN curl -L -o golangci-lint.tar.gz ${GOCILINT_LOCATION} && \
-    echo ${GOCILINT_SHA256SUM} golangci-lint.tar.gz | sha256sum -c && \
-    tar xzf golangci-lint.tar.gz golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint && \
-    mv golangci-lint-${GOCILINT_VERSION}-linux-amd64/golangci-lint /usr/local/bin
-
 ARG GH_VERSION="2.58.0"
 ARG GH_SHA256SUM="84feae3d143bc360ea1004b474f124c8cfd75363a5e197d3ce63fe23d9f3a2ea"
 ARG GH_LOCATION=https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz
@@ -35,7 +26,8 @@ RUN dnf -y install openssh-clients jq skopeo python3-pyyaml git go-toolset rsync
     dnf -y autoremove && \
     rm -rf /var/cache/dnf
 
-ARG KUSTOMIZE_VERSION="v5.6.0" \
+ARG GOCILINT_VERSION="v2.7.2" \
+    KUSTOMIZE_VERSION="v5.6.0" \
     CONTROLLER_GEN_VERSION="v0.16.4" \
     OPENAPI_GEN_VERSION="v0.29.15" \
     ENVTEST_VERSION="release-0.23" \
@@ -47,7 +39,8 @@ ENV GOPATH=/go
 ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 ENV GOFLAGS="-mod=mod"
 
-RUN go install sigs.k8s.io/kustomize/kustomize/v5@${KUSTOMIZE_VERSION} && \
+RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOCILINT_VERSION} && \
+    go install sigs.k8s.io/kustomize/kustomize/v5@${KUSTOMIZE_VERSION} && \
     go install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION} && \
     go install k8s.io/code-generator/cmd/openapi-gen@${OPENAPI_GEN_VERSION} && \
     go install sigs.k8s.io/controller-runtime/tools/setup-envtest@${ENVTEST_VERSION} && \
@@ -62,7 +55,6 @@ RUN go install sigs.k8s.io/kustomize/kustomize/v5@${KUSTOMIZE_VERSION} && \
 # non-root user's gid is 0.
 RUN for bit in r x w; do find $(go env GOPATH) -perm -u+${bit} -a ! -perm -g+${bit} -exec chmod g+${bit} '{}' +; done
 
-COPY --from=builder /usr/local/bin/golangci-lint /usr/local/bin
 COPY --from=builder /usr/local/bin/gh /usr/local/bin
 COPY --from=builder /usr/local/bin/kubectl-package /usr/local/bin
 COPY --from=yq /usr/bin/yq /usr/bin/yq


### PR DESCRIPTION
Switch golangci-lint from a pre-compiled binary download to `go install` from source

The pre-compiled golangci-lint v2.7.2 binary from GitHub releases was built with Go 1.25. When consuming operators or their dependencies require Go 1.26, golangci-lint's embedded type checker panics:
```
panic: file requires newer Go version go1.26 (application built with go1.25)
```

Building golangci-lint from source via `go install` ensures it is always compiled with the same Go version shipped in the image, preventing this class of version mismatch.
