### PR TITLE
Remove departed members from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -55,7 +55,6 @@ aliases:
     - feichashao
     - samanthajayasinghe
     - xiaoyu74
-    - Tessg22
     - smarthall
   rosa-staff-engineers:
     - Ajpantuso
@@ -75,7 +74,6 @@ aliases:
     - typeid
   rosa-managers:
     - afreiberger
-    - c-e-brumm
     - drewandersonnz
     - evalis1
     - geowa4
@@ -83,10 +81,7 @@ aliases:
     - jnewton75
     - krishvoor
     - kseiter-rh
-    - OliviaHY
-    - syncrou
     - tdrozdowski
-    - tkiss28
     - vkumar51
   hp-architects:
     - deads2k


### PR DESCRIPTION
Remove c-e-brumm, OliviaHY, and syncrou from the rosa-managers alias group, and Tessg22 from the srep-functional-team-thor alias group.