### PR TITLE
fixed boilerplate/openshift/golang-osd-operator/update

### DIFF
--- a/.tekton/boilerplate-master-pr-check.yaml
+++ b/.tekton/boilerplate-master-pr-check.yaml
@@ -62,7 +62,7 @@ spec:
           - name: name
             value: git-clone
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.2@sha256:14983fd4c447d40897ebd732e1b90b242dd3a1a781db92bb909366fbddd3b688
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.2@sha256:4ba6a13721fc5e7258d2ca6a0bed0dae9be5548691c691cb5eb36aea5ac62136
           - name: kind
             value: task
         resolver: bundles

--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -111,7 +111,7 @@ if [[ -f ${REPO_ROOT}/.gitignore ]]; then
   ${SED?} -i "/Dockerfile.olm-registry/d" ${REPO_ROOT}/.gitignore
 fi
 
-OPERATOR_NAME=$(sed -n 's/.*OperatorName .*"\([^"]*\)".*/\1/p' "${REPO_ROOT}/config/config.go")
+OPERATOR_NAME=$(${SED?} -n 's/.*OperatorName .*"\([^"]*\)".*/\1/p' "${REPO_ROOT}/config/config.go" | head -1)
 
 if [[ ! -f ${REPO_ROOT}/config/metadata/additional-labels.txt ]]; then
   mkdir -p ${REPO_ROOT}/config/metadata

--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -111,7 +111,7 @@ if [[ -f ${REPO_ROOT}/.gitignore ]]; then
   ${SED?} -i "/Dockerfile.olm-registry/d" ${REPO_ROOT}/.gitignore
 fi
 
-OPERATOR_NAME=$(${SED?} -n 's/.*OperatorName .*"\([^"]*\)".*/\1/p' "${REPO_ROOT}/config/config.go" | head -1)
+OPERATOR_NAME=$(${SED?} -n 's/.*OperatorName .*\=.*"\([^"]*\)".*/\1/p' "${REPO_ROOT}/config/config.go")
 
 if [[ ! -f ${REPO_ROOT}/config/metadata/additional-labels.txt ]]; then
   mkdir -p ${REPO_ROOT}/config/metadata

--- a/pipelines/docker-build-oci-ta/pipeline.yaml
+++ b/pipelines/docker-build-oci-ta/pipeline.yaml
@@ -490,7 +490,7 @@ spec:
           - name: name
             value: sast-unicode-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:4a8bed5c46a9b1426411e32aaf6e9f2073e10ec482743d845327e297b8796916
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:4961c44d6475f0343fe73c556a44204daa85d8c47e23f98d723255d1ff98271d
           - name: kind
             value: task
         resolver: bundles


### PR DESCRIPTION
Fix for this error:
`sed: -e expression #1, char 44: unterminated 's' command
make: *** [boilerplate-update] Error 1`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the pipeline’s referenced task image versions for repository cloning and the SAST Unicode check, by switching to newer task bundle digest references.
  * No changes to pipeline flow, parameters, or end-user behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->