### PR TITLE
Fix agentic-sdlc-check: auto-detect Konflux application and component names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directories:
+      - "/boilerplate"
+      - "/config"
+    labels:
+      - "area/dependency"
+      - "ok-to-test"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "redhat-services-prod/openshift/boilerplate"
+        # don't upgrade boilerplate via these means
+      - dependency-name: "openshift4/ose-operator-registry"
+        # don't upgrade ose-operator-registry via these means

--- a/boilerplate/openshift/golang-osd-operator/agentic-sdlc-check-pull-request.yaml.tmpl
+++ b/boilerplate/openshift/golang-osd-operator/agentic-sdlc-check-pull-request.yaml.tmpl
@@ -12,8 +12,8 @@ metadata:
       == "__DEFAULT_BRANCH__"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: __OPERATOR_NAME__
-    appstudio.openshift.io/component: __OPERATOR_NAME__
+    appstudio.openshift.io/application: __APP_NAME__
+    appstudio.openshift.io/component: __COMPONENT_NAME__
     pipelines.appstudio.openshift.io/type: test
   name: __OPERATOR_NAME__-agentic-sdlc-check
   namespace: __TENANT_NAMESPACE__

--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -167,11 +167,22 @@ if [ -d "${REPO_ROOT}/.tekton" ]; then
   echo "Generating agentic SDLC conformance check pipeline: $(basename ${AGENTIC_CHECK})"
   DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/upstream/HEAD 2>/dev/null || git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null || echo defaulting/to/master)
   DEFAULT_BRANCH=${DEFAULT_BRANCH##*/}
-  TENANT_NAMESPACE=$(grep -h 'namespace:' "${REPO_ROOT}"/.tekton/*-pull-request.yaml 2>/dev/null | grep -v agentic | head -1 | awk '{print $2}')
-  TENANT_NAMESPACE=${TENANT_NAMESPACE:-${OPERATOR_NAME}-tenant}
-  SERVICE_ACCOUNT=$(grep -h 'serviceAccountName:' "${REPO_ROOT}"/.tekton/${OPERATOR_NAME}*-pull-request.yaml 2>/dev/null | grep -v agentic | grep -v pko | grep -v e2e | head -1 | awk '{print $2}')
-  SERVICE_ACCOUNT=${SERVICE_ACCOUNT:-build-pipeline-${OPERATOR_NAME}}
-  ${SED?} "s/__OPERATOR_NAME__/${OPERATOR_NAME}/g; s/__DEFAULT_BRANCH__/${DEFAULT_BRANCH}/g; s/__TENANT_NAMESPACE__/${TENANT_NAMESPACE}/g; s/__SERVICE_ACCOUNT__/${SERVICE_ACCOUNT}/g" ${HERE}/agentic-sdlc-check-pull-request.yaml.tmpl > "${AGENTIC_CHECK}"
+  MAIN_TEKTON=$(ls "${REPO_ROOT}"/.tekton/${OPERATOR_NAME}*-pull-request.yaml 2>/dev/null | grep -v agentic | grep -v pko | grep -v e2e | head -1)
+  TENANT_NAMESPACE=${OPERATOR_NAME}-tenant
+  SERVICE_ACCOUNT=build-pipeline-${OPERATOR_NAME}
+  APP_NAME=${OPERATOR_NAME}
+  COMPONENT_NAME=${OPERATOR_NAME}
+  if [[ -n "${MAIN_TEKTON}" ]]; then
+    TENANT_NAMESPACE=$(grep 'namespace:' "${MAIN_TEKTON}" 2>/dev/null | head -1 | awk '{print $2}')
+    TENANT_NAMESPACE=${TENANT_NAMESPACE:-${OPERATOR_NAME}-tenant}
+    SERVICE_ACCOUNT=$(grep 'serviceAccountName:' "${MAIN_TEKTON}" 2>/dev/null | head -1 | awk '{print $2}')
+    SERVICE_ACCOUNT=${SERVICE_ACCOUNT:-build-pipeline-${OPERATOR_NAME}}
+    APP_NAME=$(grep 'appstudio.openshift.io/application:' "${MAIN_TEKTON}" 2>/dev/null | head -1 | awk '{print $2}')
+    APP_NAME=${APP_NAME:-${OPERATOR_NAME}}
+    COMPONENT_NAME=$(grep 'appstudio.openshift.io/component:' "${MAIN_TEKTON}" 2>/dev/null | head -1 | awk '{print $2}')
+    COMPONENT_NAME=${COMPONENT_NAME:-${OPERATOR_NAME}}
+  fi
+  ${SED?} "s/__OPERATOR_NAME__/${OPERATOR_NAME}/g; s/__DEFAULT_BRANCH__/${DEFAULT_BRANCH}/g; s/__TENANT_NAMESPACE__/${TENANT_NAMESPACE}/g; s/__SERVICE_ACCOUNT__/${SERVICE_ACCOUNT}/g; s/__APP_NAME__/${APP_NAME}/g; s/__COMPONENT_NAME__/${COMPONENT_NAME}/g" ${HERE}/agentic-sdlc-check-pull-request.yaml.tmpl > "${AGENTIC_CHECK}"
 fi
 
 # Check for pipeline files in .tekton directory and centralize them


### PR DESCRIPTION
The agentic-sdlc-check pipeline template hardcoded the operator name as the Konflux application and component labels. This fails for operators where the Konflux names differ (e.g. CAMO uses configure-alertmanager-operator-master as the application name, not configure-alertmanager-operator).

Fix: auto-detect application and component names from existing .tekton pipeline files, same pattern as namespace and service account detection. Falls back to operator name if no existing pipelines found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated weekly dependency update checks for Docker-related configuration.
  * Automatically applies labels to generated update proposals to streamline review.
  * Excludes specific protected upgrades from automated dependency updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->