### PR TITLE
Fix pipeline ref pinning to use exported BOILERPLATE_COMMIT

### DIFF
--- a/boilerplate/openshift/golang-osd-operator/update
+++ b/boilerplate/openshift/golang-osd-operator/update
@@ -183,8 +183,7 @@ if [ -d "${REPO_ROOT}/.tekton" ]; then
     COMPONENT_NAME=$(grep 'appstudio.openshift.io/component:' "${MAIN_TEKTON}" 2>/dev/null | head -1 | awk '{print $2}')
     COMPONENT_NAME=${COMPONENT_NAME:-${OPERATOR_NAME}}
   fi
-  BOILERPLATE_REVISION=$(git -C "${HERE}" rev-parse HEAD)
-  ${SED?} "s/__OPERATOR_NAME__/${OPERATOR_NAME}/g; s/__DEFAULT_BRANCH__/${DEFAULT_BRANCH}/g; s/__TENANT_NAMESPACE__/${TENANT_NAMESPACE}/g; s/__SERVICE_ACCOUNT__/${SERVICE_ACCOUNT}/g; s/__APP_NAME__/${APP_NAME}/g; s/__COMPONENT_NAME__/${COMPONENT_NAME}/g; s/__BOILERPLATE_REVISION__/${BOILERPLATE_REVISION}/g" ${HERE}/agentic-sdlc-check-pull-request.yaml.tmpl > "${AGENTIC_CHECK}"
+  ${SED?} "s/__OPERATOR_NAME__/${OPERATOR_NAME}/g; s/__DEFAULT_BRANCH__/${DEFAULT_BRANCH}/g; s/__TENANT_NAMESPACE__/${TENANT_NAMESPACE}/g; s/__SERVICE_ACCOUNT__/${SERVICE_ACCOUNT}/g; s/__APP_NAME__/${APP_NAME}/g; s/__COMPONENT_NAME__/${COMPONENT_NAME}/g; s/__BOILERPLATE_REVISION__/${BOILERPLATE_COMMIT}/g" ${HERE}/agentic-sdlc-check-pull-request.yaml.tmpl > "${AGENTIC_CHECK}"
 fi
 
 # Check for pipeline files in .tekton directory and centralize them

--- a/boilerplate/update
+++ b/boilerplate/update
@@ -165,6 +165,9 @@ if [[ -z "$LATEST_IMAGE_TAG" ]]; then
     export LATEST_IMAGE_TAG=$(cd $BP_CLONE; git describe --tags --abbrev=0 --match image-v*)
 fi
 
+# The boilerplate commit hash. Export for convention `update` scripts.
+export BOILERPLATE_COMMIT=$(cd ${BP_CLONE} && git rev-parse HEAD)
+
 # Prepare the "nexus makefile include".
 NEXUS_MK="${CONVENTION_ROOT}/generated-includes.mk"
 cat <<'EOF'>"${NEXUS_MK}"


### PR DESCRIPTION
Fixes the pipeline ref pinning introduced in #816. The previous approach used git -C HERE rev-parse HEAD in the convention update script, but HERE points to a directory inside the consuming repo (after rsync), so git resolved to the consuming repo HEAD instead of the boilerplate clone.

Fix: export BOILERPLATE_COMMIT from the main boilerplate/update script (same pattern as LATEST_IMAGE_TAG) so convention update scripts can reference it directly.

Tested locally: ran BOILERPLATE_GIT_REPO=~/src/boilerplate make boilerplate-update and verified the generated .tekton pipeline revision matches last-boilerplate-commit.