### PR TITLE
Update golangci-lint to v2.12.2 for Go 1.26 support

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/ensure.sh
+++ b/boilerplate/openshift/golang-osd-operator/ensure.sh
@@ -8,7 +8,7 @@ fi
 REPO_ROOT=$(git rev-parse --show-toplevel)
 source $REPO_ROOT/boilerplate/_lib/common.sh
 
-GOLANGCI_LINT_VERSION="2.7.2"
+GOLANGCI_LINT_VERSION="2.12.2"
 OPM_VERSION="v1.60.0"
 GRPCURL_VERSION="1.7.0"
 DEPENDENCY=${1:-}

--- a/boilerplate/openshift/golang-osd-operator/pre-commit-config.yaml
+++ b/boilerplate/openshift/golang-osd-operator/pre-commit-config.yaml
@@ -84,7 +84,7 @@ repos:
   #    Linter config: boilerplate/openshift/golang-osd-operator/golangci.yml
   # ---------------------------------------------------------------------------
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.0.2                          # pinned immutable tag — must match CI (golden rule 15)
+    rev: v2.12.2                         # pinned immutable tag — must match CI (golden rule 15)
     hooks:
       - id: golangci-lint
         args:

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -26,7 +26,7 @@ RUN dnf -y install openssh-clients jq skopeo python3-pyyaml git go-toolset rsync
     dnf -y autoremove && \
     rm -rf /var/cache/dnf
 
-ARG GOCILINT_VERSION="v2.7.2" \
+ARG GOCILINT_VERSION="v2.12.2" \
     KUSTOMIZE_VERSION="v5.6.0" \
     CONTROLLER_GEN_VERSION="v0.16.4" \
     OPENAPI_GEN_VERSION="v0.29.15" \


### PR DESCRIPTION
Update golangci-lint to v2.12.2 for Go 1.26 support