### PR TITLE
Update roxctl-scan task bundle to fix null jq error

### DIFF
--- a/pipelines/bundle-builder/pipeline.yaml
+++ b/pipelines/bundle-builder/pipeline.yaml
@@ -250,7 +250,7 @@ spec:
       - name: name
         value: roxctl-scan
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-roxctl-scan:0.1@sha256:76ed85aa05ce42d31341269837f104c3b766508313a68439085dcf9cc89d03f4
+        value: quay.io/konflux-ci/tekton-catalog/task-roxctl-scan:0.1@sha256:97e2b2cdca9110fdc8a93ba585a1a1a743f989f2fd85f4073f6e5ea9ad2ce828
       - name: kind
         value: task
       resolver: bundles

--- a/pipelines/docker-build-oci-ta/pipeline.yaml
+++ b/pipelines/docker-build-oci-ta/pipeline.yaml
@@ -296,7 +296,7 @@ spec:
           - name: name
             value: roxctl-scan
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-roxctl-scan:0.1@sha256:76ed85aa05ce42d31341269837f104c3b766508313a68439085dcf9cc89d03f4
+            value: quay.io/konflux-ci/tekton-catalog/task-roxctl-scan:0.1@sha256:97e2b2cdca9110fdc8a93ba585a1a1a743f989f2fd85f4073f6e5ea9ad2ce828
           - name: kind
             value: task
         resolver: bundles


### PR DESCRIPTION
## Summary

- Updates the `roxctl-scan` task bundle SHA in both `docker-build-oci-ta` and `bundle-builder` pipelines to include the fix for [KONFLUX-15651](https://redhat.atlassian.net/browse/KONFLUX-15651)
- The `proccess-output` step fails with `jq: Cannot iterate over null` when scanning scratch-based images (all SRE operator PKO images)
- Fix: [konflux-ci/konflux-test#906](https://github.com/konflux-ci/konflux-test/pull/906)
- New bundle confirmed working by other Konflux users

Old SHA: `76ed85aa05ce42d31341269837f104c3b766508313a68439085dcf9cc89d03f4`
New SHA: `97e2b2cdca9110fdc8a93ba585a1a1a743f989f2fd85f4073f6e5ea9ad2ce828`

Jira: https://redhat.atlassian.net/browse/KFLUXSPRT-8887

[KONFLUX-15651]: https://redhat.atlassian.net/browse/KONFLUX-15651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ