### PR TITLE
Add repo-level coderabbit config to re-enable reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,9 @@
+# The org-wide config (openshift/coderabbit) excludes "boilerplate/**" so
+# that consuming repos don't get noisy reviews of the vendored copy they
+# pull in via `make boilerplate-update`. That exclusion also matches this
+# repo's own source, since it lives under boilerplate/ too, so re-include
+# it here to keep reviews enabled for the boilerplate repo itself.
+inheritance: true
+reviews:
+  path_filters:
+    - "boilerplate/**"


### PR DESCRIPTION
## Summary
- [openshift/coderabbit#7](https://github.com/openshift/coderabbit/pull/7) added an org-wide `!boilerplate/**` path filter so consuming repos don't get noisy CodeRabbit reviews of the vendored copy they pull in via `make boilerplate-update`.
- That filter also matches this repo's own source (nearly everything here lives under `boilerplate/`), so CodeRabbit has been skipping review of PRs in this repo entirely, e.g. [#843](https://github.com/openshift/boilerplate/pull/843).
- Adds a repo-level `.coderabbit.yaml` with `inheritance: true` (per openshift/coderabbit's central-config convention) that re-includes `boilerplate/**` for this repo specifically, while leaving the org-wide exclusion intact for every consuming repo.

## Test plan
- Confirm CodeRabbit picks up and reviews this PR
- Confirm consuming repos still don't get CodeRabbit noise on their vendored `boilerplate/` directory after running `make boilerplate-update`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository-level review configuration.
  * Excluded boilerplate files from automated review checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->