### PR TITLE
Harden gangway-bridge template

### DIFF
--- a/boilerplate/openshift/golang-osd-e2e/gangway-bridge-template.yml
+++ b/boilerplate/openshift/golang-osd-e2e/gangway-bridge-template.yml
@@ -29,7 +29,7 @@ objects:
       name: gangway-bridge-${IMAGE_TAG}-${JOBID}
     spec:
       backoffLimit: 0
-      activeDeadlineSeconds: 7200
+      activeDeadlineSeconds: ${{TIMEOUT}}
       template:
         spec:
           automountServiceAccountToken: false
@@ -43,6 +43,9 @@ objects:
                 - |
                   GW="https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com/v1/executions"
                   log() { echo "$(date +%H:%M:%S) $*" >&2; }
+
+                  [[ "${TIMEOUT}" =~ ^[0-9]+$ ]] || { log "ERROR: TIMEOUT must be numeric"; exit 1; }
+                  [[ "${POLL_INTERVAL}" =~ ^[0-9]+$ ]] || { log "ERROR: POLL_INTERVAL must be numeric"; exit 1; }
 
                   BODY='{"job_execution_type":"1"}'
                   if [[ -n "${JOB_ENVS:-}" ]]; then
@@ -88,6 +91,7 @@ objects:
                   memory: "128Mi"
               securityContext:
                 runAsNonRoot: true
+                readOnlyRootFilesystem: true
                 allowPrivilegeEscalation: false
                 capabilities:
                   drop: ["ALL"]


### PR DESCRIPTION
Address review feedback on the gangway-bridge template:

1. **Dynamic activeDeadlineSeconds**: Use ${{TIMEOUT}} instead of hardcoded 7200 so the Job deadline matches the configured timeout
2. **Validate numeric parameters**: Check TIMEOUT and POLL_INTERVAL are numeric before bash arithmetic to prevent injection
3. **Read-only root filesystem**: Add readOnlyRootFilesystem: true since the polling Job doesn't need writes