### PR TITLE
Resolve build image tag to newest published, not newest git tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,11 @@ In your fork of this repository (not a consuming repository):
       note, `${CONVENTION_ROOT}/_lib/` contains some utilities that may
       be useful for `update`s.
     - `LATEST_IMAGE_TAG`: The tag for the most recent build image
-      produced by boilerplate.
+      produced by boilerplate. This is the newest `image-v*` tag that has
+      actually been **published to the registry**, which is not
+      necessarily the newest tag in git -- see [Creating a Konflux
+      release](#creating-a-konflux-release). You can set this in the
+      environment to pin a specific tag and skip the registry lookup.
 
 ### Testing Boilerplate Locally
 To test your changes, you can use the `BOILERPLATE_GIT_REPO` environment
@@ -372,6 +376,14 @@ See existing test cases for examples.
 ### Creating a Konflux release
 If you make a change to the build image produced by boilerplate in `config/Dockerfile`, you must build a new image
 from a tag through Konflux. To build a new image from a tag:
+
+> **Note:** Publishing the tag does not publish the image; it only lets you
+> start the release that builds one. Until that release completes, the tag
+> exists in git with no image behind it. `boilerplate/update` accounts for this
+> by resolving `LATEST_IMAGE_TAG` to the newest tag that is actually present in
+> the registry, so consumers who update mid-release get the previous (working)
+> image rather than a broken reference. This means **your new tag won't be
+> picked up by consumers until you finish the steps below.**
 
 1. Publish a new tag. The tag must be named `image-v{X}.{Y}.{Z}`, using [semver](https://semver.org/)
 principles when deciding what `{X}.{Y}.{Z}` should be. See https://github.com/openshift/boilerplate/pull/180

--- a/boilerplate/update
+++ b/boilerplate/update
@@ -161,8 +161,64 @@ if [ ! -f "$CONFIG_FILE" ]; then
 fi
 
 # The most recent build image tag. Export this for individual `update` scripts.
+#
+# A git tag alone doesn't mean the image is consumable: publishing the tag only
+# starts the Konflux release that builds and pushes the image. Picking the
+# newest tag unconditionally means that, for as long as that release takes,
+# consumers get a tag with no image behind it -- which breaks their
+# build/Dockerfile FROM, their .ci-operator.yaml build root, and
+# `container-make`. So walk tags newest-first and take the first one that
+# actually exists in the registry.
+#
+# Only tags reachable from the checked-out commit are considered. This keeps
+# `freeze-check` reproducible: it re-runs this driver against the commit
+# recorded in _data/last-boilerplate-commit, and must not resolve a tag that
+# was published after that commit.
+#
+# NOTE: This is deliberately inlined rather than sourced from _lib/common.sh.
+# That library derives LATEST_IMAGE_TAG from the consumer's existing
+# _data/backing-image-tag, which would defeat the resolution below; and this
+# script is intentionally kept auditable in PR diffs via .gitattributes.
 if [[ -z "$LATEST_IMAGE_TAG" ]]; then
-    export LATEST_IMAGE_TAG=$(cd $BP_CLONE; git describe --tags --abbrev=0 --match image-v*)
+    # Bound the walk so a registry outage fails fast instead of trawling
+    # through every historical tag.
+    IMAGE_TAG_SEARCH_DEPTH=${IMAGE_TAG_SEARCH_DEPTH:-10}
+    if ! command -v skopeo &>/dev/null; then
+        echo "Failed to find the skopeo binary, needed to verify the build image tag." >&2
+        echo "If you are on Mac: brew install skopeo." >&2
+        exit 1
+    fi
+    candidates=$(cd $BP_CLONE; git tag --merged HEAD --sort=-v:refname --list 'image-v*' | head -n $IMAGE_TAG_SEARCH_DEPTH)
+    for tag in $candidates; do
+        image_uri="quay.io/redhat-services-prod/openshift/boilerplate:${tag}"
+        skopeo_stderr=$(mktemp)
+        if skopeo inspect --override-os linux --override-arch amd64 "docker://${image_uri}" >/dev/null 2>$skopeo_stderr; then
+            rm -f $skopeo_stderr
+            echo "Using build image tag $tag."
+            export LATEST_IMAGE_TAG=$tag
+            break
+        fi
+        stderr=$(cat $skopeo_stderr)
+        rm -f $skopeo_stderr
+        if [[ "$stderr" == *"manifest unknown"* ]]; then
+            # The tag exists in git but its release hasn't published an image
+            # (yet). Keep looking.
+            echo "Skipping $tag: no image published for it yet."
+            continue
+        fi
+        # Anything else -- auth failure, no such host, network trouble -- means
+        # we can't tell whether the image exists. Bail rather than silently
+        # falling back to an older tag.
+        echo "Error querying the registry for ${image_uri}:" >&2
+        echo "$stderr" >&2
+        exit 1
+    done
+    if [[ -z "$LATEST_IMAGE_TAG" ]]; then
+        echo "Failed to find a published build image among the newest $IMAGE_TAG_SEARCH_DEPTH image-v* tags." >&2
+        echo "If a release is in flight, wait for it to finish. You can also set" >&2
+        echo "LATEST_IMAGE_TAG explicitly to override this check." >&2
+        exit 1
+    fi
 fi
 
 # The boilerplate commit hash. Export for convention `update` scripts.

--- a/test/case/framework/05-image-tag-resolution
+++ b/test/case/framework/05-image-tag-resolution
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+set -e
+
+cat <<EOF
+Tests that the update driver resolves LATEST_IMAGE_TAG to the newest image-v*
+tag that has actually been published to the registry, rather than the newest
+tag in git. Publishing a tag only kicks off the Konflux release that builds the
+image, so for a while a tag can exist with no image behind it.
+EOF
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+source $REPO_ROOT/test/lib.sh
+
+# We're testing the registry lookup itself, so don't let the suite-wide pin
+# short-circuit it.
+unset LATEST_IMAGE_TAG
+
+# A stub `skopeo` standing in for the registry, so this test stays offline and
+# deterministic. It reports success for tags listed in $PUBLISHED_TAGS, the
+# registry's real "manifest unknown" for anything else, and a hard error for
+# tags listed in $BROKEN_TAGS.
+stubdir=$(mktemp -d -t boilerplate-stub-XXXXXXXX)
+add_cleanup $stubdir
+export PUBLISHED_TAGS=$stubdir/published
+export BROKEN_TAGS=$stubdir/broken
+touch $PUBLISHED_TAGS $BROKEN_TAGS
+cat <<'EOF' > $stubdir/skopeo
+#!/usr/bin/env bash
+# Last arg is docker://...:tag
+for arg; do :; done
+tag=${arg##*:}
+if grep -qx "$tag" "$BROKEN_TAGS" 2>/dev/null; then
+    echo "unauthorized: access to the requested resource is not authorized" >&2
+    exit 1
+fi
+if grep -qx "$tag" "$PUBLISHED_TAGS" 2>/dev/null; then
+    echo '{"Digest":"sha256:decafbad"}'
+    exit 0
+fi
+echo "reading manifest $tag in quay.io/redhat-services-prod/openshift/boilerplate: manifest unknown" >&2
+exit 1
+EOF
+chmod +x $stubdir/skopeo
+export PATH=$stubdir:$PATH
+
+# A local clone we can hang synthetic tags off of, so we don't depend on the
+# real tag history. Tags sort above any real image-v* tag so they win the walk.
+bp_clone=$(mktemp -d -t boilerplate-clone-XXXXXXXX)
+add_cleanup $bp_clone
+git clone -q $REPO_ROOT $bp_clone
+git -C $bp_clone tag image-v90.0.0
+git -C $bp_clone tag image-v90.1.0
+git -C $bp_clone tag image-v90.2.0
+export BOILERPLATE_GIT_REPO=$bp_clone
+
+## assert_resolved_tag EXPECTED
+#
+# Bootstrap a fresh consumer, update it, and check the recorded backing image
+# tag matches EXPECTED.
+assert_resolved_tag() {
+    local expected=$1
+    local repo=$(empty_repo)
+    add_cleanup $repo
+    bootstrap_repo $repo
+    (
+        cd $repo
+        make boilerplate-update >/dev/null
+        local actual=$(cat boilerplate/_data/backing-image-tag)
+        [[ "$actual" == "$expected" ]] || err "Expected backing-image-tag '$expected', got '$actual'"
+    )
+}
+
+echo "== Newest tag published: it wins"
+printf 'image-v90.2.0\nimage-v90.1.0\nimage-v90.0.0\n' > $PUBLISHED_TAGS
+assert_resolved_tag image-v90.2.0
+
+echo "== Newest tag unpublished: falls back to the newest published one"
+# This is the regression under test: image-v90.2.0 is tagged in git but its
+# release hasn't produced an image yet.
+printf 'image-v90.1.0\nimage-v90.0.0\n' > $PUBLISHED_TAGS
+assert_resolved_tag image-v90.1.0
+
+echo "== Several newest tags unpublished: keeps walking back"
+printf 'image-v90.0.0\n' > $PUBLISHED_TAGS
+assert_resolved_tag image-v90.0.0
+
+echo "== Tags not reachable from HEAD are ignored"
+# freeze-check re-runs this driver at an older commit and must not pick up a
+# tag published after it.
+git -C $bp_clone checkout -q -b sidebar
+git -C $bp_clone commit -q --allow-empty -m "Not on master"
+git -C $bp_clone tag image-v91.0.0
+git -C $bp_clone checkout -q -
+printf 'image-v91.0.0\nimage-v90.1.0\n' > $PUBLISHED_TAGS
+assert_resolved_tag image-v90.1.0
+
+echo "== An explicit LATEST_IMAGE_TAG overrides the lookup entirely"
+printf 'image-v90.2.0\n' > $PUBLISHED_TAGS
+(
+    export LATEST_IMAGE_TAG=image-v1.2.3
+    # Point skopeo at nothing to prove we never consult the registry.
+    export PUBLISHED_TAGS=/dev/null
+    assert_resolved_tag image-v1.2.3
+)
+
+echo "== No published image among the candidates: fail loudly"
+> $PUBLISHED_TAGS
+repo=$(empty_repo)
+add_cleanup $repo
+bootstrap_repo $repo
+(
+    cd $repo
+    # Keep the walk shallow so it doesn't reach the real published tags.
+    IMAGE_TAG_SEARCH_DEPTH=3 make boilerplate-update >$LOG_DIR/05-no-image 2>&1 \
+        && err "Expected the update to fail when no candidate tag has an image"
+    grep -q "Failed to find a published build image" $LOG_DIR/05-no-image \
+        || err "Expected a 'no published build image' error; got: $(cat $LOG_DIR/05-no-image)"
+)
+
+echo "== A registry error is not treated as 'unpublished'"
+# Otherwise an auth failure or outage would silently pin consumers to an
+# arbitrarily old image.
+> $PUBLISHED_TAGS
+printf 'image-v90.2.0\n' > $BROKEN_TAGS
+repo=$(empty_repo)
+add_cleanup $repo
+bootstrap_repo $repo
+(
+    cd $repo
+    make boilerplate-update >$LOG_DIR/05-registry-error 2>&1 \
+        && err "Expected the update to fail when the registry query errors"
+    grep -q "Error querying the registry" $LOG_DIR/05-registry-error \
+        || err "Expected a registry query error; got: $(cat $LOG_DIR/05-registry-error)"
+)
+
+echo "All image tag resolution checks passed."
+exit 0

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -2,8 +2,11 @@ if [ "$BOILERPLATE_SET_X" ]; then
     set -x
 fi
 
-# NOTE: Change this when publishing a new image tag.
-LATEST_IMAGE_TAG=image-v4.0.1
+# Pin the build image tag for tests. Exporting this short-circuits the
+# registry lookup `update` would otherwise do to find the newest *published*
+# tag, which keeps the bulk of the suite offline and deterministic. Tests that
+# exercise the lookup itself unset this.
+export LATEST_IMAGE_TAG=image-v4.0.1
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 # Make all tests use this local clone by default.


### PR DESCRIPTION
Publishing an `image-v*` tag does not publish an image; it only lets you start the Konflux release that builds one. Until that release completes, the tag exists in git with nothing behind it.

`update` resolved LATEST_IMAGE_TAG with `git describe --match image-v*`, so during that window consumers recorded a tag with no image and wrote it into build/Dockerfile's FROM, .ci-operator.yaml's build root, and IMAGE_PULL_PATH. Their builds then failed on a nonexistent reference, and freeze-check pinned them there until someone updated again. This happened for real between image-v8.4.2 (tagged, never released) and image-v8.4.3.

Walk tags newest-first instead and take the first one actually present in the registry, so an update mid-release yields the previous working image.

Only tags reachable from the checked-out commit are considered. `git describe` was ancestry-scoped and a bare `git tag --list` is not; without `--merged` freeze-check would resolve tags published after the commit it replays and fail for every consumer.

The skopeo call is inlined rather than reusing _lib/common.sh's image_exists_in_repo(): that library derives LATEST_IMAGE_TAG from the consumer's existing _data/backing-image-tag, which would short-circuit the lookup and pin consumers to their old tag permanently. Sourcing it would also pull linguist-generated code into a script .gitattributes deliberately keeps visible in PR diffs.

Only "manifest unknown" means unpublished. Any other registry error is fatal, since treating an outage or auth failure as "not published" would silently walk back to an arbitrarily old image. The walk is depth-bounded so an outage fails fast.

test/lib.sh set LATEST_IMAGE_TAG without exporting it, so the driver never saw it; the whole suite would now hit the live registry. Export it to keep tests offline and deterministic. The assertion it originally fed was removed in 26fbdba.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how the latest image tag is selected and how to pin a specific image version.
  * Added release guidance explaining image publication timing and fallback behavior.

* **Tests**
  * Added deterministic coverage for image-tag selection, overrides, unpublished and unreachable tags, missing images, and registry errors.
  * Improved test configuration to support pinned image tags and registry lookup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->