### PR TITLE
Add agentic SDLC conformance check pipeline (ROSA-730)

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/agentic-sdlc-check-pull-request.yaml.tmpl
+++ b/boilerplate/openshift/golang-osd-operator/agentic-sdlc-check-pull-request.yaml.tmpl
@@ -1,0 +1,223 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/__OPERATOR_NAME__?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: 'true'
+    pipelinesascode.tekton.dev/max-keep-runs: '3'
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "master"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: __OPERATOR_NAME__
+    appstudio.openshift.io/component: __OPERATOR_NAME__
+    pipelines.appstudio.openshift.io/type: test
+  name: __OPERATOR_NAME__-agentic-sdlc-check
+  namespace: __OPERATOR_NAME__-tenant
+spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-__OPERATOR_NAME__
+  pipelineSpec:
+    tasks:
+      - name: clone-repository
+        params:
+          - name: url
+            value: '{{source_url}}'
+          - name: revision
+            value: '{{revision}}'
+        taskRef:
+          params:
+            - name: name
+              value: git-clone
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:39efcb7d049d84feccce65e589996a89b19ab7c9f504015c3792e3daee697da3
+            - name: kind
+              value: task
+          resolver: bundles
+        workspaces:
+          - name: output
+            workspace: workspace
+          - name: basic-auth
+            workspace: git-auth
+      - name: check-file-existence
+        runAfter:
+          - clone-repository
+        taskSpec:
+          steps:
+            - name: check-files
+              image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
+              workingDir: $(workspaces.source.path)/source
+              script: |
+                #!/usr/bin/env sh
+                set -eu
+
+                PASS=0
+                FAIL=0
+
+                pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+                fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+                echo "=== Agentic SDLC Conformance: File Existence (ROSA-730) ==="
+                echo "Repository: $(basename $(pwd))"
+                echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                echo ""
+
+                if [ -f "CLAUDE.md" ]; then pass "CLAUDE.md exists"; else fail "CLAUDE.md missing"; fi
+                if [ -f ".pre-commit-config.yaml" ]; then pass ".pre-commit-config.yaml exists"; else fail ".pre-commit-config.yaml missing"; fi
+                if [ -f ".codecov.yml" ]; then pass ".codecov.yml exists"; else fail ".codecov.yml missing"; fi
+                if [ -f "CONTRIBUTING.md" ]; then pass "CONTRIBUTING.md exists"; else fail "CONTRIBUTING.md missing"; fi
+                if [ -f "DEVELOPMENT.md" ]; then pass "DEVELOPMENT.md exists"; else fail "DEVELOPMENT.md missing"; fi
+                if [ -f "TESTING.md" ]; then pass "TESTING.md exists"; else fail "TESTING.md missing"; fi
+
+                if [ -f "CLAUDE.md" ]; then
+                  if [ -f ".claude/settings.json" ]; then pass ".claude/settings.json exists"; else fail ".claude/settings.json missing (CLAUDE.md present but no Claude hooks)"; fi
+                fi
+
+                if [ -d "boilerplate/openshift/golang-osd-operator" ]; then
+                  if [ -f "boilerplate/openshift/golang-osd-operator/golangci.yml" ]; then pass "golangci.yml exists (boilerplate convention)"; else fail "golangci.yml missing from boilerplate/openshift/golang-osd-operator/"; fi
+                elif [ -d "boilerplate/openshift/golang-lint" ]; then
+                  if [ -f "boilerplate/openshift/golang-lint/golangci.yml" ]; then pass "golangci.yml exists (golang-lint convention)"; else fail "golangci.yml missing from boilerplate/openshift/golang-lint/"; fi
+                else
+                  if [ -f ".golangci.yml" ] || [ -f ".golangci.yaml" ]; then pass "golangci config exists at repo root"; else fail "golangci config missing (no boilerplate dir and no root .golangci.yml/.yaml)"; fi
+                fi
+
+                echo ""
+                TOTAL=$((PASS + FAIL))
+                echo "File existence: $PASS / $TOTAL passed"
+                if [ "$FAIL" -gt 0 ]; then exit 1; fi
+          workspaces:
+            - name: source
+        workspaces:
+          - name: source
+            workspace: workspace
+      - name: check-content-validation
+        runAfter:
+          - clone-repository
+        taskSpec:
+          steps:
+            - name: check-content
+              image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
+              workingDir: $(workspaces.source.path)/source
+              script: |
+                #!/usr/bin/env sh
+                set -eu
+
+                PASS=0
+                FAIL=0
+                WARN=0
+
+                pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+                fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+                warn() { echo "WARN: $1"; WARN=$((WARN + 1)); }
+
+                echo "=== Agentic SDLC Conformance: Content Validation (ROSA-730) ==="
+                echo "Repository: $(basename $(pwd))"
+                echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                echo ""
+
+                # CLAUDE.md required sections
+                if [ -f "CLAUDE.md" ]; then
+                  claude_content=$(cat CLAUDE.md)
+
+                  if echo "$claude_content" | grep -qiE '##.*(build commands|development commands|build|dev server)'; then
+                    pass "CLAUDE.md has build/development commands section"
+                  else
+                    fail "CLAUDE.md missing build/development commands section"
+                  fi
+
+                  if echo "$claude_content" | grep -qiE '##.*(agent rules|agents must|agent)'; then
+                    pass "CLAUDE.md has agent rules section"
+                  else
+                    warn "CLAUDE.md missing agent rules section (recommended heading: Agent Rules)"
+                  fi
+
+                  if echo "$claude_content" | grep -qiE '##.*(architecture|project overview|what this operator does|overview)'; then
+                    pass "CLAUDE.md has architecture/overview section"
+                  else
+                    fail "CLAUDE.md missing architecture/overview section"
+                  fi
+                else
+                  fail "CLAUDE.md not found — skipping content checks"
+                fi
+
+                # .codecov.yml patch coverage target
+                if [ -f ".codecov.yml" ]; then
+                  patch_target=$(grep -A5 'patch:' .codecov.yml | grep 'target:' | head -1 | grep -oE '[0-9]+' | head -1)
+                  if [ -n "$patch_target" ]; then
+                    if [ "$patch_target" -ge 50 ]; then
+                      pass ".codecov.yml patch coverage target is ${patch_target}% (>= 50%)"
+                    else
+                      fail ".codecov.yml patch coverage target is ${patch_target}% (should be >= 50%)"
+                    fi
+                  else
+                    warn ".codecov.yml patch coverage target could not be parsed"
+                  fi
+                fi
+
+                # .pre-commit-config.yaml required hooks
+                if [ -f ".pre-commit-config.yaml" ]; then
+                  pcf_content=$(cat .pre-commit-config.yaml)
+
+                  if echo "$pcf_content" | grep -q 'gitleaks'; then
+                    pass ".pre-commit-config.yaml includes gitleaks (secrets detection)"
+                  else
+                    fail ".pre-commit-config.yaml missing gitleaks hook"
+                  fi
+
+                  if echo "$pcf_content" | grep -q 'golangci-lint'; then
+                    pass ".pre-commit-config.yaml includes golangci-lint"
+                  else
+                    fail ".pre-commit-config.yaml missing golangci-lint hook"
+                  fi
+
+                  if echo "$pcf_content" | grep -qE '(check-yaml|check-merge-conflict)'; then
+                    pass ".pre-commit-config.yaml includes file hygiene hooks"
+                  else
+                    fail ".pre-commit-config.yaml missing file hygiene hooks (check-yaml or check-merge-conflict)"
+                  fi
+                fi
+
+                # Documentation files must not be stubs
+                for doc in CONTRIBUTING.md DEVELOPMENT.md TESTING.md; do
+                  if [ -f "$doc" ]; then
+                    line_count=$(wc -l < "$doc")
+                    if [ "$line_count" -gt 10 ]; then
+                      pass "$doc has substantive content (${line_count} lines)"
+                    else
+                      fail "$doc appears to be a stub (${line_count} lines, expected > 10)"
+                    fi
+                  fi
+                done
+
+                echo ""
+                TOTAL=$((PASS + FAIL + WARN))
+                echo "Content validation: $PASS passed, $FAIL failed, $WARN warnings out of $TOTAL checks"
+                if [ "$FAIL" -gt 0 ]; then
+                  echo ""
+                  echo "See ROSA-730 for agentic SDLC standards: https://issues.redhat.com/browse/ROSA-730"
+                  exit 1
+                fi
+          workspaces:
+            - name: source
+        workspaces:
+          - name: source
+            workspace: workspace
+    workspaces:
+      - name: workspace
+      - name: git-auth
+  workspaces:
+    - name: workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'
+status: {}

--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -161,6 +161,13 @@ ${SED?} "s/__NAMESPACE__/$IMAGE_NAMESPACE/; s/__NAME__/$IMAGE_NAME/; s/__TAG__/$
 echo "Copying pre-commit-config.yaml to .pre-commit-config.yaml"
 cp ${HERE}/pre-commit-config.yaml $REPO_ROOT/.pre-commit-config.yaml
 
+# Add agentic SDLC conformance check pipeline (ROSA-730)
+if [ -d "${REPO_ROOT}/.tekton" ]; then
+  AGENTIC_CHECK="${REPO_ROOT}/.tekton/${OPERATOR_NAME}-agentic-sdlc-check-pull-request.yaml"
+  echo "Generating agentic SDLC conformance check pipeline: $(basename ${AGENTIC_CHECK})"
+  ${SED?} "s/__OPERATOR_NAME__/${OPERATOR_NAME}/g" ${HERE}/agentic-sdlc-check-pull-request.yaml.tmpl > "${AGENTIC_CHECK}"
+fi
+
 # Check for pipeline files in .tekton directory and centralize them
 TEKTON_DIR="${REPO_ROOT}/.tekton"
 if [ -d "$TEKTON_DIR" ]; then


### PR DESCRIPTION
## Summary

- Adds a Konflux pipeline template that validates [ROSA-730](https://redhat.atlassian.net/browse/ROSA-730) agentic SDLC standards on every PR to subscriber repos
- Generated during `make boilerplate-update` — the operator name is substituted from `config/config.go`
- The check reports a **visible red X** on non-conformant PRs but does **not block merge** (not in `required_status_checks`)

## What it checks

### File existence (parallel task)
- `CLAUDE.md`, `.pre-commit-config.yaml`, `.codecov.yml`
- `CONTRIBUTING.md`, `DEVELOPMENT.md`, `TESTING.md`
- `.claude/settings.json` (conditional on `CLAUDE.md` existing)
- `golangci.yml` (in boilerplate convention dir or repo root)

### Content validation (parallel task)
- `CLAUDE.md` has required sections (build commands, architecture/overview)
- `.codecov.yml` patch coverage target >= 50%
- `.pre-commit-config.yaml` includes gitleaks, golangci-lint, file hygiene hooks
- Documentation files are substantive (> 10 lines, not stubs)

## Files changed

| File | Description |
|------|-------------|
| `boilerplate/openshift/golang-osd-operator/agentic-sdlc-check-pull-request.yaml.tmpl` | PipelineRun template with `__OPERATOR_NAME__` placeholders |
| `boilerplate/openshift/golang-osd-operator/update` | Added generation logic to create the `.tekton/` PipelineRun during boilerplate update |

## How it works

1. During `make boilerplate-update`, the template is rendered with the operator name and written to `.tekton/<operator>-agentic-sdlc-check-pull-request.yaml`
2. Pipelines-as-Code picks it up and runs it on every PR
3. Uses the Konflux catalog `git-clone:0.1` task for cloning, and `quay.io/konflux-ci/git-clone` image for the check steps
4. Three pipeline tasks: clone → file-existence + content-validation (the checks run in parallel)

## Prior art

Tested and validated on [openshift/deadmanssnitch-operator#337](https://github.com/openshift/deadmanssnitch-operator/pull/337) — clone succeeds, both check tasks correctly report failures for missing [ROSA-730](https://redhat.atlassian.net/browse/ROSA-730) artifacts, pipeline shows red X without blocking merge.

## Test plan

- [x] Local dry-run against managed-velero-operator (conformant) and pagerduty-operator (non-conformant)
- [x] Live Konflux pipeline test on deadmanssnitch-operator PR #337
- [x] Verified non-blocking: check fails but is not in `required_status_checks`, so `/lgtm` + `/approve` still merge
- [ ] Run `make boilerplate-update` on a subscriber repo to verify template generation

[ROSA-730](https://redhat.atlassian.net/browse/ROSA-730)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ROSA-730]: https://redhat.atlassian.net/browse/ROSA-730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROSA-730]: https://redhat.atlassian.net/browse/ROSA-730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ