### PR TITLE
Update OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -54,7 +54,6 @@ aliases:
     - jaybeeunix
     - sam-nguyen7
     - wshearn
-    - devnulljason
     - npecka
     - pshickeydev
     - boranx


### PR DESCRIPTION
User changed their handle in https://github.com/openshift/boilerplate/commit/e80c64d14b1270998230374b4973695e1ef6ee35 but the new handle is not in the org which causes prow to fail CI on all repos that track boilerplate. Removing user from here for now to unblock PRs. cc @devnulljason 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal team ownership assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->