### PR TITLE
Remove jmelis from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -67,7 +67,6 @@ aliases:
     - clcollins
     - dustman9000
     - joshbranham
-    - jmelis
     - lucasponce
     - psav
     - rafael-azevedo


### PR DESCRIPTION
In order to not be in the slack handle for boilerplate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a team alias mapping by removing one GitHub username from the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->