### PR TITLE
gangway-bridge: rate limit hardening (INITIAL_DELAY, poll 429 backoff, longer intervals)

### DIFF
--- a/boilerplate/openshift/golang-osd-e2e/gangway-bridge-template.yml
+++ b/boilerplate/openshift/golang-osd-e2e/gangway-bridge-template.yml
@@ -17,7 +17,7 @@ parameters:
     value: "5"
     description: Number of times to retry the Prow job on failure before reporting failure
   - name: ACTIVE_DEADLINE
-    value: "50400"
+    value: "54000"
     description: Kubernetes Job deadline in seconds (must exceed all attempts plus backoff delays)
   - name: INITIAL_DELAY
     value: "0"
@@ -65,12 +65,13 @@ objects:
 
                   # Backoff sum: base 30s doubling each retry, capped at 900s, plus 15s max jitter
                   MAX_BACKOFF_SUM=$(( 30 * ((1 << MAX_RETRIES) - 1) + MAX_RETRIES * 15 ))
-                  # Each attempt may overshoot TIMEOUT by up to POLL_INTERVAL + status-request
-                  # max-time (30s) on the last poll cycle
-                  POLL_OVERSHOOT=$(( POLL_INTERVAL + 30 ))
+                  # Each attempt may overshoot TIMEOUT by up to the max poll_backoff (300s) +
+                  # status-request max-time (30s) + max 429 extra sleep (300s) on the last poll cycle
+                  POLL_OVERSHOOT=$(( 300 + 30 + 300 ))
                   # Trigger POST max-time (60s) + worst-case Retry-After (600s) per attempt
                   TRIGGER_OVERHEAD=$(( 60 + 600 ))
-                  REQUIRED_DEADLINE=$(( (MAX_RETRIES + 1) * (TIMEOUT + POLL_OVERSHOOT + TRIGGER_OVERHEAD) + MAX_BACKOFF_SUM ))
+                  # INITIAL_DELAY is a one-time cost at job startup, not per attempt
+                  REQUIRED_DEADLINE=$(( (MAX_RETRIES + 1) * (TIMEOUT + POLL_OVERSHOOT + TRIGGER_OVERHEAD) + MAX_BACKOFF_SUM + INITIAL_DELAY ))
                   if [[ "${ACTIVE_DEADLINE}" -lt "${REQUIRED_DEADLINE}" ]]; then
                     log "ERROR: ACTIVE_DEADLINE (${ACTIVE_DEADLINE}s) is less than the minimum required for ${MAX_RETRIES} retries with TIMEOUT=${TIMEOUT}s (need at least ${REQUIRED_DEADLINE}s)"
                     exit 1

--- a/boilerplate/openshift/golang-osd-e2e/gangway-bridge-template.yml
+++ b/boilerplate/openshift/golang-osd-e2e/gangway-bridge-template.yml
@@ -19,6 +19,9 @@ parameters:
   - name: ACTIVE_DEADLINE
     value: "50400"
     description: Kubernetes Job deadline in seconds (must exceed all attempts plus backoff delays)
+  - name: INITIAL_DELAY
+    value: "0"
+    description: Seconds to sleep before the first Gangway call; stagger concurrent jobs to avoid shared rate limit saturation
   - name: JOB_ENVS
     value: ""
     description: Comma-separated KEY=VALUE pairs passed to the Prow job
@@ -53,6 +56,12 @@ objects:
                   [[ "${TIMEOUT}" =~ ^[1-9][0-9]*$ ]] || { log "ERROR: TIMEOUT must be a positive integer"; exit 1; }
                   [[ "${POLL_INTERVAL}" =~ ^[1-9][0-9]*$ ]] || { log "ERROR: POLL_INTERVAL must be a positive integer"; exit 1; }
                   [[ "${MAX_RETRIES}" =~ ^[0-9]+$ ]] || { log "ERROR: MAX_RETRIES must be a non-negative integer"; exit 1; }
+                  [[ "${INITIAL_DELAY}" =~ ^[0-9]+$ ]] || { log "ERROR: INITIAL_DELAY must be a non-negative integer"; exit 1; }
+
+                  if [[ "${INITIAL_DELAY}" -gt 0 ]]; then
+                    log "Waiting ${INITIAL_DELAY}s before first Gangway call (INITIAL_DELAY)..."
+                    sleep "${INITIAL_DELAY}"
+                  fi
 
                   # Backoff sum: base 30s doubling each retry = 30*(2^N-1), plus 15s max jitter
                   MAX_BACKOFF_SUM=$(( 30 * ((1 << MAX_RETRIES) - 1) + MAX_RETRIES * 15 ))
@@ -183,6 +192,8 @@ objects:
                   value: ${JOB_ENVS}
                 - name: MAX_RETRIES
                   value: ${MAX_RETRIES}
+                - name: INITIAL_DELAY
+                  value: ${INITIAL_DELAY}
                 - name: ACTIVE_DEADLINE
                   value: ${ACTIVE_DEADLINE}
               resources:

--- a/boilerplate/openshift/golang-osd-e2e/gangway-bridge-template.yml
+++ b/boilerplate/openshift/golang-osd-e2e/gangway-bridge-template.yml
@@ -8,7 +8,7 @@ parameters:
     required: true
     description: Prow periodic job name to trigger via Gangway
   - name: POLL_INTERVAL
-    value: "60"
+    value: "120"
     description: Seconds between status polls
   - name: TIMEOUT
     value: "7200"
@@ -63,7 +63,7 @@ objects:
                     sleep "${INITIAL_DELAY}"
                   fi
 
-                  # Backoff sum: base 30s doubling each retry = 30*(2^N-1), plus 15s max jitter
+                  # Backoff sum: base 30s doubling each retry, capped at 900s, plus 15s max jitter
                   MAX_BACKOFF_SUM=$(( 30 * ((1 << MAX_RETRIES) - 1) + MAX_RETRIES * 15 ))
                   # Each attempt may overshoot TIMEOUT by up to POLL_INTERVAL + status-request
                   # max-time (30s) on the last poll cycle
@@ -169,7 +169,7 @@ objects:
                       RATE_LIMITED_WAITED=0
                     else
                       BACKOFF=$(( 30 * (1 << (ATTEMPT - 1)) ))
-                      [[ $BACKOFF -gt 480 ]] && BACKOFF=480
+                      [[ $BACKOFF -gt 900 ]] && BACKOFF=900
                       JITTER=$(( RANDOM % 16 ))
                       DELAY=$(( BACKOFF + JITTER ))
                       log "Retrying in ${DELAY}s (backoff=${BACKOFF}s, jitter=${JITTER}s)..."


### PR DESCRIPTION
## Summary

Gangway rate-limits at 9 req/min per source IP with a burst of 5 (nodelay). When multiple operators deploy in the same SAPM pipeline run their gangway-bridge jobs all start simultaneously and saturate the shared quota, causing trigger attempts to exhaust all retries and fail.

Three changes to reduce request pressure:

- **INITIAL_DELAY parameter** (default 0s): callers can set different delays per target in their saas file to stagger concurrent jobs (e.g. 0s, 45s, 90s for three targets). Validated on startup; skipped entirely when 0.

- **Poll loop 429 backoff**: status polls previously treated 429 the same as a transient error (S=UNKNOWN, retry at normal interval). Now detects 429 explicitly and doubles the poll interval on each consecutive rate-limited poll (capped at 300s), resetting to normal on any successful response.

- **Longer defaults**: POLL_INTERVAL raised from 60s to 120s (halves baseline polling pressure); inter-retry backoff cap raised from 480s to 900s (later attempts back off more aggressively under sustained contention).

## Test plan

- [ ] Verify `ACTIVE_DEADLINE` validation still passes with new POLL_INTERVAL default (50400s > required ~49065s for MAX_RETRIES=5, TIMEOUT=7200)
- [ ] Deploy with staggered INITIAL_DELAY values across concurrent targets and confirm jobs no longer saturate the rate limit
- [ ] Confirm poll loop logs `Rate limited polling status (429)` and backs off on 429 responses