### PR TITLE
ROSA-745: route MintMaker dependency PRs through Prow/Tide

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,7 @@
     "enabled": true,
     "packageRules": [
       {
-        "description": "Tekton patch/minor; batch and automerge Mon-Fri 02:00-04:59 UTC (requires Prow + Konflux via branch protection)",
+        "description": "Tekton patch/minor; batch Mon-Fri 02:00-04:59 UTC — pre-label lgtm/approved; Tide merges after Prow + Konflux",
         "matchUpdateTypes": [
           "minor",
           "patch",
@@ -26,8 +26,8 @@
           "digest"
         ],
         "schedule": ["* 2-4 * * 1-5"],
-        "automergeSchedule": ["* 2-4 * * 1-5"],
-        "automerge": true,
+        "automerge": false,
+        "platformAutomerge": false,
         "addLabels": ["lgtm", "approved"]
       },
       {
@@ -49,7 +49,7 @@
   "gomod": {
     "packageRules": [
       {
-        "description": "Grouped gomod minor/patch; batch and automerge Mon-Fri 02:00-04:59 UTC (requires Prow + Konflux via branch protection)",
+        "description": "Grouped gomod minor/patch; batch Mon-Fri 02:00-04:59 UTC — pre-label lgtm/approved; Tide merges after Prow + Konflux",
         "matchUpdateTypes": [
           "minor",
           "patch",
@@ -58,8 +58,8 @@
         ],
         "groupName": "gomod dependencies",
         "schedule": ["* 2-4 * * 1-5"],
-        "automergeSchedule": ["* 2-4 * * 1-5"],
-        "automerge": true,
+        "automerge": false,
+        "platformAutomerge": false,
         "addLabels": ["lgtm", "approved"]
       },
       {


### PR DESCRIPTION
## Summary

Update shared `.github/renovate.json` for Prow/Tide-integrated Konflux operators that `extends` this config.

For **gomod** and **tekton** patch/minor/pin/digest updates:

- Keep UTC weekday batch window (`02:00–04:59`, Mon–Fri) and grouped gomod PRs
- Keep `lgtm` + `approved` labels on safe dependency PRs
- Set `automerge: false` and `platformAutomerge: false` so **Tide** merges after required `ci/prow/*` and Konflux `*-on-pull-request` checks pass

Major updates are unchanged (manual review labels, no automerge).

## Rollout

Operators that only `extends` openshift/boilerplate pick this up on the next boilerplate sync — no per-repo `renovate.json` change required.

Repos with **local** `packageRules` overrides still need a separate PR (e.g. configuration-anomaly-detection #864).

## Test plan

- [ ] Merge this PR
- [ ] On one plain-extends operator: `make boilerplate-update`, merge boilerplate bump
- [ ] Next MintMaker patch/minor gomod or tekton PR: has `lgtm` + `approved`, no Renovate/platform automerge
- [ ] PR merges via Tide when required checks green

## References

- [ROSA-745](https://redhat.atlassian.net/browse/ROSA-745)
- MintMaker docs: https://konflux.pages.redhat.com/docs/users/mintmaker/user.html

[ROSA-745]: https://redhat.atlassian.net/browse/ROSA-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ