### PR TITLE
Harden boilerplate-generated CI artifacts

### DIFF
--- a/boilerplate/openshift/golang-osd-e2e/gangway-bridge-template.yml
+++ b/boilerplate/openshift/golang-osd-e2e/gangway-bridge-template.yml
@@ -44,8 +44,8 @@ objects:
                   GW="https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com/v1/executions"
                   log() { echo "$(date +%H:%M:%S) $*" >&2; }
 
-                  [[ "${TIMEOUT}" =~ ^[0-9]+$ ]] || { log "ERROR: TIMEOUT must be numeric"; exit 1; }
-                  [[ "${POLL_INTERVAL}" =~ ^[0-9]+$ ]] || { log "ERROR: POLL_INTERVAL must be numeric"; exit 1; }
+                  [[ "${TIMEOUT}" =~ ^[1-9][0-9]*$ ]] || { log "ERROR: TIMEOUT must be a positive integer"; exit 1; }
+                  [[ "${POLL_INTERVAL}" =~ ^[1-9][0-9]*$ ]] || { log "ERROR: POLL_INTERVAL must be a positive integer"; exit 1; }
 
                   BODY='{"job_execution_type":"1"}'
                   if [[ -n "${JOB_ENVS:-}" ]]; then

--- a/boilerplate/openshift/golang-osd-e2e/update
+++ b/boilerplate/openshift/golang-osd-e2e/update
@@ -94,8 +94,7 @@ EOF
 
 tee "${E2E_SUITE_DIRECTORY}/README.md" <<EOF
 ## Locally running e2e test suite
-When updating your operator it's beneficial to add e2e tests for new functionality AND ensure existing functionality is not breaking using e2e tests.
-To do this, following steps are recommended
+When updating your operator, add e2e tests for new functionality and ensure existing functionality continues to work. The following steps are recommended:
 
 1. Run "make e2e-binary-build"  to make sure e2e tests build
 2. Deploy your new version of operator in a test cluster

--- a/boilerplate/openshift/golang-osd-operator/agentic-sdlc-check-pull-request.yaml.tmpl
+++ b/boilerplate/openshift/golang-osd-operator/agentic-sdlc-check-pull-request.yaml.tmpl
@@ -43,7 +43,7 @@ spec:
       - name: url
         value: https://github.com/openshift/boilerplate
       - name: revision
-        value: master
+        value: __BOILERPLATE_REVISION__
       - name: pathInRepo
         value: pipelines/agentic-sdlc-check/pipeline.yaml
 status: {}

--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -183,7 +183,8 @@ if [ -d "${REPO_ROOT}/.tekton" ]; then
     COMPONENT_NAME=$(grep 'appstudio.openshift.io/component:' "${MAIN_TEKTON}" 2>/dev/null | head -1 | awk '{print $2}')
     COMPONENT_NAME=${COMPONENT_NAME:-${OPERATOR_NAME}}
   fi
-  ${SED?} "s/__OPERATOR_NAME__/${OPERATOR_NAME}/g; s/__DEFAULT_BRANCH__/${DEFAULT_BRANCH}/g; s/__TENANT_NAMESPACE__/${TENANT_NAMESPACE}/g; s/__SERVICE_ACCOUNT__/${SERVICE_ACCOUNT}/g; s/__APP_NAME__/${APP_NAME}/g; s/__COMPONENT_NAME__/${COMPONENT_NAME}/g" ${HERE}/agentic-sdlc-check-pull-request.yaml.tmpl > "${AGENTIC_CHECK}"
+  BOILERPLATE_REVISION=$(git -C "${HERE}" rev-parse HEAD)
+  ${SED?} "s/__OPERATOR_NAME__/${OPERATOR_NAME}/g; s/__DEFAULT_BRANCH__/${DEFAULT_BRANCH}/g; s/__TENANT_NAMESPACE__/${TENANT_NAMESPACE}/g; s/__SERVICE_ACCOUNT__/${SERVICE_ACCOUNT}/g; s/__APP_NAME__/${APP_NAME}/g; s/__COMPONENT_NAME__/${COMPONENT_NAME}/g; s/__BOILERPLATE_REVISION__/${BOILERPLATE_REVISION}/g" ${HERE}/agentic-sdlc-check-pull-request.yaml.tmpl > "${AGENTIC_CHECK}"
 fi
 
 # Check for pipeline files in .tekton directory and centralize them


### PR DESCRIPTION
## Summary

Addresses CodeRabbit findings from downstream operator PRs (e.g. openshift/splunk-forwarder-operator#457) where boilerplate-generated files were flagged for hardening.

- **Pin agentic SDLC pipeline ref to boilerplate commit SHA**: The Tekton PipelineRun template previously referenced `master` (mutable). Now uses a `__BOILERPLATE_REVISION__` placeholder that the update script resolves to the current boilerplate commit hash via `git rev-parse HEAD`. Each `make boilerplate-update` automatically picks up the correct SHA.
- **Reject zero POLL_INTERVAL and TIMEOUT in gangway bridge**: A zero value would cause the polling loop to fire continuously for the entire timeout duration. Updated regex from `^[0-9]+$` to `^[1-9][0-9]*$` to require positive integers.
- **Clean up e2e README wording**: Minor clarity improvement in the locally-running-e2e-tests instructions.

Note: The `origin-tools:latest` image tag in `gangway-bridge-template.yml` is intentionally left unpinned. This is a CI-only tooling image from the OpenShift CI infrastructure that changes frequently, and pinning to a digest would create maintenance overhead without meaningful security benefit in this context.

## Test plan

- [ ] Run `make boilerplate-update` in a subscriber repo and verify the generated `.tekton/*-agentic-sdlc-check-pull-request.yaml` has a commit SHA instead of `master` in the pipeline revision
- [ ] Verify `gangway-bridge-template.yml` rejects `POLL_INTERVAL=0` and `TIMEOUT=0`
- [ ] Verify e2e README renders correctly