### PR TITLE
fix(pipelines): pin git-clone-oci-ta to 0.1 until trusted_task_rules rollout

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,12 @@
     "enabled": true,
     "packageRules": [
       {
+        "description": "Pin git-clone-oci-ta to 0.1 until trusted_task_rules rollout (2026-07-20). Remove this rule after rollout.",
+        "matchPackageNames": ["quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta"],
+        "allowedVersions": "<0.2",
+        "enabled": true
+      },
+      {
         "description": "Tekton patch/minor; batch and automerge Mon-Fri 02:00-04:59 UTC (requires Prow + Konflux via branch protection)",
         "matchUpdateTypes": [
           "minor",

--- a/pipelines/docker-build-oci-ta/pipeline.yaml
+++ b/pipelines/docker-build-oci-ta/pipeline.yaml
@@ -134,7 +134,7 @@ spec:
           - name: name
             value: git-clone-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:89da85c1508b3a2b7ad884c1215b9fd3a7d9e28c2335aca6750948d129707035
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d30f13dd15daf89dd6dc645243b3444d35570d13f7840c3fd65e366022515205
           - name: kind
             value: task
         resolver: bundles


### PR DESCRIPTION
## Summary

- Reverts `task-git-clone-oci-ta` from 0.2 to 0.1 — version 0.2 is [missing from data-acceptable-bundles](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1782459774279499?thread_ts=1782377560.929869&cid=C04PZ7H0VA8) due to a race condition in the decentralized trusted tasks model
- Adds a Renovate `allowedVersions` pin (`<0.2`) to prevent MintMaker from auto-upgrading back to 0.2
- Pin should be removed after the `trusted_task_rules` rollout on 2026-07-20

## Test plan

- [ ] Verify Konflux pipeline runs succeed with the 0.1 bundle
- [ ] Confirm Renovate does not propose a 0.2 upgrade while the pin is in place
- [ ] Remove the Renovate pin rule after July 20 rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the repository-clone step to use a pinned, older task version for more predictable pipeline runs.
  * Added a temporary version constraint for the same task to keep builds on a trusted release until the rollout is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->