### PR TITLE
ROSAENG-66898: Enable automated UBI9 image updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,9 +7,15 @@
     "group:allDigest"
   ],
   "enabledManagers": [
+    "dockerfile",
     "tekton",
     "gomod"
   ],
+  "dockerfile": {
+    "includePaths": [
+      "config/Dockerfile"
+    ]
+  },
   "tekton": {
     "includePaths": [
       "pipelines/**",


### PR DESCRIPTION
Automate updates to the base UBI image in the boilerplate image, like https://github.com/openshift/boilerplate/blob/be126284e16f786622c88a303343124dddd64fbe/config/Dockerfile#L2

Then we can just cut releases using snapshots that are tied to commits that bump this, etc

Closes https://github.com/openshift/boilerplate/pull/880