### PR TITLE
Fix agentic SDLC check: resolve @ includes, switch to informing mode

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/agentic-sdlc-check-pull-request.yaml.tmpl
+++ b/boilerplate/openshift/golang-osd-operator/agentic-sdlc-check-pull-request.yaml.tmpl
@@ -45,6 +45,7 @@ spec:
       - name: check-file-existence
         runAfter:
           - clone-repository
+        onError: continue
         taskSpec:
           steps:
             - name: check-files
@@ -96,6 +97,7 @@ spec:
       - name: check-content-validation
         runAfter:
           - clone-repository
+        onError: continue
         taskSpec:
           steps:
             - name: check-content
@@ -118,9 +120,14 @@ spec:
                 echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
                 echo ""
 
-                # CLAUDE.md required sections
+                # CLAUDE.md required sections (resolve one level of @ includes)
                 if [ -f "CLAUDE.md" ]; then
-                  claude_content=$(cat CLAUDE.md)
+                  check_files="CLAUDE.md"
+                  for ref in $(grep -oE '@[^ `]+' CLAUDE.md 2>/dev/null); do
+                    ref_file=$(echo "$ref" | sed 's/^@//')
+                    [ -f "$ref_file" ] && check_files="$check_files $ref_file"
+                  done
+                  claude_content=$(cat $(echo "$check_files" | tr ' ' '\n' | sort -u) 2>/dev/null)
 
                   if echo "$claude_content" | grep -qiE '##.*(build commands|development commands|build|dev server)'; then
                     pass "CLAUDE.md has build/development commands section"


### PR DESCRIPTION
## Summary

Two fixes for the agentic SDLC conformance check pipeline added in #788:

1. **Resolve CLAUDE.md `@` includes** — repos using `@AGENTS.md` (or similar Claude Code include directives) had content checks fail because the script only read CLAUDE.md itself. Now resolves one level of `@` references, deduplicates with `sort -u`, and checks the combined content.

2. **Add `onError: continue`** to both check tasks so the pipeline always passes at the PipelineRun level. Non-conformance is still visible in the individual task status (red task in Konflux UI) but the overall GitHub check reports success.

## What changed

| Line | Change |
|------|--------|
| `check-file-existence` task | Added `onError: continue` |
| `check-content-validation` task | Added `onError: continue` |
| CLAUDE.md content resolution | Resolves `@` references one level deep before checking for required sections |

## Testing

Validated locally against `openshift/deadmanssnitch-operator` (which uses `@AGENTS.md` as its CLAUDE.md):
- Before fix: content checks fail (only sees `@AGENTS.md` text)
- After fix: resolves to `CLAUDE.md + AGENTS.md`, finds all required sections, passes 17/18 (1 advisory warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)