### PR TITLE
ROSAENG-63019: Remove MateSaary from boilerplate OWNERS file

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -38,7 +38,6 @@ aliases:
     - Makdaam
     - Nikokolas3270
     - RaphaelBut
-    - MateSaary
     - rolandmkunkel
     - petrkotas
     - zmird-r


### PR DESCRIPTION
Removing MateSaary from OWNERS file (member left company)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an outdated username from the functional team ownership aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->