### PR TITLE
Refactor agentic SDLC check to use centralized pipelineRef (ROSA-730)

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/agentic-sdlc-check-pull-request.yaml.tmpl
+++ b/boilerplate/openshift/golang-osd-operator/agentic-sdlc-check-pull-request.yaml.tmpl
@@ -18,203 +18,13 @@ metadata:
   name: __OPERATOR_NAME__-agentic-sdlc-check
   namespace: __TENANT_NAMESPACE__
 spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: revision
+      value: '{{revision}}'
   taskRunTemplate:
     serviceAccountName: __SERVICE_ACCOUNT__
-  pipelineSpec:
-    tasks:
-      - name: clone-repository
-        params:
-          - name: url
-            value: '{{source_url}}'
-          - name: revision
-            value: '{{revision}}'
-        taskRef:
-          params:
-            - name: name
-              value: git-clone
-            - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:39efcb7d049d84feccce65e589996a89b19ab7c9f504015c3792e3daee697da3
-            - name: kind
-              value: task
-          resolver: bundles
-        workspaces:
-          - name: output
-            workspace: workspace
-          - name: basic-auth
-            workspace: git-auth
-      - name: check-file-existence
-        runAfter:
-          - clone-repository
-        onError: continue
-        taskSpec:
-          steps:
-            - name: check-files
-              image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
-              workingDir: $(workspaces.source.path)/source
-              script: |
-                #!/usr/bin/env sh
-                set -eu
-
-                PASS=0
-                FAIL=0
-
-                pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
-                fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
-
-                echo "=== Agentic SDLC Conformance: File Existence (ROSA-730) ==="
-                echo "Repository: $(basename $(pwd))"
-                echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-                echo ""
-
-                if [ -f "CLAUDE.md" ]; then pass "CLAUDE.md exists"; else fail "CLAUDE.md missing"; fi
-                if [ -f ".pre-commit-config.yaml" ]; then pass ".pre-commit-config.yaml exists"; else fail ".pre-commit-config.yaml missing"; fi
-                if [ -f ".codecov.yml" ]; then pass ".codecov.yml exists"; else fail ".codecov.yml missing"; fi
-                if [ -f "CONTRIBUTING.md" ]; then pass "CONTRIBUTING.md exists"; else fail "CONTRIBUTING.md missing"; fi
-                if [ -f "DEVELOPMENT.md" ]; then pass "DEVELOPMENT.md exists"; else fail "DEVELOPMENT.md missing"; fi
-                if [ -f "TESTING.md" ]; then pass "TESTING.md exists"; else fail "TESTING.md missing"; fi
-
-                if [ -f "CLAUDE.md" ]; then
-                  if [ -f ".claude/settings.json" ]; then pass ".claude/settings.json exists"; else fail ".claude/settings.json missing (CLAUDE.md present but no Claude hooks)"; fi
-                fi
-
-                if [ -d "boilerplate/openshift/golang-osd-operator" ]; then
-                  if [ -f "boilerplate/openshift/golang-osd-operator/golangci.yml" ]; then pass "golangci.yml exists (boilerplate convention)"; else fail "golangci.yml missing from boilerplate/openshift/golang-osd-operator/"; fi
-                elif [ -d "boilerplate/openshift/golang-lint" ]; then
-                  if [ -f "boilerplate/openshift/golang-lint/golangci.yml" ]; then pass "golangci.yml exists (golang-lint convention)"; else fail "golangci.yml missing from boilerplate/openshift/golang-lint/"; fi
-                else
-                  if [ -f ".golangci.yml" ] || [ -f ".golangci.yaml" ]; then pass "golangci config exists at repo root"; else fail "golangci config missing (no boilerplate dir and no root .golangci.yml/.yaml)"; fi
-                fi
-
-                echo ""
-                TOTAL=$((PASS + FAIL))
-                echo "File existence: $PASS / $TOTAL passed"
-                if [ "$FAIL" -gt 0 ]; then exit 1; fi
-          workspaces:
-            - name: source
-        workspaces:
-          - name: source
-            workspace: workspace
-      - name: check-content-validation
-        runAfter:
-          - clone-repository
-        onError: continue
-        taskSpec:
-          steps:
-            - name: check-content
-              image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
-              workingDir: $(workspaces.source.path)/source
-              script: |
-                #!/usr/bin/env sh
-                set -eu
-
-                PASS=0
-                FAIL=0
-                WARN=0
-
-                pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
-                fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
-                warn() { echo "WARN: $1"; WARN=$((WARN + 1)); }
-
-                echo "=== Agentic SDLC Conformance: Content Validation (ROSA-730) ==="
-                echo "Repository: $(basename $(pwd))"
-                echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-                echo ""
-
-                # CLAUDE.md required sections (resolve one level of @ includes)
-                if [ -f "CLAUDE.md" ]; then
-                  check_files="CLAUDE.md"
-                  for ref in $(grep -oE '@[^ `]+' CLAUDE.md 2>/dev/null); do
-                    ref_file=$(echo "$ref" | sed 's/^@//')
-                    [ -f "$ref_file" ] && check_files="$check_files $ref_file"
-                  done
-                  claude_content=$(cat $(echo "$check_files" | tr ' ' '\n' | sort -u) 2>/dev/null)
-
-                  if echo "$claude_content" | grep -qiE '##.*(build commands|development commands|build|dev server)'; then
-                    pass "CLAUDE.md has build/development commands section"
-                  else
-                    fail "CLAUDE.md missing build/development commands section"
-                  fi
-
-                  if echo "$claude_content" | grep -qiE '##.*(agent rules|agents must|agent)'; then
-                    pass "CLAUDE.md has agent rules section"
-                  else
-                    warn "CLAUDE.md missing agent rules section (recommended heading: Agent Rules)"
-                  fi
-
-                  if echo "$claude_content" | grep -qiE '##.*(architecture|project overview|what this operator does|overview)'; then
-                    pass "CLAUDE.md has architecture/overview section"
-                  else
-                    fail "CLAUDE.md missing architecture/overview section"
-                  fi
-                else
-                  fail "CLAUDE.md not found — skipping content checks"
-                fi
-
-                # .codecov.yml patch coverage target
-                if [ -f ".codecov.yml" ]; then
-                  patch_target=$(grep -A5 'patch:' .codecov.yml | grep 'target:' | head -1 | grep -oE '[0-9]+' | head -1)
-                  if [ -n "$patch_target" ]; then
-                    if [ "$patch_target" -ge 50 ]; then
-                      pass ".codecov.yml patch coverage target is ${patch_target}% (>= 50%)"
-                    else
-                      fail ".codecov.yml patch coverage target is ${patch_target}% (should be >= 50%)"
-                    fi
-                  else
-                    warn ".codecov.yml patch coverage target could not be parsed"
-                  fi
-                fi
-
-                # .pre-commit-config.yaml required hooks
-                if [ -f ".pre-commit-config.yaml" ]; then
-                  pcf_content=$(cat .pre-commit-config.yaml)
-
-                  if echo "$pcf_content" | grep -q 'gitleaks'; then
-                    pass ".pre-commit-config.yaml includes gitleaks (secrets detection)"
-                  else
-                    fail ".pre-commit-config.yaml missing gitleaks hook"
-                  fi
-
-                  if echo "$pcf_content" | grep -q 'golangci-lint'; then
-                    pass ".pre-commit-config.yaml includes golangci-lint"
-                  else
-                    fail ".pre-commit-config.yaml missing golangci-lint hook"
-                  fi
-
-                  if echo "$pcf_content" | grep -qE '(check-yaml|check-merge-conflict)'; then
-                    pass ".pre-commit-config.yaml includes file hygiene hooks"
-                  else
-                    fail ".pre-commit-config.yaml missing file hygiene hooks (check-yaml or check-merge-conflict)"
-                  fi
-                fi
-
-                # Documentation files must not be stubs
-                for doc in CONTRIBUTING.md DEVELOPMENT.md TESTING.md; do
-                  if [ -f "$doc" ]; then
-                    line_count=$(wc -l < "$doc")
-                    if [ "$line_count" -gt 10 ]; then
-                      pass "$doc has substantive content (${line_count} lines)"
-                    else
-                      fail "$doc appears to be a stub (${line_count} lines, expected > 10)"
-                    fi
-                  fi
-                done
-
-                echo ""
-                TOTAL=$((PASS + FAIL + WARN))
-                echo "Content validation: $PASS passed, $FAIL failed, $WARN warnings out of $TOTAL checks"
-                if [ "$FAIL" -gt 0 ]; then
-                  echo ""
-                  echo "See ROSA-730 for agentic SDLC standards: https://issues.redhat.com/browse/ROSA-730"
-                  exit 1
-                fi
-          workspaces:
-            - name: source
-        workspaces:
-          - name: source
-            workspace: workspace
-    workspaces:
-      - name: workspace
-      - name: git-auth
   workspaces:
     - name: workspace
       volumeClaimTemplate:
@@ -227,4 +37,13 @@ spec:
     - name: git-auth
       secret:
         secretName: '{{ git_auth_secret }}'
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: https://github.com/openshift/boilerplate
+      - name: revision
+        value: master
+      - name: pathInRepo
+        value: pipelines/agentic-sdlc-check/pipeline.yaml
 status: {}

--- a/pipelines/agentic-sdlc-check/pipeline.yaml
+++ b/pipelines/agentic-sdlc-check/pipeline.yaml
@@ -1,0 +1,214 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: agentic-sdlc-check
+spec:
+  description: |
+    Checks that a repository conforms to ROSA-730 agentic SDLC standards.
+    Validates file existence and content for CLAUDE.md, pre-commit hooks,
+    codecov, documentation, and linting configuration.
+    Runs in informing mode — individual tasks may fail without failing the pipeline.
+  params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: ""
+      description: Revision of the Source Repository
+      name: revision
+      type: string
+  tasks:
+    - name: clone-repository
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.revision)
+        - name: subdirectory
+          value: source
+      taskRef:
+        params:
+          - name: name
+            value: git-clone
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:39efcb7d049d84feccce65e589996a89b19ab7c9f504015c3792e3daee697da3
+          - name: kind
+            value: task
+        resolver: bundles
+      workspaces:
+        - name: output
+          workspace: workspace
+        - name: basic-auth
+          workspace: git-auth
+    - name: check-file-existence
+      runAfter:
+        - clone-repository
+      onError: continue
+      taskSpec:
+        steps:
+          - name: check-files
+            image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
+            workingDir: $(workspaces.source.path)/source
+            script: |
+              #!/usr/bin/env sh
+              set -eu
+
+              PASS=0
+              FAIL=0
+
+              pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+              fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+              echo "=== Agentic SDLC Conformance: File Existence (ROSA-730) ==="
+              echo "Repository: $(basename $(pwd))"
+              echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+              echo ""
+
+              if [ -f "CLAUDE.md" ]; then pass "CLAUDE.md exists"; else fail "CLAUDE.md missing"; fi
+              if [ -f ".pre-commit-config.yaml" ]; then pass ".pre-commit-config.yaml exists"; else fail ".pre-commit-config.yaml missing"; fi
+              if [ -f ".codecov.yml" ]; then pass ".codecov.yml exists"; else fail ".codecov.yml missing"; fi
+              if [ -f "CONTRIBUTING.md" ]; then pass "CONTRIBUTING.md exists"; else fail "CONTRIBUTING.md missing"; fi
+              if [ -f "DEVELOPMENT.md" ]; then pass "DEVELOPMENT.md exists"; else fail "DEVELOPMENT.md missing"; fi
+              if [ -f "TESTING.md" ]; then pass "TESTING.md exists"; else fail "TESTING.md missing"; fi
+
+              if [ -f "CLAUDE.md" ]; then
+                if [ -f ".claude/settings.json" ]; then pass ".claude/settings.json exists"; else fail ".claude/settings.json missing (CLAUDE.md present but no Claude hooks)"; fi
+              fi
+
+              if [ -d "boilerplate/openshift/golang-osd-operator" ]; then
+                if [ -f "boilerplate/openshift/golang-osd-operator/golangci.yml" ]; then pass "golangci.yml exists (boilerplate convention)"; else fail "golangci.yml missing from boilerplate/openshift/golang-osd-operator/"; fi
+              elif [ -d "boilerplate/openshift/golang-lint" ]; then
+                if [ -f "boilerplate/openshift/golang-lint/golangci.yml" ]; then pass "golangci.yml exists (golang-lint convention)"; else fail "golangci.yml missing from boilerplate/openshift/golang-lint/"; fi
+              else
+                if [ -f ".golangci.yml" ] || [ -f ".golangci.yaml" ]; then pass "golangci config exists at repo root"; else fail "golangci config missing (no boilerplate dir and no root .golangci.yml/.yaml)"; fi
+              fi
+
+              echo ""
+              TOTAL=$((PASS + FAIL))
+              echo "File existence: $PASS / $TOTAL passed"
+              if [ "$FAIL" -gt 0 ]; then exit 1; fi
+        workspaces:
+          - name: source
+      workspaces:
+        - name: source
+          workspace: workspace
+    - name: check-content-validation
+      runAfter:
+        - clone-repository
+      onError: continue
+      taskSpec:
+        steps:
+          - name: check-content
+            image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
+            workingDir: $(workspaces.source.path)/source
+            script: |
+              #!/usr/bin/env sh
+              set -eu
+
+              PASS=0
+              FAIL=0
+              WARN=0
+
+              pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+              fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+              warn() { echo "WARN: $1"; WARN=$((WARN + 1)); }
+
+              echo "=== Agentic SDLC Conformance: Content Validation (ROSA-730) ==="
+              echo "Repository: $(basename $(pwd))"
+              echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+              echo ""
+
+              # CLAUDE.md required sections (resolve one level of @ includes)
+              if [ -f "CLAUDE.md" ]; then
+                check_files="CLAUDE.md"
+                for ref in $(grep -oE '@[^ `]+' CLAUDE.md 2>/dev/null); do
+                  ref_file=$(echo "$ref" | sed 's/^@//')
+                  [ -f "$ref_file" ] && check_files="$check_files $ref_file"
+                done
+                claude_content=$(cat $(echo "$check_files" | tr ' ' '\n' | sort -u) 2>/dev/null)
+
+                if echo "$claude_content" | grep -qiE '##.*(build commands|development commands|build|dev server)'; then
+                  pass "CLAUDE.md has build/development commands section"
+                else
+                  fail "CLAUDE.md missing build/development commands section"
+                fi
+
+                if echo "$claude_content" | grep -qiE '##.*(agent rules|agents must|agent)'; then
+                  pass "CLAUDE.md has agent rules section"
+                else
+                  warn "CLAUDE.md missing agent rules section (recommended heading: Agent Rules)"
+                fi
+
+                if echo "$claude_content" | grep -qiE '##.*(architecture|project overview|what this operator does|overview)'; then
+                  pass "CLAUDE.md has architecture/overview section"
+                else
+                  fail "CLAUDE.md missing architecture/overview section"
+                fi
+              else
+                fail "CLAUDE.md not found — skipping content checks"
+              fi
+
+              # .codecov.yml patch coverage target
+              if [ -f ".codecov.yml" ]; then
+                patch_target=$(grep -A5 'patch:' .codecov.yml | grep 'target:' | head -1 | grep -oE '[0-9]+' | head -1)
+                if [ -n "$patch_target" ]; then
+                  if [ "$patch_target" -ge 50 ]; then
+                    pass ".codecov.yml patch coverage target is ${patch_target}% (>= 50%)"
+                  else
+                    fail ".codecov.yml patch coverage target is ${patch_target}% (should be >= 50%)"
+                  fi
+                else
+                  warn ".codecov.yml patch coverage target could not be parsed"
+                fi
+              fi
+
+              # .pre-commit-config.yaml required hooks
+              if [ -f ".pre-commit-config.yaml" ]; then
+                pcf_content=$(cat .pre-commit-config.yaml)
+
+                if echo "$pcf_content" | grep -q 'gitleaks'; then
+                  pass ".pre-commit-config.yaml includes gitleaks (secrets detection)"
+                else
+                  fail ".pre-commit-config.yaml missing gitleaks hook"
+                fi
+
+                if echo "$pcf_content" | grep -q 'golangci-lint'; then
+                  pass ".pre-commit-config.yaml includes golangci-lint"
+                else
+                  fail ".pre-commit-config.yaml missing golangci-lint hook"
+                fi
+
+                if echo "$pcf_content" | grep -qE '(check-yaml|check-merge-conflict)'; then
+                  pass ".pre-commit-config.yaml includes file hygiene hooks"
+                else
+                  fail ".pre-commit-config.yaml missing file hygiene hooks (check-yaml or check-merge-conflict)"
+                fi
+              fi
+
+              # Documentation files must not be stubs
+              for doc in CONTRIBUTING.md DEVELOPMENT.md TESTING.md; do
+                if [ -f "$doc" ]; then
+                  line_count=$(wc -l < "$doc")
+                  if [ "$line_count" -gt 10 ]; then
+                    pass "$doc has substantive content (${line_count} lines)"
+                  else
+                    fail "$doc appears to be a stub (${line_count} lines, expected > 10)"
+                  fi
+                fi
+              done
+
+              echo ""
+              TOTAL=$((PASS + FAIL + WARN))
+              echo "Content validation: $PASS passed, $FAIL failed, $WARN warnings out of $TOTAL checks"
+              if [ "$FAIL" -gt 0 ]; then
+                echo ""
+                echo "See ROSA-730 for agentic SDLC standards: https://issues.redhat.com/browse/ROSA-730"
+                exit 1
+              fi
+        workspaces:
+          - name: source
+      workspaces:
+        - name: source
+          workspace: workspace
+  workspaces:
+    - name: workspace
+    - name: git-auth


### PR DESCRIPTION
## Summary

Moves the agentic SDLC conformance check logic from the per-repo PipelineRun template into a centralized Pipeline definition, matching the pattern used by `docker-build-oci-ta`.

**Before:** Each subscriber repo gets a ~230-line PipelineRun with all check logic inlined. Updating check logic requires `make boilerplate-update` across all repos.

**After:** Each subscriber repo gets a ~45-line PipelineRun that references `pipelines/agentic-sdlc-check/pipeline.yaml` via the git resolver. Updating check logic only needs a commit to boilerplate — all repos pick it up immediately.

## Files changed

| File | Change |
|------|--------|
| `pipelines/agentic-sdlc-check/pipeline.yaml` | **New** — centralized Pipeline with clone, file-existence, and content-validation tasks |
| `boilerplate/.../agentic-sdlc-check-pull-request.yaml.tmpl` | **Rewritten** — thin PipelineRun with `pipelineRef` instead of inline `pipelineSpec` |

## How it works

The PipelineRun in each subscriber repo now contains only:
- Operator-specific metadata (namespace, SA, labels)
- `pipelineRef` pointing at `pipelines/agentic-sdlc-check/pipeline.yaml` in this repo
- Params: `git-url` and `revision`

```yaml
pipelineRef:
  resolver: git
  params:
    - name: url
      value: https://github.com/openshift/boilerplate
    - name: revision
      value: master
    - name: pathInRepo
      value: pipelines/agentic-sdlc-check/pipeline.yaml
```

Non-boilerplate repos can use the same `pipelineRef` since the pipeline lives in a public repo.

## Benefits

- Check logic updates don't require `make boilerplate-update` across repos
- Non-boilerplate repos can reference the same pipeline
- Matches the established pattern for `docker-build-oci-ta`
- Template is small enough to review at a glance

🤖 Generated with [Claude Code](https://claude.com/claude-code)