### PR TITLE
feat: add skip-roxctl-scan for scratch PKO images

### DIFF
--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -36,6 +36,13 @@ spec:
         value: pipelines/docker-build-oci-ta/pipeline.yaml
 ```
 
+Optional PipelineRun params (in addition to the Konflux catalog defaults):
+
+| Param | Default | When to set `true` |
+|---|---|---|
+| `skip-preflight-cert-check` | `false` | Scratch / PKO images that fail ecosystem cert preflight |
+| `skip-roxctl-scan` | `false` | Scratch / PKO images that fail ACS `roxctl-scan` (no OS). Does **not** skip clamav, SAST, or RPM signature scans. Prefer this over `skip-checks`. |
+
 ### References
 
 - https://konflux.pages.redhat.com/docs/users/patterns/centralize-pipeline-definitions.html

--- a/pipelines/docker-build-oci-ta/pipeline.yaml
+++ b/pipelines/docker-build-oci-ta/pipeline.yaml
@@ -71,6 +71,10 @@ spec:
       default: "false"
       type: string
       description: Skip the preflight cert-check. This can required for scratch images. Valid values are false and true.
+    - name: skip-roxctl-scan
+      default: "false"
+      type: string
+      description: Skip ACS/roxctl-scan only (keep clamav, SAST, RPM signature, etc.). Use for FROM-scratch PKO/package images that have no OS for ACS to scan. Valid values are false and true.
     - name: enable-package-registry-proxy
       default: 'true'
       description: Use the package registry proxy when prefetching dependencies
@@ -302,6 +306,10 @@ spec:
         resolver: bundles
       when:
         - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
+        - input: $(params.skip-roxctl-scan)
           operator: in
           values:
             - "false"


### PR DESCRIPTION
## Summary
- Add optional `skip-roxctl-scan` on `docker-build-oci-ta`, same pattern as `skip-preflight-cert-check`
- ACS `roxctl-scan` (replaced Clair on 2026-08-28) fails on FROM-scratch PKO/package images
- `skip-checks: true` is the wrong workaround: it disables clamav/SAST/RPM scans and Enterprise Contract then fails

## Test plan
- [ ] Default remains `false`; operator images still run ACS
- [ ] PKO PipelineRuns can set `skip-roxctl-scan: true` and still run clamav/SAST/RPM signature
- [ ] Follow-up in rbac-permissions-operator: https://github.com/openshift/rbac-permissions-operator/pull/419


Made with [Cursor](https://cursor.com)