### PR TITLE
Resolve boilerplate image tag from published images

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,10 @@ In your fork of this repository (not a consuming repository):
       note, `${CONVENTION_ROOT}/_lib/` contains some utilities that may
       be useful for `update`s.
     - `LATEST_IMAGE_TAG`: The tag for the most recent build image
-      produced by boilerplate.
+      published by boilerplate. When unset, `boilerplate/update` searches
+      reachable `image-v*` tags and selects the newest one whose image is
+      present in the registry. Set this explicitly to pin a tag or skip the
+      registry lookup.
 
 ### Testing Boilerplate Locally
 To test your changes, you can use the `BOILERPLATE_GIT_REPO` environment
@@ -376,6 +379,10 @@ from a tag through Konflux. To build a new image from a tag:
 1. Publish a new tag. The tag must be named `image-v{X}.{Y}.{Z}`, using [semver](https://semver.org/)
 principles when deciding what `{X}.{Y}.{Z}` should be. See https://github.com/openshift/boilerplate/pull/180
 for an example.
+
+   Publishing the Git tag starts the image release but does not make the image
+   immediately available. Until the release finishes, `boilerplate/update`
+   will continue using the newest previously published image tag.
 
     ```shell
     # create tag

--- a/boilerplate/_lib/common.sh
+++ b/boilerplate/_lib/common.sh
@@ -74,7 +74,7 @@ current_branch() {
     )
 }
 
-## image_exits_in_repo IMAGE_URI
+## image_exists_in_repo IMAGE_URI
 #
 # Checks whether IMAGE_URI -- e.g. quay.io/app-sre/osd-metrics-exporter:abcd123
 # -- exists in the remote repository.
@@ -190,7 +190,7 @@ IMAGE_NAMESPACE=openshift
 IMAGE_NAME=boilerplate
 # LATEST_IMAGE_TAG may be set manually or by `update`, in which case
 # that's the value we want to use.
-if [[ -z "$LATEST_IMAGE_TAG" ]]; then
+if [[ -z "$LATEST_IMAGE_TAG" && -z "$SKIP_LATEST_IMAGE_TAG_RESOLUTION" ]]; then
     # (Non-ancient) consumers will have the tag in this file.
     if [[ -f ${CONVENTION_ROOT}/_data/backing-image-tag ]]; then
         LATEST_IMAGE_TAG=$(cat ${CONVENTION_ROOT}/_data/backing-image-tag)

--- a/boilerplate/update
+++ b/boilerplate/update
@@ -160,9 +160,33 @@ if [ ! -f "$CONFIG_FILE" ]; then
   exit 1
 fi
 
-# The most recent build image tag. Export this for individual `update` scripts.
+# The most recent published build image tag. Export this for individual
+# `update` scripts.
 if [[ -z "$LATEST_IMAGE_TAG" ]]; then
-    export LATEST_IMAGE_TAG=$(cd $BP_CLONE; git describe --tags --abbrev=0 --match image-v*)
+    # common.sh contains the registry-checking helper, but normally initializes
+    # LATEST_IMAGE_TAG from the consumer's existing backing-image-tag file.
+    # Suppress that initialization while loading the helper so we can resolve
+    # the tag from the boilerplate clone below.
+    SKIP_LATEST_IMAGE_TAG_RESOLUTION=1
+    source "${CONVENTION_ROOT}/_lib/common.sh"
+    unset SKIP_LATEST_IMAGE_TAG_RESOLUTION
+
+    # A Git tag only starts the image release; it does not guarantee that the
+    # image has been published yet. Only consider tags reachable from HEAD so
+    # freeze-check remains reproducible when replaying an older commit.
+    candidates=$(cd "$BP_CLONE" && git tag --merged HEAD --sort=-v:refname --list 'image-v*')
+    for tag in $candidates; do
+        if image_exists_in_repo "${IMAGE_REPO}/${IMAGE_NAME}:${tag}"; then
+            export LATEST_IMAGE_TAG="$tag"
+            break
+        fi
+    done
+
+    if [[ -z "$LATEST_IMAGE_TAG" ]]; then
+        echo "Failed to find a published build image among the reachable image-v* tags." >&2
+        echo "Wait for the image release to finish, or set LATEST_IMAGE_TAG explicitly." >&2
+        exit 1
+    fi
 fi
 
 # The boilerplate commit hash. Export for convention `update` scripts.

--- a/test/case/framework/05-image-tag-resolution
+++ b/test/case/framework/05-image-tag-resolution
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+set -e
+
+cat <<EOF
+Tests that boilerplate/update selects the newest image-v* tag whose image is
+published, while ignoring unreachable tags and propagating registry errors.
+EOF
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+source "$REPO_ROOT/test/lib.sh"
+
+# The rest of the framework pins an image so it stays offline. This test
+# exercises the lookup itself instead.
+unset LATEST_IMAGE_TAG
+
+# Use a deterministic skopeo replacement instead of contacting Quay.
+stubdir=$(mktemp -d -t boilerplate-skopeo-XXXXXXXX)
+add_cleanup "$stubdir"
+export PUBLISHED_TAGS="$stubdir/published"
+export BROKEN_TAGS="$stubdir/broken"
+touch "$PUBLISHED_TAGS" "$BROKEN_TAGS"
+cat <<'EOF' > "$stubdir/skopeo"
+#!/usr/bin/env bash
+
+set -e
+
+for arg in "$@"; do
+    image_uri=$arg
+done
+tag=${image_uri##*:}
+
+if grep -Fqx "$tag" "$BROKEN_TAGS"; then
+    echo "unauthorized: access to the requested resource is not authorized" >&2
+    exit 1
+fi
+
+if grep -Fqx "$tag" "$PUBLISHED_TAGS"; then
+    echo '{"Digest":"sha256:decafbad"}'
+    exit 0
+fi
+
+echo "reading manifest $tag: manifest unknown" >&2
+exit 1
+EOF
+chmod +x "$stubdir/skopeo"
+export PATH="$stubdir:$PATH"
+
+# Create a local boilerplate repository with synthetic tags. Copy the two
+# files under test into the clone as well, so this case remains useful when
+# run against an uncommitted working tree.
+bp_clone=$(mktemp -d -t boilerplate-image-tags-XXXXXXXX)
+add_cleanup "$bp_clone"
+git clone -q "$REPO_ROOT" "$bp_clone"
+git -C "$bp_clone" config user.name "Boilerplate Image Tag Test"
+git -C "$bp_clone" config user.email "boilerplate-image-tag-test@example.com"
+cp "$REPO_ROOT/boilerplate/update" "$bp_clone/boilerplate/update"
+cp "$REPO_ROOT/boilerplate/_lib/common.sh" "$bp_clone/boilerplate/_lib/common.sh"
+git -C "$bp_clone" add boilerplate/update boilerplate/_lib/common.sh
+if ! git -C "$bp_clone" diff --cached --quiet; then
+    git -C "$bp_clone" commit -q -m "Use working tree update scripts for test"
+fi
+git -C "$bp_clone" tag image-v90.0.0
+git -C "$bp_clone" tag image-v90.1.0
+git -C "$bp_clone" tag image-v90.2.0
+
+# Add a newer tag on a side branch. It must not be selected when the update
+# runs against the default branch.
+default_branch=$(git -C "$bp_clone" symbolic-ref --short HEAD)
+git -C "$bp_clone" checkout -q -b image-tag-test-side
+git -C "$bp_clone" commit -q --allow-empty -m "Create unreachable image tag"
+git -C "$bp_clone" tag image-v91.0.0
+git -C "$bp_clone" checkout -q "$default_branch"
+
+export BOILERPLATE_GIT_REPO="$bp_clone"
+
+assert_resolved_tag() {
+    local expected=$1
+    local repo
+    local actual
+
+    repo=$(empty_repo)
+    add_cleanup "$repo"
+    bootstrap_repo "$repo"
+    (
+        cd "$repo"
+        make --no-print-directory boilerplate-update >/dev/null
+        actual=$(cat boilerplate/_data/backing-image-tag)
+        [[ "$actual" == "$expected" ]] || err "Expected backing-image-tag '$expected', got '$actual'"
+    )
+}
+
+echo "== Select the newest published tag"
+printf '%s\n' image-v90.2.0 image-v90.1.0 image-v90.0.0 > "$PUBLISHED_TAGS"
+assert_resolved_tag image-v90.2.0
+
+echo "== Fall back when the newest Git tag is unpublished"
+printf '%s\n' image-v90.1.0 image-v90.0.0 > "$PUBLISHED_TAGS"
+assert_resolved_tag image-v90.1.0
+
+echo "== Ignore tags that are not reachable from HEAD"
+printf '%s\n' image-v91.0.0 image-v90.1.0 > "$PUBLISHED_TAGS"
+assert_resolved_tag image-v90.1.0
+
+echo "== Respect an explicit tag override"
+> "$PUBLISHED_TAGS"
+(
+    export LATEST_IMAGE_TAG=image-v99.0.0
+    assert_resolved_tag image-v99.0.0
+)
+
+echo "== Fail when no candidate image is published"
+> "$PUBLISHED_TAGS"
+repo=$(empty_repo)
+add_cleanup "$repo"
+bootstrap_repo "$repo"
+if (
+    cd "$repo"
+    make --no-print-directory boilerplate-update > "$LOG_DIR/05-no-image" 2>&1
+); then
+    err "Expected the update to fail when no candidate image exists"
+fi
+grep -q "Failed to find a published build image" "$LOG_DIR/05-no-image" \
+    || err "Expected a no-published-image error; got: $(cat "$LOG_DIR/05-no-image")"
+
+echo "== Propagate registry errors"
+printf '%s\n' image-v90.2.0 > "$BROKEN_TAGS"
+repo=$(empty_repo)
+add_cleanup "$repo"
+bootstrap_repo "$repo"
+if (
+    cd "$repo"
+    make --no-print-directory boilerplate-update > "$LOG_DIR/05-registry-error" 2>&1
+); then
+    err "Expected the update to fail when the registry query errors"
+fi
+grep -q "Error querying the repository" "$LOG_DIR/05-registry-error" \
+    || err "Expected a registry-query error; got: $(cat "$LOG_DIR/05-registry-error")"
+
+echo "All image tag resolution checks passed."

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -2,8 +2,9 @@ if [ "$BOILERPLATE_SET_X" ]; then
     set -x
 fi
 
-# NOTE: Change this when publishing a new image tag.
-LATEST_IMAGE_TAG=image-v4.0.1
+# Keep the existing test suite offline and deterministic. Tests that exercise
+# published image-tag resolution explicitly unset this variable.
+export LATEST_IMAGE_TAG=image-v4.0.1
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 # Make all tests use this local clone by default.


### PR DESCRIPTION
A different approach to https://github.com/openshift/boilerplate/pull/842, in order to guard the time it takes from release tagging to push to quay so consumers CI doesn't fail permanently in the meantime.

Closes https://github.com/openshift/boilerplate/pull/842