### PR TITLE
gangway-bridge: tighten POLL_OVERSHOOT and remove redundant 429 sleep

### DIFF
--- a/boilerplate/openshift/golang-osd-e2e/gangway-bridge-template.yml
+++ b/boilerplate/openshift/golang-osd-e2e/gangway-bridge-template.yml
@@ -65,9 +65,9 @@ objects:
 
                   # Backoff sum: base 30s doubling each retry, capped at 900s, plus 15s max jitter
                   MAX_BACKOFF_SUM=$(( 30 * ((1 << MAX_RETRIES) - 1) + MAX_RETRIES * 15 ))
-                  # Each attempt may overshoot TIMEOUT by up to the max poll_backoff (300s) +
-                  # status-request max-time (30s) + max 429 extra sleep (300s) on the last poll cycle
-                  POLL_OVERSHOOT=$(( 300 + 30 + 300 ))
+                  # Each attempt may overshoot TIMEOUT by up to max(POLL_INTERVAL, 300s max backoff) +
+                  # status-request max-time (30s) on the last poll cycle
+                  POLL_OVERSHOOT=$(( (POLL_INTERVAL > 300 ? POLL_INTERVAL : 300) + 30 ))
                   # Trigger POST max-time (60s) + worst-case Retry-After (600s) per attempt
                   TRIGGER_OVERHEAD=$(( 60 + 600 ))
                   # INITIAL_DELAY is a one-time cost at job startup, not per attempt
@@ -138,7 +138,6 @@ objects:
                         poll_backoff=$(( poll_backoff * 2 ))
                         [[ $poll_backoff -gt 300 ]] && poll_backoff=300
                         log "Rate limited polling status (429) — backing off ${poll_backoff}s"
-                        sleep "$poll_backoff"
                         continue
                       fi
                       poll_backoff="${POLL_INTERVAL}"


### PR DESCRIPTION
## Summary

- `POLL_OVERSHOOT` now uses `max(POLL_INTERVAL, 300) + 30` instead of the hardcoded `300 + 30 + 300`. This correctly budgets whichever delay is larger (a long POLL_INTERVAL or the 300s max backoff cap) plus the 30s curl timeout, rather than always assuming 630s.
- Removed the redundant `sleep "$poll_backoff"` from the 429 response branch. The loop's leading `sleep "$poll_backoff"` at the top of the next iteration already provides the backoff delay; the extra sleep was doubling it.

`REQUIRED_DEADLINE` validation continues to use the updated `POLL_OVERSHOOT`, so deadline math stays correct.

## Test plan

- [ ] Verify ACTIVE_DEADLINE validation still rejects an undersized deadline
- [ ] Verify polling with a 429 response backs off correctly via the loop-top sleep (no double delay)
- [ ] Verify POLL_OVERSHOOT with POLL_INTERVAL > 300 uses POLL_INTERVAL as the budget
