### PR TITLE
Revert prefetch-dependencies to original bundle format

### DIFF
--- a/pipelines/docker-build-oci-ta/pipeline.yaml
+++ b/pipelines/docker-build-oci-ta/pipeline.yaml
@@ -158,7 +158,7 @@ spec:
           - name: name
             value: prefetch-dependencies-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.9.0
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.9.0@sha256:4486aaa69770d6b27c59c8df7d82e450d95dab2302aef9b8a345f2ac0fabbab0
           - name: kind
             value: task
         resolver: bundles


### PR DESCRIPTION
## Summary
This PR reverts the changes from #844 and #845, restoring the original bundle reference format that includes digest pinning.

## Rationale
After investigation, the Enterprise Contract validation failures appear to be caused by an upstream issue in the Konflux/Tekton stack, not by the bundle reference format itself.

The original format with digest pinning is correct and should work once the upstream issue is resolved.

## Changes
Restores the bundle reference to:
```yaml
value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.9.0@sha256:4486aaa69770d6b27c59c8df7d82e450d95dab2302aef9b8a345f2ac0fabbab0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the dependency prefetch task bundle to a specific SHA256 digest for more reliable and reproducible builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->