### PR TITLE
Derive Konflux tenant and SA from existing pipelines (ROSA-730)

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/agentic-sdlc-check-pull-request.yaml.tmpl
+++ b/boilerplate/openshift/golang-osd-operator/agentic-sdlc-check-pull-request.yaml.tmpl
@@ -16,10 +16,10 @@ metadata:
     appstudio.openshift.io/component: __OPERATOR_NAME__
     pipelines.appstudio.openshift.io/type: test
   name: __OPERATOR_NAME__-agentic-sdlc-check
-  namespace: __OPERATOR_NAME__-tenant
+  namespace: __TENANT_NAMESPACE__
 spec:
   taskRunTemplate:
-    serviceAccountName: build-pipeline-__OPERATOR_NAME__
+    serviceAccountName: __SERVICE_ACCOUNT__
   pipelineSpec:
     tasks:
       - name: clone-repository

--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -167,7 +167,11 @@ if [ -d "${REPO_ROOT}/.tekton" ]; then
   echo "Generating agentic SDLC conformance check pipeline: $(basename ${AGENTIC_CHECK})"
   DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/upstream/HEAD 2>/dev/null || git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null || echo defaulting/to/master)
   DEFAULT_BRANCH=${DEFAULT_BRANCH##*/}
-  ${SED?} "s/__OPERATOR_NAME__/${OPERATOR_NAME}/g; s/__DEFAULT_BRANCH__/${DEFAULT_BRANCH}/g" ${HERE}/agentic-sdlc-check-pull-request.yaml.tmpl > "${AGENTIC_CHECK}"
+  TENANT_NAMESPACE=$(grep -h 'namespace:' "${REPO_ROOT}"/.tekton/*-pull-request.yaml 2>/dev/null | grep -v agentic | head -1 | awk '{print $2}')
+  TENANT_NAMESPACE=${TENANT_NAMESPACE:-${OPERATOR_NAME}-tenant}
+  SERVICE_ACCOUNT=$(grep -h 'serviceAccountName:' "${REPO_ROOT}"/.tekton/${OPERATOR_NAME}*-pull-request.yaml 2>/dev/null | grep -v agentic | grep -v pko | grep -v e2e | head -1 | awk '{print $2}')
+  SERVICE_ACCOUNT=${SERVICE_ACCOUNT:-build-pipeline-${OPERATOR_NAME}}
+  ${SED?} "s/__OPERATOR_NAME__/${OPERATOR_NAME}/g; s/__DEFAULT_BRANCH__/${DEFAULT_BRANCH}/g; s/__TENANT_NAMESPACE__/${TENANT_NAMESPACE}/g; s/__SERVICE_ACCOUNT__/${SERVICE_ACCOUNT}/g" ${HERE}/agentic-sdlc-check-pull-request.yaml.tmpl > "${AGENTIC_CHECK}"
 fi
 
 # Check for pipeline files in .tekton directory and centralize them


### PR DESCRIPTION
## Summary

The agentic SDLC check pipeline template previously constructed the Konflux tenant namespace and service account from the operator name (`<operator>-tenant`, `build-pipeline-<operator>`). This fails for repos onboarded to Konflux with non-standard naming.

This PR reads both values from existing `.tekton/*-pull-request.yaml` files instead, which are the source of truth (created by Konflux during onboarding, never regenerated by boilerplate). Falls back to the convention if no existing pipelines are found.

## Affected repos

| Repo | Actual tenant | Convention would produce |
|------|--------------|------------------------|
| configure-alertmanager-operator | `camo-hcm-tenant` | `configure-alertmanager-operator-tenant` |
| configure-goalert-operator | `fedramp-srep-tenant` | `configure-goalert-operator-tenant` |

CAMO also has a non-standard SA: `build-pipeline-configure-alertmanager-operator-master` vs `build-pipeline-configure-alertmanager-operator`.

## How it works

```bash
# Read from existing Konflux pipelines, skip the agentic check itself
TENANT_NAMESPACE=$(grep -h 'namespace:' .tekton/*-pull-request.yaml | grep -v agentic | head -1 | awk '{print $2}')
TENANT_NAMESPACE=${TENANT_NAMESPACE:-${OPERATOR_NAME}-tenant}

SERVICE_ACCOUNT=$(grep -h 'serviceAccountName:' .tekton/*-pull-request.yaml | grep -v agentic | head -1 | awk '{print $2}')
SERVICE_ACCOUNT=${SERVICE_ACCOUNT:-build-pipeline-${OPERATOR_NAME}}
```

## Related

- [ROSAENG-61679](https://redhat.atlassian.net/browse/ROSAENG-61679): CAMO tenant naming mismatch
- PR #790: `@` include resolution and `onError: continue` (merged)
- PR #798: Default branch detection (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ROSAENG-61679]: https://redhat.atlassian.net/browse/ROSAENG-61679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ