### PR TITLE
Fix invalid 'version' field in prefetch-dependencies taskRef

### DIFF
--- a/pipelines/docker-build-oci-ta/pipeline.yaml
+++ b/pipelines/docker-build-oci-ta/pipeline.yaml
@@ -154,8 +154,14 @@ spec:
       runAfter:
         - clone-repository
       taskRef:
-        name: prefetch-dependencies-oci-ta
-        version: "0.9"
+        params:
+          - name: name
+            value: prefetch-dependencies-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.9.0
+          - name: kind
+            value: task
+        resolver: bundles
       workspaces:
         - name: git-basic-auth
           workspace: git-auth


### PR DESCRIPTION
## Problem

PR #844 introduced an invalid  field in the taskRef which breaks Tekton pipeline validation:



**Evidence**: https://github.com/openshift/rbac-permissions-operator/pull/410 - all pipelines failing with this error after updating boilerplate.

## Root Cause

The  field is **not** part of the Tekton API spec for taskRef. It was mistakenly used based on upstream Konflux source templates which get transformed before deployment.

## Solution

This PR fixes it by using the proper Tekton **bundles resolver** format, but **without digest pinning**:



**Key difference from original**: Removed  digest

## Why This Works

### Tekton Validation
✅ Uses standard bundles resolver format (valid Tekton API)

### Enterprise Contract Validation  
✅ Bundle without digest generates EC key with version tag:
- EC key: `oci://quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.9.0`
- Matches allowed entry in `trusted_tasks` data

### Previous Attempts
❌ With digest: `task-name:0.9.0@sha256:...` → EC key missing version tag, matched deny rules  
❌ With `version` field → Invalid Tekton API, rejected by pipeline validation

## Trade-offs

- **Loses digest pinning**: Tekton will pull by tag instead of immutable digest
- **Acceptable because**: Konflux manages tags and updates them when task definitions change per their versioning system

## Testing

This should be tested in a downstream repo to verify:
1. ✅ Tekton accepts the pipeline definition
2. ✅ Pipeline runs successfully  
3. ✅ Enterprise Contract validation passes

## Related

- Fixes #844
- Resolves errors seen in https://github.com/openshift/rbac-permissions-operator/pull/410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dependency prefetching pipeline configuration to use the latest Tekton bundle reference format.
  * Updated the referenced dependency prefetching task bundle to version 0.9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->