### PR TITLE
fix(pipelines): update git-clone-oci-ta task bundle to trusted version

### DIFF
--- a/pipelines/docker-build-oci-ta/pipeline.yaml
+++ b/pipelines/docker-build-oci-ta/pipeline.yaml
@@ -134,7 +134,7 @@ spec:
           - name: name
             value: git-clone-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:89da85c1508b3a2b7ad884c1215b9fd3a7d9e28c2335aca6750948d129707035
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:52827a47564514f6accab971b8fad4f1c1cf59997507ed7c4e534615eeeae567
           - name: kind
             value: task
         resolver: bundles


### PR DESCRIPTION
## Summary
- Updates `git-clone-oci-ta` task bundle digest from `sha256:89da85c1...` to `sha256:52827a47...` (the current trusted version)
- The previous digest was revoked, causing `trusted_task.trusted` violations in downstream repos (e.g. rbac-permissions-operator)

## Test plan
- [ ] Verify downstream builds (e.g. rbac-permissions-operator) no longer fail with `trusted_task.trusted` violation for `git-clone-oci-ta`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal build pipeline reference to a newer bundled image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->