### PR TITLE
SRE Operator Observability Compliance Markdown Template

### DIFF
--- a/boilerplate/openshift/doc/sre-operator-observability-template.md
+++ b/boilerplate/openshift/doc/sre-operator-observability-template.md
@@ -1,0 +1,23 @@
+# SRE Operator Observability Compliance Card
+
+## Operator name
+
+### Intended Purpose
+
+What purpose does the operator serve?
+
+### Blast Radius (customer-facing or internal)
+
+Classify the blast radius of operational disruption of the operator as customer-facing or internal, and provide specific details about the blast radius.
+
+### Key Metrics and Alerts
+
+Document metrics and alerts that are key for SRE remediation of operational disruptions of the operator.
+
+### Responsible Parties
+
+List the individuals who will be paged in the event of an incident.
+
+### Post-promotion Health Signals
+
+List the health signals that, upon inspection, verfiy that the operator is functioning properly post-promotion. 

--- a/boilerplate/openshift/doc/sre-operator-observability-template.md
+++ b/boilerplate/openshift/doc/sre-operator-observability-template.md
@@ -8,7 +8,7 @@ What purpose does the operator serve?
 
 ### Blast Radius (customer-facing or internal)
 
-Classify the blast radius of operational disruption of the operator as customer-facing or internal, and provide specific details about the blast radius.
+Provide details about the blast radius of the operator as it pertains to SREs, and then provide details that pertain to the customer view.
 
 ### Key Metrics and Alerts
 


### PR DESCRIPTION
Add a markdown template that should be used for each SRE operator to make an "Operator Observability Scorecard".