### PR TITLE
ROSAENG-1344: Add make e2e-local target for local operator e2e testing

### DIFF
--- a/boilerplate/openshift/golang-osd-e2e/README.md
+++ b/boilerplate/openshift/golang-osd-e2e/README.md
@@ -31,8 +31,49 @@ following:
 |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `e2e-binary-build`     | Compiles ginkgo tests under test/e2e and creates the ginkgo binary.                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `e2e-image-build-push` | Builds e2e image and pushes to operator's quay repo. Image name is defaulted to <operator-image-name>-test-harness. Quay repository must be created beforehand.                                                                                                                                                                                                                                                                                                                        |
+| `e2e-local`            | Builds the e2e binary and runs it against a cluster via KUBECONFIG or backplane. Supports focused tests via GINKGO_FOCUS.                                                                                                                                                                                                                                                                                                                                                              |
 
 #### E2E Local Testing
 
-Please follow [this README](https://github.com/openshift/ops-sop/blob/master/v4/howto/osde2e/operator-test-harnesses.md#using-ginkgo) to run your e2e tests locally
+Run e2e tests locally against a managed cluster without waiting for the full Prow CI pipeline.
+
+**Prerequisites:**
+- `ocm` CLI logged into the appropriate environment (`ocm login --use-auth-code --url staging`)
+- Access to a managed cluster (via KUBECONFIG or backplane)
+- Go toolchain installed
+
+**Option 1: Using backplane (recommended)**
+
+```bash
+# Run all tests against a cluster by ID
+make e2e-local CLUSTER_ID=2rmlgv5dbdp2285n85o7h3aaa6pafkpq
+
+# Run focused tests
+make e2e-local CLUSTER_ID=2rmlgv5dbdp2285n85o7h3aaa6pafkpq GINKGO_FOCUS="is installed"
+
+# Run tests with a label filter
+make e2e-local CLUSTER_ID=2rmlgv5dbdp2285n85o7h3aaa6pafkpq GINKGO_LABEL_FILTER="!slow"
+```
+
+**Option 2: Using an existing KUBECONFIG**
+
+```bash
+# Set KUBECONFIG to your cluster's kubeconfig
+export KUBECONFIG=/path/to/kubeconfig
+
+# Run all tests
+make e2e-local
+
+# Run a single test
+make e2e-local GINKGO_FOCUS="reconciles required resources"
+```
+
+**Output:**
+- Test results print to stdout with verbose Ginkgo output
+- JUnit XML report saved to `e2e-local-junit.xml`
+
+**Tips:**
+- Use lease clusters for testing (check `#rosa-prow-info` for available clusters)
+- The operator must be deployed on the target cluster (via PKO or OLM)
+- If tests fail with "not found" errors, verify the operator is running: `oc get deployment -n <operator-namespace>`
 

--- a/boilerplate/openshift/golang-osd-e2e/standard.mk
+++ b/boilerplate/openshift/golang-osd-e2e/standard.mk
@@ -64,6 +64,26 @@ e2e-binary-build:
 	go mod tidy
 	go test ./test/e2e -v -c --tags=osde2e -o e2e.test
 
+# Run e2e tests locally against a cluster accessible via KUBECONFIG.
+# Usage:
+#   make e2e-local                              # run all tests
+#   make e2e-local GINKGO_FOCUS="test name"     # run matching tests
+#   make e2e-local CLUSTER_ID=<id>              # use backplane for cluster access
+#
+# Requires: KUBECONFIG set, or CLUSTER_ID + ocm login for backplane access.
+.PHONY: e2e-local
+e2e-local: e2e-binary-build
+	@if [ -n "$(CLUSTER_ID)" ] && [ -z "$(KUBECONFIG)" ]; then \
+		echo "Logging into cluster $(CLUSTER_ID) via backplane..."; \
+		ocm backplane login $(CLUSTER_ID); \
+	fi
+	@echo "Running e2e tests against $${KUBECONFIG:-backplane cluster}..."
+	DISABLE_JUNIT_REPORT=true ./e2e.test \
+		--ginkgo.v \
+		--ginkgo.junit-report=e2e-local-junit.xml \
+		$(if $(GINKGO_FOCUS),--ginkgo.focus="$(GINKGO_FOCUS)") \
+		$(if $(GINKGO_LABEL_FILTER),--ginkgo.label-filter="$(GINKGO_LABEL_FILTER)")
+
 # push e2e image tagged as latest and as repo commit hash
 .PHONY: e2e-image-build-push
 e2e-image-build-push: container-engine-login


### PR DESCRIPTION
## Summary

- Add `make e2e-local` target for running operator e2e tests locally
- Supports backplane access via `CLUSTER_ID` or direct `KUBECONFIG`
- Supports focused tests via `GINKGO_FOCUS` and label filters via `GINKGO_LABEL_FILTER`
- JUnit report saved to `e2e-local-junit.xml`
- Updated README with prerequisites, examples, and tips

## Usage

```bash
# Via backplane
make e2e-local CLUSTER_ID=<cluster-id>

# Via KUBECONFIG
export KUBECONFIG=/path/to/kubeconfig
make e2e-local

# Focused test
make e2e-local CLUSTER_ID=<id> GINKGO_FOCUS="is installed"
```

Jira: https://redhat.atlassian.net/browse/ROSAENG-1344