### PR TITLE
ROSAENG-61296: migrate to pinned Codecov CLI for coverage uploads

### DIFF
--- a/boilerplate/openshift/golang-codecov/codecov.sh
+++ b/boilerplate/openshift/golang-codecov/codecov.sh
@@ -23,11 +23,11 @@ rm -f "${COVER_PROFILE}.tmp"
 # Configure the git refs and job link based on how the job was triggered via prow
 if [[ "${JOB_TYPE}" == "presubmit" ]]; then
        echo "detected PR code coverage job for #${PULL_NUMBER}"
-       REF_FLAGS="-P ${PULL_NUMBER} -C ${PULL_PULL_SHA}"
+       REF_FLAGS="--pr ${PULL_NUMBER} --commit-sha ${PULL_PULL_SHA}"
        JOB_LINK="${CI_SERVER_URL}/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
 elif [[ "${JOB_TYPE}" == "postsubmit" ]]; then
        echo "detected branch code coverage job for ${PULL_BASE_REF}"
-       REF_FLAGS="-B ${PULL_BASE_REF} -C ${PULL_BASE_SHA}"
+       REF_FLAGS="--branch ${PULL_BASE_REF} --commit-sha ${PULL_BASE_SHA}"
        JOB_LINK="${CI_SERVER_URL}/logs/${JOB_NAME}/${BUILD_ID}"
 elif [[ "${JOB_TYPE}" == "local" ]]; then
        echo "coverage report available at ${COVER_PROFILE}"
@@ -43,12 +43,17 @@ export CI_BUILD_ID="${JOB_NAME}"
 export CI_JOB_ID="${BUILD_ID}"
 
 if [[ "${JOB_TYPE}" != "local" ]]; then
-       if [[ -z "${ARTIFACT_DIR:-}" ]] || [[ ! -d "${ARTIFACT_DIR}" ]] || [[ ! -w "${ARTIFACT_DIR}" ]]; then
-              echo '${ARTIFACT_DIR} must be set for non-local jobs, and must point to a writable directory' >&2
-              exit 1
-       fi
-       curl -sS https://codecov.io/bash -o "${ARTIFACT_DIR}/codecov.sh"
-       bash <(cat "${ARTIFACT_DIR}/codecov.sh") -Z -K -f "${COVER_PROFILE}" -r "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}
+       CODECOV_VERSION="${CODECOV_VERSION:-v11.3.1}"
+       CODECOV_SHA256="${CODECOV_SHA256:-ca1d64196d2d34771084afe76ea657d581bf628e31d993ff8e52ea09cc88a56d}"
+       CODECOV_BIN="$(mktemp -d)/codecov"
+
+       curl -sSfL "https://github.com/codecov/codecov-cli/releases/download/${CODECOV_VERSION}/codecovcli_linux" \
+              -o "${CODECOV_BIN}"
+       echo "${CODECOV_SHA256}  ${CODECOV_BIN}" | sha256sum -c -
+       chmod +x "${CODECOV_BIN}"
+
+       "${CODECOV_BIN}" upload-process --fail-on-error --git-service github \
+              --file "${COVER_PROFILE}" --slug "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}
 else
-       bash <(curl -s https://codecov.io/bash) -Z -K -f "${COVER_PROFILE}" -r "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}
+       echo "coverage report available at ${COVER_PROFILE} (no upload in local mode)"
 fi

--- a/boilerplate/openshift/golang-osd-operator/codecov.sh
+++ b/boilerplate/openshift/golang-osd-operator/codecov.sh
@@ -23,11 +23,11 @@ rm -f "${COVER_PROFILE}.tmp"
 # Configure the git refs and job link based on how the job was triggered via prow
 if [[ "${JOB_TYPE}" == "presubmit" ]]; then
        echo "detected PR code coverage job for #${PULL_NUMBER}"
-       REF_FLAGS="-P ${PULL_NUMBER} -C ${PULL_PULL_SHA}"
+       REF_FLAGS="--pr ${PULL_NUMBER} --commit-sha ${PULL_PULL_SHA}"
        JOB_LINK="${CI_SERVER_URL}/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
 elif [[ "${JOB_TYPE}" == "postsubmit" ]]; then
        echo "detected branch code coverage job for ${PULL_BASE_REF}"
-       REF_FLAGS="-B ${PULL_BASE_REF} -C ${PULL_BASE_SHA}"
+       REF_FLAGS="--branch ${PULL_BASE_REF} --commit-sha ${PULL_BASE_SHA}"
        JOB_LINK="${CI_SERVER_URL}/logs/${JOB_NAME}/${BUILD_ID}"
 elif [[ "${JOB_TYPE}" == "local" ]]; then
        echo "coverage report available at ${COVER_PROFILE}"
@@ -43,12 +43,17 @@ export CI_BUILD_ID="${JOB_NAME}"
 export CI_JOB_ID="${BUILD_ID}"
 
 if [[ "${JOB_TYPE}" != "local" ]]; then
-       if [[ -z "${ARTIFACT_DIR:-}" ]] || [[ ! -d "${ARTIFACT_DIR}" ]] || [[ ! -w "${ARTIFACT_DIR}" ]]; then
-              echo '${ARTIFACT_DIR} must be set for non-local jobs, and must point to a writable directory' >&2
-              exit 1
-       fi
-       curl -sS https://codecov.io/bash -o "${ARTIFACT_DIR}/codecov.sh"
-       bash <(cat "${ARTIFACT_DIR}/codecov.sh") -Z -K -f "${COVER_PROFILE}" -r "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}
+       CODECOV_VERSION="${CODECOV_VERSION:-v11.3.1}"
+       CODECOV_SHA256="${CODECOV_SHA256:-ca1d64196d2d34771084afe76ea657d581bf628e31d993ff8e52ea09cc88a56d}"
+       CODECOV_BIN="$(mktemp -d)/codecov"
+
+       curl -sSfL "https://github.com/codecov/codecov-cli/releases/download/${CODECOV_VERSION}/codecovcli_linux" \
+              -o "${CODECOV_BIN}"
+       echo "${CODECOV_SHA256}  ${CODECOV_BIN}" | sha256sum -c -
+       chmod +x "${CODECOV_BIN}"
+
+       "${CODECOV_BIN}" upload-process --fail-on-error --git-service github \
+              --file "${COVER_PROFILE}" --slug "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}
 else
-       bash <(curl -s https://codecov.io/bash) -Z -K -f "${COVER_PROFILE}" -r "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}
+       echo "coverage report available at ${COVER_PROFILE} (no upload in local mode)"
 fi

--- a/boilerplate/test/test-base-convention/codecov.sh
+++ b/boilerplate/test/test-base-convention/codecov.sh
@@ -18,11 +18,11 @@ rm -f "${COVER_PROFILE}.tmp"
 # Configure the git refs and job link based on how the job was triggered via prow
 if [[ "${JOB_TYPE}" == "presubmit" ]]; then
        echo "detected PR code coverage job for #${PULL_NUMBER}"
-       REF_FLAGS="-P ${PULL_NUMBER} -C ${PULL_PULL_SHA}"
+       REF_FLAGS="--pr ${PULL_NUMBER} --commit-sha ${PULL_PULL_SHA}"
        JOB_LINK="${CI_SERVER_URL}/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
 elif [[ "${JOB_TYPE}" == "postsubmit" ]]; then
        echo "detected branch code coverage job for ${PULL_BASE_REF}"
-       REF_FLAGS="-B ${PULL_BASE_REF} -C ${PULL_BASE_SHA}"
+       REF_FLAGS="--branch ${PULL_BASE_REF} --commit-sha ${PULL_BASE_SHA}"
        JOB_LINK="${CI_SERVER_URL}/logs/${JOB_NAME}/${BUILD_ID}"
 elif [[ "${JOB_TYPE}" == "local" ]]; then
        echo "coverage report available at ${COVER_PROFILE}"
@@ -37,4 +37,14 @@ export CI_BUILD_URL="${JOB_LINK}"
 export CI_BUILD_ID="${JOB_NAME}"
 export CI_JOB_ID="${BUILD_ID}"
 
-bash <(curl -s https://codecov.io/bash) -Z -K -f "${COVER_PROFILE}" -r "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}
+CODECOV_VERSION="${CODECOV_VERSION:-v11.3.1}"
+CODECOV_SHA256="${CODECOV_SHA256:-ca1d64196d2d34771084afe76ea657d581bf628e31d993ff8e52ea09cc88a56d}"
+CODECOV_BIN="$(mktemp -d)/codecov"
+
+curl -sSfL "https://github.com/codecov/codecov-cli/releases/download/${CODECOV_VERSION}/codecovcli_linux" \
+       -o "${CODECOV_BIN}"
+echo "${CODECOV_SHA256}  ${CODECOV_BIN}" | sha256sum -c -
+chmod +x "${CODECOV_BIN}"
+
+"${CODECOV_BIN}" upload-process --fail-on-error --git-service github \
+       --file "${COVER_PROFILE}" --slug "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}


### PR DESCRIPTION
## Summary

- Replaces the legacy Codecov bash uploader with the Codecov CLI binary, pinned to a specific version and verified via SHA256 checksum
- Updates CLI flags to match the current Codecov CLI interface
- `CODECOV_VERSION` and `CODECOV_SHA256` are overridable via environment variables, allowing subscriber operators to pin a different CLI release

### Files updated
- `boilerplate/openshift/golang-osd-operator/codecov.sh`
- `boilerplate/openshift/golang-codecov/codecov.sh`
- `boilerplate/test/test-base-convention/codecov.sh`

Closes [ROSAENG-61296](https://redhat.atlassian.net/browse/ROSAENG-61296)

## Test plan

- [x] Verify all three scripts pass `bash -n` syntax check
- [x] Same fix validated end-to-end in [rhobs-synthetics-agent PR #246](https://github.com/rhobs/rhobs-synthetics-agent/pull/246) (CI green)
- [ ] Confirm coverage jobs succeed in a subscriber operator after boilerplate update

[ROSAENG-61296]: https://redhat.atlassian.net/browse/ROSAENG-61296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ