### PR TITLE
fix(pipelines): update Konflux task bundle digests to trusted versions

### DIFF
--- a/pipelines/bundle-builder/pipeline.yaml
+++ b/pipelines/bundle-builder/pipeline.yaml
@@ -268,7 +268,7 @@ spec:
       - name: name
         value: clair-scan
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:312fb4d135e351bde38bcb14a7897b238d0aac19703b4e507c105f12b57836f1
+        value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:8fad4c2e2f470f82ee43d6b2ac72327b4d9c6e9cb514a678911c1c9359c29894
       - name: kind
         value: task
       resolver: bundles
@@ -413,7 +413,7 @@ spec:
       - name: name
         value: rpms-signature-scan
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:65370ccb44ff82e4ce128addd913f3c96b298607b3760ee1339ed10011a4bd6b
+        value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:c78924dc4178da2356f4e8ee04e4ee5022e27851cc7d722765a2b0d337fdb069
       - name: kind
         value: task
       resolver: bundles

--- a/pipelines/docker-build-oci-ta/pipeline.yaml
+++ b/pipelines/docker-build-oci-ta/pipeline.yaml
@@ -292,7 +292,7 @@ spec:
           - name: name
             value: clair-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:312fb4d135e351bde38bcb14a7897b238d0aac19703b4e507c105f12b57836f1
+            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:8fad4c2e2f470f82ee43d6b2ac72327b4d9c6e9cb514a678911c1c9359c29894
           - name: kind
             value: task
         resolver: bundles
@@ -344,7 +344,7 @@ spec:
           - name: name
             value: sast-snyk-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:91980bb3d6ba0b200a2030f2be0722da0fbc9338c0c6ff897d0005a2f1259a9b
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.5@sha256:bdd187c336ee2e9e83e7a98b3e405635f3d3caf5d56c7780212469a3f3809c5c
           - name: kind
             value: task
         resolver: bundles
@@ -462,7 +462,7 @@ spec:
           - name: name
             value: sast-shell-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:fc685d6f7dfb7c9ab2f2db38bbe2c8d383407847350ccd8b96352322c487b13c
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:c4ef47e3b4e0508572d266fb745be7e374c29dc02580328cbe9f4d472a8aca57
           - name: kind
             value: task
         resolver: bundles
@@ -490,7 +490,7 @@ spec:
           - name: name
             value: sast-unicode-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:5807ffe3a0cca5cf970076bbc7a404642cc6e3eebe64e9e5e6a4f20da740bf73
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:90efa582de7770d55102b74014a765cd16a25a56f2cf644b56a788c70c4dc749
           - name: kind
             value: task
         resolver: bundles
@@ -552,7 +552,7 @@ spec:
           - name: name
             value: rpms-signature-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:65370ccb44ff82e4ce128addd913f3c96b298607b3760ee1339ed10011a4bd6b
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:c78924dc4178da2356f4e8ee04e4ee5022e27851cc7d722765a2b0d337fdb069
           - name: kind
             value: task
         resolver: bundles


### PR DESCRIPTION
## Summary
- Update 5 task bundle digest references in `docker-build-oci-ta` and 2 in `bundle-builder` pipelines to match the latest trusted upstream Konflux pipeline bundle (`pipeline-docker-build-oci-ta:devel`)
- The previous digests were rebuilt by Konflux CI (with the same floating version tags) but Renovate's `tekton-bundle` manager only detects version tag changes, not digest-only rebuilds — so these were missed by the automated PR #774
- This fixes EC `trusted_task.trusted` verification failures in downstream repos (e.g. `rbac-permissions-operator`)

### Updated tasks
| Task | Version | Old Digest | New Digest |
|------|---------|-----------|-----------|
| `task-clair-scan` | 0.3 | `312fb4d...` | `8fad4c2...` |
| `task-sast-snyk-check-oci-ta` | 0.5 | `91980bb...` | `bdd187c...` |
| `task-sast-shell-check-oci-ta` | 0.1 | `fc685d6...` | `c4ef47e...` |
| `task-sast-unicode-check-oci-ta` | 0.4 | `5807ffe...` | `90efa58...` |
| `task-rpms-signature-scan` | 0.2 | `65370cc...` | `c78924d...` |

## Test plan
- [ ] Verify EC `trusted_task.trusted` policy passes for builds using these pipelines
- [ ] Confirm downstream repos (e.g. `rbac-permissions-operator`) no longer fail with `required_untrusted_task_found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pipeline task bundle references to newer image digests in the build and security scanning workflows.
  * Several scan steps now pull from refreshed bundle versions while keeping task behavior and parameters unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->