### PR TITLE
Update OWNERS_ALIASES to match ROSA org restructure

### DIFF
--- a/.tekton/OWNERS
+++ b/.tekton/OWNERS
@@ -1,6 +1,6 @@
 reviewers:
 - joshbranham
-- srep-infra-cicd
+- rosa-staff-engineers
 approvers:
 - joshbranham
-- srep-infra-cicd
+- rosa-staff-engineers

--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,12 @@
 reviewers:
 - srep-functional-team-aurora
-- srep-functional-leads
-- srep-team-leads
+- rosa-staff-engineers
 - xiaoyu74
 - joshbranham
 approvers:
 - srep-functional-team-aurora
-- srep-functional-leads
-- srep-team-leads
+- rosa-staff-engineers
 - joshbranham
 maintainers:
-- srep-functional-leads
-- srep-team-leads
+- rosa-staff-engineers
 - joshbranham

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -50,13 +50,6 @@ aliases:
     - Mhodesty
     - nephomaniac
     - tnierman
-  srep-functional-team-security:
-    - jaybeeunix
-    - sam-nguyen7
-    - wshearn
-    - npecka
-    - pshickeydev
-    - boranx
   srep-functional-team-thor:
     - diakovnec
     - MitaliBhalla
@@ -65,25 +58,42 @@ aliases:
     - xiaoyu74
     - Tessg22
     - smarthall
-  srep-infra-cicd:
-    - ritmun
-    - yiqinzhang
-    - varunraokadaparthi
-  srep-functional-leads:
-    - clcollins
+  rosa-staff-engineers:
+    - Ajpantuso
     - bergmannf
-    - theautoroboto
-    - smarthall
-    - sam-nguyen7
-    - ravitri
-  srep-team-leads:
-    - rafael-azevedo
-    - dustman9000
     - bmeng
+    - bpresnel-rh
+    - cdoan1
+    - clcollins
+    - dustman9000
+    - joshbranham
+    - jmelis
+    - lucasponce
+    - psav
+    - rafael-azevedo
+    - ravitri
+    - rbhilare
+    - robpblake
+    - smarthall
+    - syed
+    - theautoroboto
+    - tiwillia
     - typeid
-  sre-group-leads:
-    - apahim
-    - maorfr
-    - rogbas
-  srep-architects:
-    - cblecker
+  rosa-managers:
+    - afreiberger
+    - c-e-brumm
+    - drewandersonnz
+    - evalis1
+    - geowa4
+    - jcaianirh
+    - jnewton75
+    - krishvoor
+    - kseiter-rh
+    - OliviaHY
+    - syncrou
+    - tdrozdowski
+    - tkiss28
+    - vkumar51
+  hp-architects:
+    - deads2k
+    - jhjaggars

--- a/boilerplate/openshift/golang-osd-e2e/OWNERS
+++ b/boilerplate/openshift/golang-osd-e2e/OWNERS
@@ -1,4 +1,4 @@
 reviewers:
-- srep-infra-cicd
+- rosa-staff-engineers
 approvers:
-- srep-infra-cicd
+- rosa-staff-engineers

--- a/boilerplate/openshift/golang-osd-operator-precheck/OWNERS
+++ b/boilerplate/openshift/golang-osd-operator-precheck/OWNERS
@@ -1,4 +1,4 @@
 reviewers:
-- srep-infra-cicd
+- rosa-staff-engineers
 approvers:
-- srep-infra-cicd
+- rosa-staff-engineers

--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -18,17 +18,62 @@ cp ${HERE}/.codecov.yml $REPO_ROOT
 echo "Copying OWNERS_ALIASES to your repository root."
 cp -L ${HERE}/OWNERS_ALIASES $REPO_ROOT
 
-# Clean up srep-infra-cicd from .tekton/OWNERS if it exists
-TEKTON_OWNERS="${REPO_ROOT}/.tekton/OWNERS"
-if [[ -f "${TEKTON_OWNERS}" ]] && grep -q "srep-infra-cicd" "${TEKTON_OWNERS}"; then
-	echo "Removing srep-infra-cicd from .tekton/OWNERS..."
-	${SED?} -i '/srep-infra-cicd/d' "${TEKTON_OWNERS}"
-
-	# If no owners remain (ignoring section headers, comments, and blank lines), remove the file
-	if ! grep -qE "^\\s*-\\s+\\S" "${TEKTON_OWNERS}"; then
-		echo "Removing .tekton/OWNERS (no owners remain after cleanup)"
-		rm "${TEKTON_OWNERS}"
+# Migrate renamed/removed aliases in OWNERS files (one-time migration)
+OWNERS_UPDATED=()
+NEEDS_REVIEW=()
+while IFS= read -r -d '' owners_file; do
+	changed=false
+	if grep -q 'srep-functional-leads' "${owners_file}"; then
+		echo "Renaming srep-functional-leads -> rosa-staff-engineers in ${owners_file}"
+		${SED?} -i 's/srep-functional-leads/rosa-staff-engineers/g' "${owners_file}"
+		changed=true
 	fi
+	if grep -q 'srep-architects' "${owners_file}"; then
+		echo "Renaming srep-architects -> hp-architects in ${owners_file}"
+		${SED?} -i 's/srep-architects/hp-architects/g' "${owners_file}"
+		changed=true
+	fi
+	for stale in srep-team-leads sre-group-leads; do
+		if grep -q "${stale}" "${owners_file}"; then
+			echo "Removing ${stale} from ${owners_file}"
+			${SED?} -i "/${stale}/d" "${owners_file}"
+			changed=true
+		fi
+	done
+	for stale in srep-functional-team-security srep-infra-cicd; do
+		if grep -q "${stale}" "${owners_file}"; then
+			echo "WARNING: Removing ${stale} from ${owners_file} (alias no longer exists, no direct replacement)"
+			${SED?} -i "/${stale}/d" "${owners_file}"
+			NEEDS_REVIEW+=("${owners_file}: ${stale} was removed with no replacement. Please add appropriate reviewers/approvers.")
+			changed=true
+		fi
+	done
+	if [[ "${changed}" == "true" ]]; then
+		if ! grep -qE "^\s*-\s+\S" "${owners_file}"; then
+			echo "Removing ${owners_file} (no owners remain after cleanup)"
+			rm "${owners_file}"
+		fi
+		OWNERS_UPDATED+=("${owners_file}")
+	fi
+done < <(find "${REPO_ROOT}" -name 'OWNERS' -not -path '*/.git/*' -not -path '*/boilerplate/*' -print0)
+
+if [[ ${#OWNERS_UPDATED[@]} -gt 0 ]]; then
+	echo ""
+	echo "====================="
+	echo "NOTICE: Boilerplate updated the following OWNERS files to migrate stale aliases:"
+	for f in "${OWNERS_UPDATED[@]}"; do
+		echo "  - ${f}"
+	done
+	echo ""
+	echo "Please review these files to ensure the changes are correct."
+	if [[ ${#NEEDS_REVIEW[@]} -gt 0 ]]; then
+		echo ""
+		echo "ACTION REQUIRED:"
+		for msg in "${NEEDS_REVIEW[@]}"; do
+			echo "  - ${msg}"
+		done
+	fi
+	echo "====================="
 fi
 
 # Add dependabot configuration

--- a/boilerplate/openshift/osd-container-image/update
+++ b/boilerplate/openshift/osd-container-image/update
@@ -14,6 +14,64 @@ source $CONVENTION_ROOT/_lib/common.sh
 echo "Copying OWNERS_ALIASES to your repository root."
 cp ${HERE}/OWNERS_ALIASES $REPO_ROOT
 
+# Migrate renamed/removed aliases in OWNERS files (one-time migration)
+OWNERS_UPDATED=()
+NEEDS_REVIEW=()
+while IFS= read -r -d '' owners_file; do
+	changed=false
+	if grep -q 'srep-functional-leads' "${owners_file}"; then
+		echo "Renaming srep-functional-leads -> rosa-staff-engineers in ${owners_file}"
+		${SED?} -i 's/srep-functional-leads/rosa-staff-engineers/g' "${owners_file}"
+		changed=true
+	fi
+	if grep -q 'srep-architects' "${owners_file}"; then
+		echo "Renaming srep-architects -> hp-architects in ${owners_file}"
+		${SED?} -i 's/srep-architects/hp-architects/g' "${owners_file}"
+		changed=true
+	fi
+	for stale in srep-team-leads sre-group-leads; do
+		if grep -q "${stale}" "${owners_file}"; then
+			echo "Removing ${stale} from ${owners_file}"
+			${SED?} -i "/${stale}/d" "${owners_file}"
+			changed=true
+		fi
+	done
+	for stale in srep-functional-team-security srep-infra-cicd; do
+		if grep -q "${stale}" "${owners_file}"; then
+			echo "WARNING: Removing ${stale} from ${owners_file} (alias no longer exists, no direct replacement)"
+			${SED?} -i "/${stale}/d" "${owners_file}"
+			NEEDS_REVIEW+=("${owners_file}: ${stale} was removed with no replacement. Please add appropriate reviewers/approvers.")
+			changed=true
+		fi
+	done
+	if [[ "${changed}" == "true" ]]; then
+		if ! grep -qE "^\s*-\s+\S" "${owners_file}"; then
+			echo "Removing ${owners_file} (no owners remain after cleanup)"
+			rm "${owners_file}"
+		fi
+		OWNERS_UPDATED+=("${owners_file}")
+	fi
+done < <(find "${REPO_ROOT}" -name 'OWNERS' -not -path '*/.git/*' -not -path '*/boilerplate/*' -print0)
+
+if [[ ${#OWNERS_UPDATED[@]} -gt 0 ]]; then
+	echo ""
+	echo "====================="
+	echo "NOTICE: Boilerplate updated the following OWNERS files to migrate stale aliases:"
+	for f in "${OWNERS_UPDATED[@]}"; do
+		echo "  - ${f}"
+	done
+	echo ""
+	echo "Please review these files to ensure the changes are correct."
+	if [[ ${#NEEDS_REVIEW[@]} -gt 0 ]]; then
+		echo ""
+		echo "ACTION REQUIRED:"
+		for msg in "${NEEDS_REVIEW[@]}"; do
+			echo "  - ${msg}"
+		done
+	fi
+	echo "====================="
+fi
+
 # Add dependabot configuration
 mkdir -p $REPO_ROOT/.github
 TARGET_FILE="${REPO_ROOT}/.github/dependabot.yml"

--- a/pipelines/OWNERS
+++ b/pipelines/OWNERS
@@ -1,4 +1,4 @@
 reviewers:
-- srep-infra-cicd
+- rosa-staff-engineers
 approvers:
-- srep-infra-cicd
+- rosa-staff-engineers


### PR DESCRIPTION
## Summary

The ROSA org has been restructured under Hybrid Platforms. The old "SREP" naming and "leads" terminology no longer applies.

- Rename aliases to match the new ROSA org structure
  - `srep-functional-leads` -> `rosa-staff-engineers`
  - `srep-architects` -> `hp-architects`
- Remove aliases that no longer apply
  - `srep-team-leads` (removed)
  - `sre-group-leads` (removed)
  - `srep-functional-team-security` (moved to Platform Engineering)
  - `srep-infra-cicd` (moved to Platform Engineering)
- Add new aliases
  - `rosa-managers` (ROSA managers in the openshift org)
- Update all OWNERS files in this repo to use the new alias names
- Convention update scripts (`golang-osd-operator/update`, `osd-container-image/update`) now auto-migrate stale alias references in consuming repos during `make boilerplate-update`

### Impact on consuming repos

When consuming repos run `make boilerplate-update`, the update script will automatically:
1. Copy in the new `OWNERS_ALIASES`
2. Rename `srep-functional-leads` -> `rosa-staff-engineers` in all OWNERS files
3. Rename `srep-architects` -> `hp-architects` in all OWNERS files
4. Remove references to `srep-team-leads`, `sre-group-leads`, `srep-functional-team-security`, and `srep-infra-cicd` from all OWNERS files
5. Print a notice listing which OWNERS files were updated for maintainer review

This affects ~26 repos in the openshift org that reference `srep-functional-leads`/`srep-team-leads`, and 2 repos that reference `srep-functional-team-security`.

Tested locally against `route-monitor-operator` with `BOILERPLATE_GIT_REPO` override.

## Test plan

- [x] Local test against route-monitor-operator
- [ ] CI passes
- [ ] Verify no stale references in this repo
