### PR TITLE
Drop osd-cluster-ready from boilerplate subscribers

### DIFF
--- a/subscribers.yaml
+++ b/subscribers.yaml
@@ -145,13 +145,6 @@ subscribers:
       - name: openshift/golang-lint
         status: manual
 
-  - name: openshift/osd-cluster-ready
-    conventions:
-      - name: openshift/osd-container-image
-        status: manual
-      - name: openshift/golang-lint
-        status: manual
-
   - name: openshift/osd-example-operator
     conventions:
       - name: openshift/golang-osd-operator


### PR DESCRIPTION
## Summary
- Remove `openshift/osd-cluster-ready` from `subscribers.yaml`.
- The Job was undeployed from managed-cluster-config in https://github.com/openshift/managed-cluster-config/pull/2771; this drops the leftover boilerplate subscription.

## Test plan
- [ ] Confirm `osd-cluster-ready` no longer appears in `subscribers.yaml`.
- [ ] No other subscriber entries were changed.


Made with [Cursor](https://cursor.com)