### PR TITLE
Update UBI9 base image to 9.8-1788245065

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -L -o kubectl-package ${KUBECTL_PACKAGE_LOCATION} && \
     chmod +x kubectl-package && \
     mv kubectl-package /usr/local/bin
 
-FROM registry.access.redhat.com/ubi9:9.8-1788245065
+FROM registry.access.redhat.com/ubi9:9.8-1788939089
 
 RUN dnf -y install openssh-clients jq skopeo python3-pyyaml git go-toolset rsync && \
     dnf clean all && \

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -L -o kubectl-package ${KUBECTL_PACKAGE_LOCATION} && \
     chmod +x kubectl-package && \
     mv kubectl-package /usr/local/bin
 
-FROM registry.access.redhat.com/ubi9:9.8-1785906690
+FROM registry.access.redhat.com/ubi9:9.8-1788245065
 
 RUN dnf -y install openssh-clients jq skopeo python3-pyyaml git go-toolset rsync && \
     dnf clean all && \


### PR DESCRIPTION
Bump the UBI9 base image from \`9.8-1785906690\` to \`9.8-1788939089\` (latest available tag).

The newer digest serves \`go-toolset 1.26.7\` via the \`ubi-9-appstream-rpms\` repo, so the existing unpinned \`dnf install go-toolset\` naturally resolves to 1.26.7 — no RPM version pinning needed. This preserves the automated MintMaker update flow for future Go version upgrades.

Verified: \`dnf list go-toolset\` on both \`ubi9:9.8-1788939089\` and \`ubi9:9.8-1788921549\` returns \`go-toolset.x86_64 1.26.7-1.el9_8\`.