### PR TITLE
ROSAENG-62320: Add automatic retry to gangway bridge template

### DIFF
--- a/boilerplate/openshift/golang-osd-e2e/gangway-bridge-template.yml
+++ b/boilerplate/openshift/golang-osd-e2e/gangway-bridge-template.yml
@@ -12,7 +12,13 @@ parameters:
     description: Seconds between status polls
   - name: TIMEOUT
     value: "7200"
-    description: Maximum seconds to wait for job completion
+    description: Maximum seconds to wait per attempt for job completion
+  - name: MAX_RETRIES
+    value: "1"
+    description: Number of times to retry the Prow job on failure before reporting failure
+  - name: ACTIVE_DEADLINE
+    value: "14430"
+    description: Kubernetes Job deadline in seconds (should exceed TIMEOUT * (MAX_RETRIES + 1))
   - name: JOB_ENVS
     value: ""
     description: Comma-separated KEY=VALUE pairs passed to the Prow job
@@ -29,7 +35,7 @@ objects:
       name: gangway-bridge-${IMAGE_TAG}-${JOBID}
     spec:
       backoffLimit: 0
-      activeDeadlineSeconds: ${{TIMEOUT}}
+      activeDeadlineSeconds: ${{ACTIVE_DEADLINE}}
       template:
         spec:
           automountServiceAccountToken: false
@@ -46,6 +52,7 @@ objects:
 
                   [[ "${TIMEOUT}" =~ ^[1-9][0-9]*$ ]] || { log "ERROR: TIMEOUT must be a positive integer"; exit 1; }
                   [[ "${POLL_INTERVAL}" =~ ^[1-9][0-9]*$ ]] || { log "ERROR: POLL_INTERVAL must be a positive integer"; exit 1; }
+                  [[ "${MAX_RETRIES}" =~ ^[0-9]+$ ]] || { log "ERROR: MAX_RETRIES must be a non-negative integer"; exit 1; }
 
                   BODY='{"job_execution_type":"1"}'
                   if [[ -n "${JOB_ENVS:-}" ]]; then
@@ -53,21 +60,41 @@ objects:
                     BODY=$(jq -cn --argjson e "$ENVS" '{"job_execution_type":"1","pod_spec_options":{"envs":$e}}')
                   fi
 
-                  RESP=$(curl -sfSL --retry 3 --retry-delay 10 -X POST -H "Authorization: Bearer ${GANGWAY_TOKEN}" -H "Content-Type: application/json" -d "${BODY}" "${GW}/${JOB_NAME}")
-                  ID=$(echo "$RESP" | jq -re .id)
-                  PROW_URL="https://prow.ci.openshift.org/view/gs/test-platform-results/logs/${JOB_NAME}/${ID}"
-                  log "Triggered ${JOB_NAME} -> ${ID}"
-                  log "Prow logs: ${PROW_URL}"
+                  trigger_and_poll() {
+                    RESP=$(curl -sfSL --retry 3 --retry-delay 10 -X POST -H "Authorization: Bearer ${GANGWAY_TOKEN}" -H "Content-Type: application/json" -d "${BODY}" "${GW}/${JOB_NAME}")
+                    ID=$(echo "$RESP" | jq -re .id)
+                    PROW_URL="https://prow.ci.openshift.org/view/gs/test-platform-results/logs/${JOB_NAME}/${ID}"
+                    log "Triggered ${JOB_NAME} -> ${ID}"
+                    log "Prow logs: ${PROW_URL}"
 
-                  END=$((SECONDS + ${TIMEOUT}))
-                  while [[ $SECONDS -lt $END ]]; do
-                    sleep "${POLL_INTERVAL}"
-                    S=$(curl -sfSL -H "Authorization: Bearer ${GANGWAY_TOKEN}" "${GW}/${ID}" | jq -r .job_status) || S=UNKNOWN
-                    log "${S} ($((SECONDS))s)"
-                    case $S in SUCCESS) log "Prow logs: ${PROW_URL}"; exit 0;; FAILURE|ABORTED|ERROR) log "Prow logs: ${PROW_URL}"; exit 1;; esac
+                    END=$((SECONDS + ${TIMEOUT}))
+                    while [[ $SECONDS -lt $END ]]; do
+                      sleep "${POLL_INTERVAL}"
+                      S=$(curl -sfSL -H "Authorization: Bearer ${GANGWAY_TOKEN}" "${GW}/${ID}" | jq -r .job_status) || S=UNKNOWN
+                      log "${S} ($((SECONDS))s)"
+                      case $S in
+                        SUCCESS) log "Prow logs: ${PROW_URL}"; return 0;;
+                        FAILURE|ABORTED|ERROR) log "Prow logs: ${PROW_URL}"; return 1;;
+                      esac
+                    done
+                    log "Prow logs: ${PROW_URL}"
+                    log "Timeout"; return 1
+                  }
+
+                  ATTEMPT=0
+                  while true; do
+                    ATTEMPT=$((ATTEMPT + 1))
+                    log "Attempt ${ATTEMPT} of $((MAX_RETRIES + 1))"
+                    if trigger_and_poll; then
+                      exit 0
+                    fi
+                    if [[ $ATTEMPT -gt $MAX_RETRIES ]]; then
+                      log "All attempts exhausted"
+                      exit 1
+                    fi
+                    log "Retrying in 30s..."
+                    sleep 30
                   done
-                  log "Prow logs: ${PROW_URL}"
-                  log "Timeout"; exit 1
               env:
                 - name: JOB_NAME
                   value: ${JOB_NAME}
@@ -82,6 +109,8 @@ objects:
                   value: ${TIMEOUT}
                 - name: JOB_ENVS
                   value: ${JOB_ENVS}
+                - name: MAX_RETRIES
+                  value: ${MAX_RETRIES}
               resources:
                 requests:
                   cpu: "50m"


### PR DESCRIPTION
## Summary
- Add MAX_RETRIES parameter (default 1) so the bridge retries the Prow job once on failure before reporting failure
- Most infra flakes (DiskPressure, node eviction, quota exceeded) are transient and pass on retry
- Adds ACTIVE_DEADLINE parameter for the Kubernetes Job deadline, independent from the per-attempt TIMEOUT
- Backward compatible: existing saas files don't set MAX_RETRIES so they get 1 retry by default

## How it works
The bridge script wraps the existing trigger-and-poll logic in a trigger_and_poll function. On FAILURE/ABORTED/ERROR, it waits 30s and retries up to MAX_RETRIES times. On SUCCESS at any attempt, it exits 0 immediately.

## Test plan
- Verify existing operator e2e promotions still work with the new default (1 retry)
- Verify MAX_RETRIES=0 preserves the old no-retry behavior
- Monitor for reduced infra-flake-caused pipeline blocks

Jira: https://redhat.atlassian.net/browse/ROSAENG-62320